### PR TITLE
cmd: add -p option targeting custom app path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -33,8 +34,8 @@ func init() {
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
-func getAppAndModule() (string, string) {
-	goModFile, err := ioutil.ReadFile("go.mod")
+func getAppAndModule(path string) (string, string) {
+	goModFile, err := ioutil.ReadFile(filepath.Join(path, "go.mod"))
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/typed.go
+++ b/cmd/typed.go
@@ -10,12 +10,16 @@ import (
 	"github.com/tendermint/starport/templates/typed"
 )
 
+func init() {
+	typedCmd.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
+}
+
 var typedCmd = &cobra.Command{
 	Use:   "type [typeName] [field1] [field2] ...",
 	Short: "Generates CRUD actions for type",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		appName, modulePath := getAppAndModule()
+		appName, modulePath := getAppAndModule(appPath)
 		var fields []typed.Field
 		for _, f := range args[1:] {
 			fs := strings.Split(f, ":")

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go run main.go "$@"


### PR DESCRIPTION
-p option enables serving apps on a different path other than current
directory. (for serve and type commands)

it is also useful when serving apps in Docker containers with starport since
they persist in different paths. devs no longer need to `cd` first to
the app.

also useful during development of starport. currently using starport cli
in the development mode requires to run `make`. this is a long running
task that makes a bunch of long configuration including `npm install`. instead of `make` we can
directly run `go run main.go` in development which is faster. but using starport
this way requires the ability of setting a path to the application
because we can no longer `cd` into the app. `cd`ing into the app and
running `go run path/to/main.go` is also possible but not convenient.

e.g.: `go run main.go serve -p blog/`.

NOTE: instead of running `go run main.go` manually use new `scripts/dev serve -p blog/` which is easier to work with.

resolves #21.