### PR TITLE
Update changelog.md

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## `develop`
+## `v0.0.10-rc.3`
 
 ### Features:
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Configure `genesis.json` through `genesis` field in `config.yml`
 * Initialize git repository on `app` scaffolding
 * Check Go and GOPATH when running `serve`
+* Added `version` command
 
 ### Changes:
 
@@ -19,6 +20,7 @@
 * Failure to start the frontend doesn't prevent Starport from running
 * Changes to `config.yml` trigger reinitialization of the app
 * Running `starport add wasm` multiple times no longer breaks the app
+* Running `starport add type...` multiple times no longer breaks the app
 
 ## `v0.0.10-rc.X`
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,22 @@
 # Changelog
 
+## `develop`
+
 ## `v0.0.10-rc.3`
+
+### Features:
+
+* Added `version` command
+
+### Fixes:
+
+* Running `starport add type...` multiple times no longer breaks the app
 
 ### Features:
 
 * Configure `genesis.json` through `genesis` field in `config.yml`
 * Initialize git repository on `app` scaffolding
 * Check Go and GOPATH when running `serve`
-* Added `version` command
 
 ### Changes:
 
@@ -20,7 +29,6 @@
 * Failure to start the frontend doesn't prevent Starport from running
 * Changes to `config.yml` trigger reinitialization of the app
 * Running `starport add wasm` multiple times no longer breaks the app
-* Running `starport add type...` multiple times no longer breaks the app
 
 ## `v0.0.10-rc.X`
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,6 @@
 
 ## `develop`
 
-## `v0.0.10-rc.3`
-
 ### Features:
 
 * Added `version` command
@@ -11,6 +9,8 @@
 ### Fixes:
 
 * Running `starport add type...` multiple times no longer breaks the app
+
+## `v0.0.10-rc.3`
 
 ### Features:
 


### PR DESCRIPTION
* Added `version` command
* Running `starport add type...` multiple times no longer breaks the app

We should just add to changelog in the same PRs, though.