### PR TITLE
interface/cli/starport/cmd: refactor `serve` short-running cmd exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
-	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
+	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 // indirect
-	golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4 // indirect
+	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191122220453-ac88ee75c92c/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 h1:DZhuSZLsGlFL4CmhA8BcRA0mnthyA/nZ00AqCUo7vHg=
-golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
+golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -254,8 +254,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4 h1:gtF+PUC1CD1a9ocwQHbVNXuTp6RQsAYt6tpi6zjT81Y=
-golang.org/x/sys v0.0.0-20200727154430-2d971f7391a4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/cmdrunner/cmdrunner.go
+++ b/pkg/cmdrunner/cmdrunner.go
@@ -1,0 +1,102 @@
+package cmdrunner
+
+import (
+	"context"
+	"io"
+	"os/exec"
+
+	"github.com/tendermint/starport/pkg/cmdrunner/step"
+)
+
+type Runner struct {
+	stdout  io.Writer
+	stderr  io.Writer
+	workdir string
+}
+
+type Option func(*Runner)
+
+func DefaultStdout(w io.Writer) Option {
+	return func(r *Runner) {
+		r.stdout = w
+	}
+}
+
+func DefaultStderr(w io.Writer) Option {
+	return func(r *Runner) {
+		r.stderr = w
+	}
+}
+
+func DefaultWorkdir(path string) Option {
+	return func(r *Runner) {
+		r.workdir = path
+	}
+}
+
+func New(options ...Option) *Runner {
+	r := &Runner{}
+	for _, o := range options {
+		o(r)
+	}
+	return r
+}
+
+// Run blocks untill all steps are complated their executions.
+func (r *Runner) Run(ctx context.Context, steps ...*step.Step) error {
+	if len(steps) == 0 {
+		// this is a programmer error so better to panic instead of
+		// returning an err.
+		panic("no steps to run")
+	}
+	for _, s := range steps {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.PreExec != nil {
+			if err := s.PreExec(); err != nil {
+				return err
+			}
+		}
+		execErr := r.runStep(ctx, s)
+		if s.PostExec != nil {
+			if err := s.PostExec(execErr); err != nil {
+				return err
+			}
+		}
+		if execErr != nil {
+			return execErr
+		}
+	}
+	return nil
+}
+
+func (r *Runner) runStep(ctx context.Context, s *step.Step) error {
+	if s.Exec.Command == "" {
+		// this is a programmer error so better to panic instead of
+		// returning an err.
+		panic("empty command")
+	}
+	c := exec.CommandContext(ctx, s.Exec.Command, s.Exec.Args...)
+	var (
+		stdout = s.Stdout
+		stderr = s.Stderr
+		dir    = s.Workdir
+	)
+	if stdout == nil {
+		stdout = r.stdout
+	}
+	if stderr == nil {
+		stderr = r.stderr
+	}
+	if dir == "" {
+		dir = r.workdir
+	}
+	c.Stdout = stdout
+	c.Stderr = stderr
+	c.Dir = dir
+	if err := c.Start(); err != nil {
+		return err
+	}
+	return c.Wait()
+}

--- a/pkg/cmdrunner/step/step.go
+++ b/pkg/cmdrunner/step/step.go
@@ -1,0 +1,76 @@
+package step
+
+import "io"
+
+type Step struct {
+	Exec     Execution
+	PreExec  func() error
+	PostExec func(error) error
+	Stdout   io.Writer
+	Stderr   io.Writer
+	Workdir  string
+}
+
+type Option func(*Step)
+
+func New(options ...Option) *Step {
+	s := &Step{}
+	for _, o := range options {
+		o(s)
+	}
+	return s
+}
+
+type Execution struct {
+	Command string
+	Args    []string
+}
+
+func Exec(command string, args ...string) Option {
+	return func(s *Step) {
+		s.Exec = Execution{command, args}
+	}
+}
+
+func PreExec(hook func() error) Option {
+	return func(s *Step) {
+		s.PreExec = hook
+	}
+}
+
+func PostExec(hook func(exitErr error) error) Option { // *os.ExitError
+	return func(s *Step) {
+		s.PostExec = hook
+	}
+}
+
+func Stdout(w io.Writer) Option {
+	return func(s *Step) {
+		s.Stdout = w
+	}
+}
+
+func Stderr(w io.Writer) Option {
+	return func(s *Step) {
+		s.Stderr = w
+	}
+}
+
+func Workdir(path string) Option {
+	return func(s *Step) {
+		s.Workdir = path
+	}
+}
+
+type Steps []*Step
+
+func (s *Steps) Add(step *Step) {
+	*s = append(*s, step)
+}
+
+// Parallel enables running a step in parallel with others.
+// a parallel step only started if previous non-parallel steps are has
+// been complated their execution.
+func Parallel() Option {
+	return func(s *Step) {}
+}


### PR DESCRIPTION
### refactor `serve` command for short-running command executions

_trying out the [previously proposed](https://github.com/tendermint/starport/pull/14) command runner API to refactor serve._

solves a part of https://github.com/tendermint/starport/issues/81.

