### PR TITLE
interface/cli/starport/cmd: made add command newable

### DIFF
--- a/interface/cli/starport/cmd/add.go
+++ b/interface/cli/starport/cmd/add.go
@@ -8,19 +8,24 @@ import (
 	"github.com/tendermint/starport/templates/add"
 )
 
-var addCmd = &cobra.Command{
-	Use:   "add [feature]",
-	Short: "Adds a feature to a project.",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		appName, _ := getAppAndModule(appPath)
-		g, _ := add.New(&add.Options{
-			Feature: args[0],
-			AppName: appName,
-		})
-		run := genny.WetRunner(context.Background())
-		run.With(g)
-		run.Run()
-		// fmt.Printf("\n🎉 Created a type `%[1]v`.\n\n", args[0])
-	},
+func NewAdd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "add [feature]",
+		Short: "Adds a feature to a project.",
+		Args:  cobra.MinimumNArgs(1),
+		Run:   addHandler,
+	}
+	return c
+}
+
+func addHandler(cmd *cobra.Command, args []string) {
+	appName, _ := getAppAndModule(appPath)
+	g, _ := add.New(&add.Options{
+		Feature: args[0],
+		AppName: appName,
+	})
+	run := genny.WetRunner(context.Background())
+	run.With(g)
+	run.Run()
+	// fmt.Printf("\n🎉 Created a type `%[1]v`.\n\n", args[0])
 }

--- a/interface/cli/starport/cmd/cmd.go
+++ b/interface/cli/starport/cmd/cmd.go
@@ -18,7 +18,7 @@ func New() *cobra.Command {
 	c.AddCommand(NewApp())
 	c.AddCommand(typedCmd)
 	c.AddCommand(NewServe())
-	c.AddCommand(addCmd)
+	c.AddCommand(NewAdd())
 	c.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	return c
 }


### PR DESCRIPTION
* reconstructed organization of add command.

solves a part of #56.