### PR TITLE
publish starport to npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
-          scope: ilgooz
+          scope: tendermint
       - run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
       - run: ./scripts/npm-publish
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,8 +15,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           scope: ilgooz
       - run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
-      - run: echo $RELEASE_VERSION
-      - run: echo ${{secrets.NPM_TOKEN}}
       - run: ./scripts/npm-publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,22 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: 'https://registry.npmjs.org'
+          scope: ilgooz
+      - run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
+      - run: echo $RELEASE_VERSION
+      - run: echo ${{secrets.NPM_TOKEN}}
+      - run: ./scripts/npm-publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.npm/bin/index
+++ b/.npm/bin/index
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('../lib/starport.js');
+

--- a/.npm/lib/conf.js
+++ b/.npm/lib/conf.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const home = require('home-path');
+
+exports.starportDir = path.join(home(), ".starport");
+exports.starportPath = path.join(exports.starportDir, "starport");

--- a/.npm/lib/install.js
+++ b/.npm/lib/install.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const tmp = require('tmp');
+const decompress = require('decompress');
+const download = require('download');
+const ora = require('ora');
+const pkg = require('../package.json')
+const { starportDir, starportPath } = require('./conf');
+
+const baseUrl = 'http://github.com/tendermint/starport/releases/download';
+const urls = {
+  linux(version)  { return `${baseUrl}/v${version}/starport_${version}_linux_amd64.tar.gz` },
+  darwin(version) { return `${baseUrl}/v${version}/starport_${version}_darwin_amd64.tar.gz` }
+};
+
+async function main() {
+  const urlf = urls[process.platform];
+  if (!urlf) {
+    throw new Error(`unsupported platform '${process.platform}'`)
+  }
+  const url = urlf(pkg.version);
+  const tmptar = tmp.fileSync();
+  if (!fs.existsSync(starportDir)) {
+    fs.mkdirSync(starportDir)
+  }
+  if (fs.existsSync(starportPath)) {
+    fs.unlinkSync(starportPath);
+  }
+  const sp = ora('💫 installing starport to your system...').start();
+  sp.color = 'yellow';
+  try {
+    fs.writeFileSync(tmptar.name, await download(url));
+    await decompress(tmptar.name, starportDir);
+  } catch ({ message }) {
+    throw new Error(`cannot install starport err:\n\t${message}`) ;
+  } finally {
+    sp.stop();
+    tmptar.removeCallback();
+  }
+}
+
+(async function () {
+  try {
+    await main();
+  } catch (e) {
+    console.log(e.message);
+    process.exit(1);
+  }
+})();
+

--- a/.npm/lib/install.js
+++ b/.npm/lib/install.js
@@ -1,37 +1,41 @@
-const fs = require('fs');
-const tmp = require('tmp');
-const decompress = require('decompress');
-const download = require('download');
-const ora = require('ora');
-const pkg = require('../package.json')
-const { starportDir, starportPath } = require('./conf');
+const fs = require("fs");
+const tmp = require("tmp");
+const decompress = require("decompress");
+const download = require("download");
+const ora = require("ora");
+const pkg = require("../package.json");
+const { starportDir, starportPath } = require("./conf");
 
-const baseUrl = 'http://github.com/tendermint/starport/releases/download';
+const baseUrl = "http://github.com/tendermint/starport/releases/download";
 const urls = {
-  linux(version)  { return `${baseUrl}/v${version}/starport_${version}_linux_amd64.tar.gz` },
-  darwin(version) { return `${baseUrl}/v${version}/starport_${version}_darwin_amd64.tar.gz` }
+  linux(version) {
+    return `${baseUrl}/v${version}/starport_${version}_linux_amd64.tar.gz`;
+  },
+  darwin(version) {
+    return `${baseUrl}/v${version}/starport_${version}_darwin_amd64.tar.gz`;
+  },
 };
 
 async function main() {
   const urlf = urls[process.platform];
   if (!urlf) {
-    throw new Error(`unsupported platform '${process.platform}'`)
+    throw new Error(`unsupported platform '${process.platform}'`);
   }
   const url = urlf(pkg.version);
   const tmptar = tmp.fileSync();
   if (!fs.existsSync(starportDir)) {
-    fs.mkdirSync(starportDir)
+    fs.mkdirSync(starportDir);
   }
   if (fs.existsSync(starportPath)) {
     fs.unlinkSync(starportPath);
   }
-  const sp = ora('💫 installing starport to your system...').start();
-  sp.color = 'yellow';
+  const sp = ora("💫 Installing Starport...").start();
+  sp.color = "yellow";
   try {
     fs.writeFileSync(tmptar.name, await download(url));
     await decompress(tmptar.name, starportDir);
   } catch ({ message }) {
-    throw new Error(`cannot install starport err:\n\t${message}`) ;
+    throw new Error(`cannot install starport err:\n\t${message}`);
   } finally {
     sp.stop();
     tmptar.removeCallback();
@@ -46,4 +50,3 @@ async function main() {
     process.exit(1);
   }
 })();
-

--- a/.npm/lib/starport.js
+++ b/.npm/lib/starport.js
@@ -1,0 +1,22 @@
+const tmp = require('tmp');
+const { spawn } = require('child_process');
+const { starportPath } = require('./conf');
+
+async function main() {
+  const args = process.argv;
+  args.shift(); // node
+  args.shift(); // starport
+  spawn(starportPath, args, {
+    stdio: [process.stdin, process.stdout, process.stderr],
+  });
+}
+
+(async function () {
+  try {
+    await main();
+  } catch (e) {
+    console.log(e.message);
+    process.exit(1);
+  }
+})();
+

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ilgooz/st",
+  "version": "0.0.0",
+  "description": "starport",
+  "scripts": {
+    "preinstall": "node lib/install.js"
+  },
+  "bin": {
+    "starport": "bin/index"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "decompress": "^4.2.1",
+    "download": "^8.0.0",
+    "home-path": "^1.0.7",
+    "ora": "^4.0.4",
+    "tmp": "^0.2.1"
+  }
+}

--- a/.npm/package.json
+++ b/.npm/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ilgooz/st",
+  "name": "@tendermint/starport",
   "version": "0.0.0",
   "description": "starport",
   "scripts": {

--- a/scripts/npm-publish
+++ b/scripts/npm-publish
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i "s/\"version\": \".*\"/\"version\": \"$RELEASE_VERSION\"/g" ./.npm/package.json
+npm publish --access public ./.npm

--- a/scripts/npm-publish
+++ b/scripts/npm-publish
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# replace package's version to release version at package.json.
 sed -i "s/\"version\": \".*\"/\"version\": \"$RELEASE_VERSION\"/g" ./.npm/package.json
+
+# publish!
 npm publish --access public ./.npm


### PR DESCRIPTION
after each release.

starport can be installed globally by using: `npm i -g
@tendermint/starport`.

while being installed, it automatically dedects current platform and
downloads the Go binary with the release's version on the fly and installs it.

- [x] TODO: the package name at `./npm/package.json`, npm scope at `./github/workflows/npm-publish.yml` and `NPM_TOKEN` secret on Github Secrets has to be updated later.

NOTE: only covers x64 architectures.
NOTE: fix TODO above before merging.

closes #31 