### PR TITLE
services/serve: wait for a fix on build error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gobuffalo/plush v3.8.3+incompatible
 	github.com/gobuffalo/plushgen v0.1.2
 	github.com/goccy/go-yaml v1.8.0
+	github.com/gookit/color v1.2.7
 	github.com/gorilla/mux v1.7.4
 	github.com/ilgooz/analytics-go v3.1.1-0.20200723195510-acde4190c655+incompatible
 	github.com/karrick/godirwalk v1.15.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/gookit/color v1.2.7 h1:4qePMNWZhrmbfYJDix+J4V2l0iVW+6jQGjicELlN14E=
+github.com/gookit/color v1.2.7/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=

--- a/starport/services/serve/serve.go
+++ b/starport/services/serve/serve.go
@@ -190,12 +190,16 @@ func (s *starportServe) buildSteps() (steps step.Steps) {
 		step.PostExec(captureBuildErr),
 		step.Stderr(buildErr),
 	))
-	steps.Add(step.New(step.Exec("go", "mod", "verify")))
+	steps.Add(step.New(
+		step.Exec("go", "mod", "verify"),
+	))
+
 	cwd, _ := os.Getwd()
+
 	steps.Add(step.New(
 		step.Exec("go", "install", "-mod", "readonly", "-ldflags", ldflags, filepath.Join(cwd, "cmd", appd)),
 		step.PreExec(func() error {
-			fmt.Println("\n🛠️  Building the app...")
+			fmt.Println("🛠️  Building the app...")
 			return nil
 		}),
 		step.PostExec(captureBuildErr),

--- a/starport/services/serve/serve.go
+++ b/starport/services/serve/serve.go
@@ -192,10 +192,6 @@ func (s *starportServe) buildSteps() (steps step.Steps) {
 	))
 	steps.Add(step.New(
 		step.Exec("go", "mod", "verify"),
-		step.PreExec(func() error {
-			fmt.Println("🛠️  Building the app...")
-			return nil
-		}),
 		step.PostExec(captureBuildErr),
 		step.Stderr(buildErr),
 	))
@@ -204,6 +200,10 @@ func (s *starportServe) buildSteps() (steps step.Steps) {
 
 	steps.Add(step.New(
 		step.Exec("go", "install", "-mod", "readonly", "-ldflags", ldflags, filepath.Join(cwd, "cmd", appd)),
+		step.PreExec(func() error {
+			fmt.Println("🛠️  Building the app...")
+			return nil
+		}),
 		step.PostExec(captureBuildErr),
 		step.Stderr(buildErr),
 	))

--- a/starport/services/serve/serve.go
+++ b/starport/services/serve/serve.go
@@ -192,16 +192,18 @@ func (s *starportServe) buildSteps() (steps step.Steps) {
 	))
 	steps.Add(step.New(
 		step.Exec("go", "mod", "verify"),
+		step.PreExec(func() error {
+			fmt.Println("🛠️  Building the app...")
+			return nil
+		}),
+		step.PostExec(captureBuildErr),
+		step.Stderr(buildErr),
 	))
 
 	cwd, _ := os.Getwd()
 
 	steps.Add(step.New(
 		step.Exec("go", "install", "-mod", "readonly", "-ldflags", ldflags, filepath.Join(cwd, "cmd", appd)),
-		step.PreExec(func() error {
-			fmt.Println("🛠️  Building the app...")
-			return nil
-		}),
 		step.PostExec(captureBuildErr),
 		step.Stderr(buildErr),
 	))


### PR DESCRIPTION
instead of aborting the serve on an error related to building the app's backend, wait for a fix and try to rebuild.

resolves #107.

