### PR TITLE
Continue building without Node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: mod
 
 ui:
 	@rm -rf ui/dist
-	@which npm 1>/dev/null && cd ui && npm install 1>/dev/null && npm run build 1>/dev/null
+	-@which npm 1>/dev/null && cd ui && npm install 1>/dev/null && npm run build 1>/dev/null
 
 install: ui build
 	@go install -mod=readonly ./...

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,8 @@ brew install tendermint/tap/starport
 git clone https://github.com/tendermint/starport && cd starport && make
 ```
 
+Requirements: Go 1.14 and Node.js (optional, used to build the welcome screen).
+
 ## Creating an application
 
 This command creates an empty template for a Cosmos SDK application. By default it also includes a module with the same name as the package. To create a new application called `blog`, run:


### PR DESCRIPTION
* Continue building if Node.js is not found (welcome screen won't show up)
* Added Node.js as an optional requirement in the readme.

close https://github.com/tendermint/starport/issues/4