### PR TITLE
interface/cli/starport/cmd: made app command newable

### DIFF
--- a/interface/cli/starport/cmd/app.go
+++ b/interface/cli/starport/cmd/app.go
@@ -11,28 +11,37 @@ import (
 	"github.com/tendermint/starport/templates/app"
 )
 
-var appCmd = &cobra.Command{
-	Use:   "app [github.com/org/repo]",
-	Short: "Generates an empty application",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		path, err := gomodulepath.Parse(args[0])
-		if err != nil {
-			return err
-		}
-		denom, _ := cmd.Flags().GetString("denom")
-		g, _ := app.New(&app.Options{
-			ModulePath:       path.RawPath,
-			AppName:          path.Package,
-			BinaryNamePrefix: path.Root,
-			Denom:            denom,
-		})
-		run := genny.WetRunner(context.Background())
-		run.With(g)
-		pwd, _ := os.Getwd()
-		run.Root = pwd + "/" + path.Root
-		run.Run()
-		message := `
+// NewApp creates new command named `app` to create Cosmos scaffolds customized
+// by the user given options.
+func NewApp() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "app [github.com/org/repo]",
+		Short: "Generates an empty application",
+		Args:  cobra.ExactArgs(1),
+		RunE:  appHandler,
+	}
+	c.Flags().StringP("denom", "d", "token", "Token denomination")
+	return c
+}
+
+func appHandler(cmd *cobra.Command, args []string) error {
+	path, err := gomodulepath.Parse(args[0])
+	if err != nil {
+		return err
+	}
+	denom, _ := cmd.Flags().GetString("denom")
+	g, _ := app.New(&app.Options{
+		ModulePath:       path.RawPath,
+		AppName:          path.Package,
+		BinaryNamePrefix: path.Root,
+		Denom:            denom,
+	})
+	run := genny.WetRunner(context.Background())
+	run.With(g)
+	pwd, _ := os.Getwd()
+	run.Root = pwd + "/" + path.Root
+	run.Run()
+	message := `
 ⭐️ Successfully created a Cosmos app '%[1]v'.
 👉 Get started with the following commands:
 
@@ -41,7 +50,6 @@ var appCmd = &cobra.Command{
 
 NOTE: add -v flag for advanced use.
 `
-		fmt.Printf(message, path.Root)
-		return nil
-	},
+	fmt.Printf(message, path.Root)
+	return nil
 }

--- a/interface/cli/starport/cmd/cmd.go
+++ b/interface/cli/starport/cmd/cmd.go
@@ -15,12 +15,11 @@ func New() *cobra.Command {
 		Use:   "starport",
 		Short: "A tool for scaffolding out Cosmos applications",
 	}
-	c.AddCommand(appCmd)
+	c.AddCommand(NewApp())
 	c.AddCommand(typedCmd)
 	c.AddCommand(NewServe())
 	c.AddCommand(addCmd)
 	c.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	appCmd.Flags().StringP("denom", "d", "token", "Token denomination")
 	return c
 }
 


### PR DESCRIPTION
* reconstructed organization of app command.

solves a part of #56,
depends on https://github.com/tendermint/starport/pull/64.