### PR TITLE
ci: disable linter for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 # This workflow is run on every pull request and push to master
 # The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master


### PR DESCRIPTION
we are in a refactoring period and it is safe to ignore linter errors at this stage since some of the related code will be changed.