### PR TITLE
Added custom bech32 address prefixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,5 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344 // indirect
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
+	golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 h1:sIky/MyNRSHTrdxfsiUSS4WIAMvInbeXljJz+jDjeYE=
-golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3 h1:qDJKu1y/1SjhWac4BQZjLljqvqiWUhjmDMnonmVGDAU=
+golang.org/x/sys v0.0.0-20200802091954-4b90ce9b60b3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/starport/interface/cli/starport/cmd/app.go
+++ b/starport/interface/cli/starport/cmd/app.go
@@ -21,7 +21,7 @@ func NewApp() *cobra.Command {
 		RunE:  appHandler,
 	}
 	c.Flags().StringP("denom", "d", "token", "Token denomination")
-	c.Flags().String("prefix", "cosmos", "Address prefix")
+	c.Flags().String("address-prefix", "cosmos", "Address prefix")
 	return c
 }
 
@@ -31,13 +31,13 @@ func appHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	denom, _ := cmd.Flags().GetString("denom")
-	prefix, _ := cmd.Flags().GetString("prefix")
+	addressPrefix, _ := cmd.Flags().GetString("address-prefix")
 	g, _ := app.New(&app.Options{
 		ModulePath:       path.RawPath,
 		AppName:          path.Package,
 		BinaryNamePrefix: path.Root,
 		Denom:            denom,
-		Prefix:           prefix,
+		AddressPrefix:    addressPrefix,
 	})
 	run := genny.WetRunner(context.Background())
 	run.With(g)

--- a/starport/interface/cli/starport/cmd/app.go
+++ b/starport/interface/cli/starport/cmd/app.go
@@ -21,6 +21,7 @@ func NewApp() *cobra.Command {
 		RunE:  appHandler,
 	}
 	c.Flags().StringP("denom", "d", "token", "Token denomination")
+	c.Flags().String("prefix", "cosmos", "Address prefix")
 	return c
 }
 
@@ -30,11 +31,13 @@ func appHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	denom, _ := cmd.Flags().GetString("denom")
+	prefix, _ := cmd.Flags().GetString("prefix")
 	g, _ := app.New(&app.Options{
 		ModulePath:       path.RawPath,
 		AppName:          path.Package,
 		BinaryNamePrefix: path.Root,
 		Denom:            denom,
+		Prefix:           prefix,
 	})
 	run := genny.WetRunner(context.Background())
 	run.With(g)

--- a/starport/templates/app/new.go
+++ b/starport/templates/app/new.go
@@ -20,7 +20,7 @@ func New(opts *Options) (*genny.Generator, error) {
 	ctx.Set("AppName", opts.AppName)
 	ctx.Set("BinaryNamePrefix", opts.BinaryNamePrefix)
 	ctx.Set("Denom", opts.Denom)
-	ctx.Set("Prefix", opts.Prefix)
+	ctx.Set("AddressPrefix", opts.AddressPrefix)
 	ctx.Set("title", strings.Title)
 
 	g.Transformer(plushgen.Transformer(ctx))

--- a/starport/templates/app/new.go
+++ b/starport/templates/app/new.go
@@ -20,6 +20,7 @@ func New(opts *Options) (*genny.Generator, error) {
 	ctx.Set("AppName", opts.AppName)
 	ctx.Set("BinaryNamePrefix", opts.BinaryNamePrefix)
 	ctx.Set("Denom", opts.Denom)
+	ctx.Set("Prefix", opts.Prefix)
 	ctx.Set("title", strings.Title)
 
 	g.Transformer(plushgen.Transformer(ctx))

--- a/starport/templates/app/options.go
+++ b/starport/templates/app/options.go
@@ -6,6 +6,7 @@ type Options struct {
 	BinaryNamePrefix string
 	ModulePath       string
 	Denom            string
+	Prefix           string
 }
 
 // Validate that options are usuable

--- a/starport/templates/app/options.go
+++ b/starport/templates/app/options.go
@@ -6,7 +6,7 @@ type Options struct {
 	BinaryNamePrefix string
 	ModulePath       string
 	Denom            string
-	Prefix           string
+	AddressPrefix    string
 }
 
 // Validate that options are usuable

--- a/starport/templates/app/templates/Makefile.plush
+++ b/starport/templates/app/templates/Makefile.plush
@@ -34,8 +34,8 @@ init-user2:
 	<%= BinaryNamePrefix %>cli keys add user2 --output json 2>&1
 
 init-post:
-	<%= BinaryNamePrefix %>d add-genesis-account $$(<%= BinaryNamePrefix %>cli keys show user1 -a) 1000token,100000000stake
-	<%= BinaryNamePrefix %>d add-genesis-account $$(<%= BinaryNamePrefix %>cli keys show user2 -a) 500token
+	<%= BinaryNamePrefix %>d add-genesis-account $$(<%= BinaryNamePrefix %>cli keys show user1 -a) 1000<%= Denom %>,100000000stake
+	<%= BinaryNamePrefix %>d add-genesis-account $$(<%= BinaryNamePrefix %>cli keys show user2 -a) 500<%= Denom %>
 	<%= BinaryNamePrefix %>cli config chain-id <%= AppName %>
 	<%= BinaryNamePrefix %>cli config output json
 	<%= BinaryNamePrefix %>cli config indent true

--- a/starport/templates/app/templates/app/prefix.go.plush
+++ b/starport/templates/app/templates/app/prefix.go.plush
@@ -1,0 +1,22 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	AccountAddressPrefix   = "<%= Prefix %>"
+	AccountPubKeyPrefix    = "<%= Prefix %>pub"
+	ValidatorAddressPrefix = "<%= Prefix %>valoper"
+	ValidatorPubKeyPrefix  = "<%= Prefix %>valoperpub"
+	ConsNodeAddressPrefix  = "<%= Prefix %>valcons"
+	ConsNodePubKeyPrefix   = "<%= Prefix %>valconspub"
+)
+
+func SetConfig() {
+	config := sdk.GetConfig()
+	config.SetBech32PrefixForAccount(AccountAddressPrefix, AccountPubKeyPrefix)
+	config.SetBech32PrefixForValidator(ValidatorAddressPrefix, ValidatorPubKeyPrefix)
+	config.SetBech32PrefixForConsensusNode(ConsNodeAddressPrefix, ConsNodePubKeyPrefix)
+	config.Seal()
+}

--- a/starport/templates/app/templates/app/prefix.go.plush
+++ b/starport/templates/app/templates/app/prefix.go.plush
@@ -5,12 +5,12 @@ import (
 )
 
 var (
-	AccountAddressPrefix   = "<%= Prefix %>"
-	AccountPubKeyPrefix    = "<%= Prefix %>pub"
-	ValidatorAddressPrefix = "<%= Prefix %>valoper"
-	ValidatorPubKeyPrefix  = "<%= Prefix %>valoperpub"
-	ConsNodeAddressPrefix  = "<%= Prefix %>valcons"
-	ConsNodePubKeyPrefix   = "<%= Prefix %>valconspub"
+	AccountAddressPrefix   = "<%= AddressPrefix %>"
+	AccountPubKeyPrefix    = "<%= AddressPrefix %>pub"
+	ValidatorAddressPrefix = "<%= AddressPrefix %>valoper"
+	ValidatorPubKeyPrefix  = "<%= AddressPrefix %>valoperpub"
+	ConsNodeAddressPrefix  = "<%= AddressPrefix %>valcons"
+	ConsNodePubKeyPrefix   = "<%= AddressPrefix %>valconspub"
 )
 
 func SetConfig() {

--- a/starport/templates/app/templates/cmd/{{binaryNamePrefix}}cli/main.go.plush
+++ b/starport/templates/app/templates/cmd/{{binaryNamePrefix}}cli/main.go.plush
@@ -10,7 +10,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/lcd"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
@@ -35,12 +34,7 @@ func main() {
 	// Instantiate the codec for the command line application
 	cdc := app.MakeCodec()
 
-	// Read in the configuration file for the sdk
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
-	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
-	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
-	config.Seal()
+	app.SetConfig()
 
 	// TODO: setup keybase, viper object, etc. to be passed into
 	// the below functions and eliminate global vars, like we do

--- a/starport/templates/app/templates/cmd/{{binaryNamePrefix}}d/main.go.plush
+++ b/starport/templates/app/templates/cmd/{{binaryNamePrefix}}d/main.go.plush
@@ -33,11 +33,7 @@ var invCheckPeriod uint
 func main() {
 	cdc := app.MakeCodec()
 
-	config := sdk.GetConfig()
-	config.SetBech32PrefixForAccount(sdk.Bech32PrefixAccAddr, sdk.Bech32PrefixAccPub)
-	config.SetBech32PrefixForValidator(sdk.Bech32PrefixValAddr, sdk.Bech32PrefixValPub)
-	config.SetBech32PrefixForConsensusNode(sdk.Bech32PrefixConsAddr, sdk.Bech32PrefixConsPub)
-	config.Seal()
+	app.SetConfig()
 
 	ctx := server.NewDefaultContext()
 	cobra.EnableCommandSorting = false

--- a/starport/templates/app/templates/frontend/src/store/index.js.plush
+++ b/starport/templates/app/templates/frontend/src/store/index.js.plush
@@ -2,11 +2,12 @@ import Vue from "vue";
 import Vuex from "vuex";
 import axios from "axios";
 import app from "./app.js";
-import { Secp256k1Wallet, SigningCosmosClient } from "@cosmjs/launchpad";
+import { Secp256k1Wallet, SigningCosmosClient, makeCosmoshubPath } from "@cosmjs/launchpad";
 
 Vue.use(Vuex);
 
 const API = "http://localhost:8080";
+const ADDRESS_PREFIX = "<%= Prefix %>"
 
 export default new Vuex.Store({
   state: {
@@ -45,7 +46,7 @@ export default new Vuex.Store({
     },
     async accountSignIn({ commit }, { mnemonic }) {
       return new Promise(async (resolve, reject) => {
-        const wallet = await Secp256k1Wallet.fromMnemonic(mnemonic);
+        const wallet = await Secp256k1Wallet.fromMnemonic(mnemonic, makeCosmoshubPath(0), ADDRESS_PREFIX);
         const [{ address }] = await wallet.getAccounts();
         const url = `${API}/auth/accounts/${address}`;
         const acc = (await axios.get(url)).data;

--- a/starport/templates/app/templates/frontend/src/store/index.js.plush
+++ b/starport/templates/app/templates/frontend/src/store/index.js.plush
@@ -7,7 +7,7 @@ import { Secp256k1Wallet, SigningCosmosClient, makeCosmoshubPath } from "@cosmjs
 Vue.use(Vuex);
 
 const API = "http://localhost:8080";
-const ADDRESS_PREFIX = "<%= Prefix %>"
+const ADDRESS_PREFIX = "<%= AddressPrefix %>"
 
 export default new Vuex.Store({
   state: {


### PR DESCRIPTION
Adds a `--address-prefix` flag to `starport app`.

```
starport app github.com/dundermifflin/scranton --address-prefix office --denom schrutebuck
```

Also, fixes custom `denom` in `Makefile`.

close https://github.com/tendermint/starport/issues/93

