### PR TITLE
refactoring demonstration for serve

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -15,6 +20,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/radovskyb/watcher"
 	"github.com/spf13/cobra"
+	sr "github.com/tendermint/starport/pkg/cmdsteprunner"
+	"github.com/tendermint/starport/pkg/lineprefixer"
 )
 
 // Env ...
@@ -23,51 +30,112 @@ type Env struct {
 	NodeJS  bool   `json:"node_js"`
 }
 
-func startServe(verbose bool) (*exec.Cmd, *exec.Cmd) {
+// ctx for cancellation
+// controlling stdout, stderr for testability.
+func startServe(ctx context.Context, stdout, stderr io.Writer, isVerbose bool) (*exec.Cmd, *exec.Cmd) {
+	// outOption logs step outputs (both regular and error) with a prefix for each log line
+	// in the verbose mode.
+	//
+	// prefixing with line is helpful to debug long logs.
+	//
+	// we can also customize this func to color/style the lines or prefixes.
+	outOption := func(prefix string) sr.StepOption {
+		var stdout io.Writer = lineprefixer.NewWriter(prefix, stdout)
+		var stderr io.Writer = lineprefixer.NewWriter(prefix, stderr)
+		if !isVerbose {
+			stdout = ioutil.Discard
+			stderr = ioutil.Discard
+		}
+		return sr.StepStdouterr(stdout, stderr)
+	}
+	// initMessagePrinter is a shortcut to register a hook to the StepPreExec in order to
+	// only print a message.
+	initMessagePrinter := func(message string) func() error {
+		fmt.Fprint(stdout, message)
+		return nil
+
+	}
+	// proxyError is a shortcut to register a hook to the StepAfterExec in order to
+	// replace command's execution error with a dummy(hidden) error.
+	proxyError := func(message string) func(error) error {
+		// err arg can be utilized to provide more details.
+		// for ex exitErr := err.(*cmd.ExitError: https://golang.org/pkg/os/exec/#ExitError),
+		// do something with the exit code to provide more detail to returned error.
+		return func(err error) error {
+			if err != nil {
+				return errors.New(message)
+			}
+			return nil
+		}
+	}
+
+	// NOTE: the above three funcs can be placed under a util pkg (pkg/a-util-pkg) in order to
+	// reduce code from this package so it can be easier to read and understand main
+	// functionality here.
+
+	// userBuf keeps user data to be used later.
+	userBuf := &bytes.Buffer{}
+
+	// list of steps to run.
+	steps := []sr.Step{
+		sr.NewStep(
+			sr.StepCommand("go", "mod", "tidy"),
+			outOption("tidy: "),
+			sr.StepPreExec(initMessagePrinter("\n📦 Installing dependencies...\n")),
+			sr.StepAfterExec(proxyError("Error running go mod tidy. Please, check ./go.mod")),
+		),
+		sr.NewStep(
+			sr.StepCommand("make"),
+			outOption("all: "),
+			sr.StepPreExec(initMessagePrinter("🚧 Building the application...\n")),
+			sr.StepAfterExec(proxyError("Error in building the application. Please, check ./Makefile")),
+		),
+		sr.NewStep(
+			sr.StepCommand("make", "init-pre"),
+			outOption("init pre: "),
+			sr.StepPreExec(initMessagePrinter("💫 Initializing the chain...\n")),
+			sr.StepAfterExec(proxyError("Error in initializing the chain. Please, check ./init.sh")),
+		),
+		sr.NewStep(
+			sr.StepCommand("make", "init-user", "-s"),
+			outOption("init user: "),
+			sr.StepStdout(userBuf), // this overwrites the given stdout in the above line but not stderr by intention.
+			sr.StepAfterExec(func(err error) error {
+				if err != nil { // if command exited with a non-zero code, nothing to do.
+					return err
+				}
+				var user map[string]interface{}
+				if err := json.NewDecoder(userBuf).Decode(&user); err != nil {
+					return err
+				}
+				fmt.Fprintf(stdout, "🙂 Created an account. Password (mnemonic): %[1]v\n", user["mnemonic"])
+				return nil
+			}),
+		),
+		sr.NewStep(
+			sr.StepCommand("make", "init-post"),
+			outOption("init post: "),
+		),
+	}
+
+	// New(options...) can have options to optionally run steps in parallel or for ex. continue
+	// to other steps if previous one exited with a failure.
+	r := sr.New()
+
+	// ctx for cancallation. if context is cancalled by a timeout or programatically, next steps should not run
+	// and current one should be interrupted. intrreption specially useful when we may want to use cmdsteprunner
+	// for 'serve' functionality (starting long running servers).
+	if err := r.Run(ctx, steps...); err != nil {
+		// instead of this we should return with the error and Fatal in the caller function.
+		// because a Fatal will end the program and we need to use it carefully. returning error
+		// helps to testability as well.
+		log.Fatal(err)
+	}
+
+	// NOTE: following code not relavent to this proposal.
 	appName, _ := getAppAndModule()
-	fmt.Printf("\n📦 Installing dependencies...\n")
-	cmdMod := exec.Command("/bin/sh", "-c", "go mod tidy")
-	if verbose {
-		cmdMod.Stdout = os.Stdout
-	}
-	if err := cmdMod.Run(); err != nil {
-		log.Fatal("Error running go mod tidy. Please, check ./go.mod")
-	}
-	fmt.Printf("🚧 Building the application...\n")
-	cmdMake := exec.Command("/bin/sh", "-c", "make")
-	if verbose {
-		cmdMake.Stdout = os.Stdout
-	}
-	if err := cmdMake.Run(); err != nil {
-		log.Fatal("Error in building the application. Please, check ./Makefile")
-	}
-	fmt.Printf("💫 Initializing the chain...\n")
-	cmdInitPre := exec.Command("make", "init-pre")
-	if err := cmdInitPre.Run(); err != nil {
-		log.Fatal("Error in initializing the chain. Please, check ./init.sh")
-	}
-	if verbose {
-		cmdInitPre.Stdout = os.Stdout
-	}
-	userString, err := exec.Command("make", "init-user", "-s").Output()
-	if err != nil {
-		log.Fatal(err)
-	}
-	var userJSON map[string]interface{}
-	json.Unmarshal(userString, &userJSON)
-	fmt.Printf("🙂 Created an account. Password (mnemonic): %[1]v\n", userJSON["mnemonic"])
-	cmdInitPost := exec.Command("make", "init-post")
-	if err := cmdInitPost.Run(); err != nil {
-		log.Fatal(err)
-	}
-	if verbose {
-		cmdInitPost.Stdout = os.Stdout
-	}
-	if verbose {
-		cmdInitPost.Stdout = os.Stdout
-	}
 	cmdTendermint := exec.Command(fmt.Sprintf("%[1]vd", appName), "start") //nolint:gosec // Subprocess launched with function call as argument or cmd arguments
-	if verbose {
+	if isVerbose {
 		fmt.Printf("🌍 Running a server at http://localhost:26657 (Tendermint)\n")
 		cmdTendermint.Stdout = os.Stdout
 	} else {
@@ -77,14 +145,14 @@ func startServe(verbose bool) (*exec.Cmd, *exec.Cmd) {
 		log.Fatal(fmt.Sprintf("Error in running %[1]vd start", appName), err)
 	}
 	cmdREST := exec.Command(fmt.Sprintf("%[1]vcli", appName), "rest-server") //nolint:gosec // Subprocess launched with function call as argument or cmd arguments
-	if verbose {
+	if isVerbose {
 		fmt.Printf("🌍 Running a server at http://localhost:1317 (LCD)\n")
 		cmdREST.Stdout = os.Stdout
 	}
 	if err := cmdREST.Start(); err != nil {
 		log.Fatal(fmt.Sprintf("Error in running %[1]vcli rest-server", appName))
 	}
-	if verbose {
+	if isVerbose {
 		fmt.Printf("🔧 Running dev interface at http://localhost:12345\n\n")
 	}
 	router := mux.NewRouter()
@@ -133,7 +201,7 @@ func startServe(verbose bool) (*exec.Cmd, *exec.Cmd) {
 	go func() {
 		http.ListenAndServe(":12345", router)
 	}()
-	if !verbose {
+	if !isVerbose {
 		fmt.Printf("\n🚀 Get started: http://localhost:12345/\n\n")
 	}
 	return cmdTendermint, cmdREST
@@ -148,11 +216,14 @@ var serveCmd = &cobra.Command{
 		cmdNpm := gocmd.NewCmd("npm", "run", "dev")
 		cmdNpm.Dir = "frontend"
 		cmdNpm.Start()
-		cmdt, cmdr := startServe(verbose)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		cmdt, cmdr := startServe(ctx, os.Stdout, os.Stderr, verbose)
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
 		go func() {
 			<-c
+			// later in other PR, we can use cancel() here to cancel long running procceses.
 			cmdNpm.Stop()
 			cmdr.Process.Kill()
 			cmdt.Process.Kill()
@@ -166,7 +237,7 @@ var serveCmd = &cobra.Command{
 				case <-w.Event:
 					cmdr.Process.Kill()
 					cmdt.Process.Kill()
-					cmdt, cmdr = startServe(verbose)
+					cmdt, cmdr = startServe(ctx, os.Stdout, os.Stderr, verbose)
 				case err := <-w.Error:
 					log.Println(err)
 				case <-w.Closed:

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,10 @@ require (
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/yuin/goldmark v1.1.33 // indirect
 	golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0 // indirect
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae // indirect
+	golang.org/x/tools v0.0.0-20200711155855-7342f9734a7d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,10 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.32 h1:5tjfNdR2ki3yYQ842+eX2sQHeiwpKJ0RnHO4IYOc4V8=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.1.33 h1:Q0PzHNn2h69wYmmE2SukzuQe0VBwErZrgJ5ZB8od6zQ=
+github.com/yuin/goldmark v1.1.33/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -220,7 +224,10 @@ golang.org/x/crypto v0.0.0-20200707235045-ab33eee955e0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -234,6 +241,8 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZ
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -266,6 +275,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191224055732-dd894d0a8a40/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41 h1:9Di9iYgOt9ThCipBxChBVhgNipDoE5mxO84rQV7D0FE=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200711155855-7342f9734a7d h1:F3OmlXCzYtG9YE6tXDnUOlJBzVzHF8EcmZ1yTJlcgIk=
+golang.org/x/tools v0.0.0-20200711155855-7342f9734a7d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/pkg/cmdsteprunner/cmdsteprunner.go
+++ b/pkg/cmdsteprunner/cmdsteprunner.go
@@ -1,0 +1,29 @@
+package cmdsteprunner
+
+import (
+	"context"
+)
+
+type Runner struct {
+	o runnerOptions
+}
+
+type RunnerOption func(*runnerOptions)
+
+type runnerOptions struct {
+}
+
+func New(options ...RunnerOption) *Runner {
+	var opts runnerOptions
+	for _, o := range options {
+		o(&opts)
+	}
+	r := &Runner{
+		o: opts,
+	}
+	return r
+}
+
+func (r *Runner) Run(ctx context.Context, steps ...Step) error {
+	return nil
+}

--- a/pkg/cmdsteprunner/step.go
+++ b/pkg/cmdsteprunner/step.go
@@ -1,0 +1,76 @@
+package cmdsteprunner
+
+import (
+	"io"
+)
+
+type Step struct {
+	o stepOptions
+}
+
+type StepOption func(*stepOptions)
+
+type stepOptions struct {
+	afterExec func(error) error
+	stdout    io.Writer
+	stderr    io.Writer
+}
+
+var defaultAfterExec = func(err error) error { return err }
+
+func StepStdout(w io.Writer) StepOption {
+	return func(o *stepOptions) {
+		o.stdout = w
+	}
+}
+
+func StepStderr(w io.Writer) StepOption {
+	return func(o *stepOptions) {
+		o.stderr = w
+	}
+}
+
+func StepStdouterr(stdout, stderr io.Writer) StepOption {
+	return func(o *stepOptions) {
+		StepStdout(stdout)(o)
+		StepStderr(stderr)(o)
+	}
+}
+
+// StepPreExec hook is executed just before executing the step.
+// returning a non-nil error from the hook will make the other steps not run if
+// continue on failure has not been enabled on Runner.
+func StepPreExec(hook func() error) StepOption {
+	return func(o *stepOptions) {
+	}
+}
+
+// StepAfterExec hook is executed after command is complated.
+// err in the hook is filled if execution is complated with a non-zero code.
+//
+// returning a non-nil error from the hook will make the other steps not run if
+// continue on failure has not been enabled on Runner.
+func StepAfterExec(hook func(err error) error) StepOption {
+	return func(o *stepOptions) {
+	}
+}
+
+type Command []string
+
+func StepCommand(name string, arg ...string) Command {
+	return Command(append([]string{name}, arg...))
+}
+
+func NewStep(cmd Command, options ...StepOption) Step {
+	opts := stepOptions{
+		afterExec: defaultAfterExec,
+	}
+	for _, o := range options {
+		o(&opts)
+	}
+	s := Step{
+		o: opts,
+	}
+	return s
+
+}

--- a/pkg/lineprefixer/lineprefixer.go
+++ b/pkg/lineprefixer/lineprefixer.go
@@ -1,0 +1,11 @@
+package lineprefixer
+
+import "io"
+
+type Writer struct{}
+
+func NewWriter(prefix string, w io.Writer) *Writer {
+	return nil
+}
+
+func (w *Writer) Write(p []byte) (n int, err error) { return 0, nil }


### PR DESCRIPTION
this is partially relevant with https://github.com/tendermint/starport/issues/7.

unlike the actual proposition described in #7, as a first step, this demonstration only focuses on simplifying "non long running" command executions by creating some generic util packages to extract the functionality to `pkg/` and using them under the `cmd` package.

@fadeev how do you feel about this kind of an [API](https://github.com/tendermint/starport/blob/a0b784aed24c0ce46e1fa62d2b659c2e776613f3/cmd/serve.go#L76-L133)?
