### PR TITLE
interface/cli/starport/cmd: made type command newable

### DIFF
--- a/interface/cli/starport/cmd/cmd.go
+++ b/interface/cli/starport/cmd/cmd.go
@@ -16,7 +16,7 @@ func New() *cobra.Command {
 		Short: "A tool for scaffolding out Cosmos applications",
 	}
 	c.AddCommand(NewApp())
-	c.AddCommand(typedCmd)
+	c.AddCommand(NewTyped())
 	c.AddCommand(NewServe())
 	c.AddCommand(addCmd)
 	c.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/interface/cli/starport/cmd/cmd.go
+++ b/interface/cli/starport/cmd/cmd.go
@@ -16,7 +16,7 @@ func New() *cobra.Command {
 		Short: "A tool for scaffolding out Cosmos applications",
 	}
 	c.AddCommand(NewApp())
-	c.AddCommand(NewTyped())
+	c.AddCommand(NewType())
 	c.AddCommand(NewServe())
 	c.AddCommand(addCmd)
 	c.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/interface/cli/starport/cmd/type.go
+++ b/interface/cli/starport/cmd/type.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tendermint/starport/templates/typed"
 )
 
-func NewTyped() *cobra.Command {
+func NewType() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "type [typeName] [field1] [field2] ...",
 		Short: "Generates CRUD actions for type",
@@ -21,7 +21,7 @@ func NewTyped() *cobra.Command {
 	return c
 }
 
-func typedHandler(cmd *cobra.Command, args []string) {
+func typeHandler(cmd *cobra.Command, args []string) {
 	appName, modulePath := getAppAndModule(appPath)
 	var fields []typed.Field
 	for _, f := range args[1:] {

--- a/interface/cli/starport/cmd/type.go
+++ b/interface/cli/starport/cmd/type.go
@@ -15,7 +15,7 @@ func NewType() *cobra.Command {
 		Use:   "type [typeName] [field1] [field2] ...",
 		Short: "Generates CRUD actions for type",
 		Args:  cobra.MinimumNArgs(1),
-		Run:   typedHandler,
+		Run:   typeHandler,
 	}
 	c.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
 	return c

--- a/interface/cli/starport/cmd/typed.go
+++ b/interface/cli/starport/cmd/typed.go
@@ -10,44 +10,46 @@ import (
 	"github.com/tendermint/starport/templates/typed"
 )
 
-func init() {
-	typedCmd.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
+func NewTyped() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "type [typeName] [field1] [field2] ...",
+		Short: "Generates CRUD actions for type",
+		Args:  cobra.MinimumNArgs(1),
+		Run:   typedHandler,
+	}
+	c.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
+	return c
 }
 
-var typedCmd = &cobra.Command{
-	Use:   "type [typeName] [field1] [field2] ...",
-	Short: "Generates CRUD actions for type",
-	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		appName, modulePath := getAppAndModule(appPath)
-		var fields []typed.Field
-		for _, f := range args[1:] {
-			fs := strings.Split(f, ":")
-			name := fs[0]
-			var datatype string
-			acceptedTypes := map[string]bool{
-				"string": true,
-				"bool":   true,
-				"int":    true,
-				"float":  true,
-			}
-			if len(fs) == 2 && acceptedTypes[fs[1]] {
-				datatype = fs[1]
-			} else {
-				datatype = "string"
-			}
-			field := typed.Field{Name: name, Datatype: datatype}
-			fields = append(fields, field)
+func typedHandler(cmd *cobra.Command, args []string) {
+	appName, modulePath := getAppAndModule(appPath)
+	var fields []typed.Field
+	for _, f := range args[1:] {
+		fs := strings.Split(f, ":")
+		name := fs[0]
+		var datatype string
+		acceptedTypes := map[string]bool{
+			"string": true,
+			"bool":   true,
+			"int":    true,
+			"float":  true,
 		}
-		g, _ := typed.New(&typed.Options{
-			ModulePath: modulePath,
-			AppName:    appName,
-			TypeName:   args[0],
-			Fields:     fields,
-		})
-		run := genny.WetRunner(context.Background())
-		run.With(g)
-		run.Run()
-		fmt.Printf("\n🎉 Created a type `%[1]v`.\n\n", args[0])
-	},
+		if len(fs) == 2 && acceptedTypes[fs[1]] {
+			datatype = fs[1]
+		} else {
+			datatype = "string"
+		}
+		field := typed.Field{Name: name, Datatype: datatype}
+		fields = append(fields, field)
+	}
+	g, _ := typed.New(&typed.Options{
+		ModulePath: modulePath,
+		AppName:    appName,
+		TypeName:   args[0],
+		Fields:     fields,
+	})
+	run := genny.WetRunner(context.Background())
+	run.With(g)
+	run.Run()
+	fmt.Printf("\n🎉 Created a type `%[1]v`.\n\n", args[0])
 }


### PR DESCRIPTION
* reconstructed organization of `type` command.

solves a part of #56.