### PR TITLE
Replace frontend dir name with vue

### DIFF
--- a/starport/templates/typed/new.go
+++ b/starport/templates/typed/new.go
@@ -194,7 +194,7 @@ func clientRestRestModify(opts *Options) genny.RunFn {
 
 func frontendSrcStoreAppModify(opts *Options) genny.RunFn {
 	return func(r *genny.Runner) error {
-		path := "frontend/src/store/app.js"
+		path := "vue/src/store/app.js"
 		f, err := r.Disk.Find(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
`type` silently failed, because it tried to generate frontend files in `./frontend` (and we've replaced it with `./vue`)

fix https://github.com/tendermint/starport/issues/178

He gotta write a test for this :smile:

