### PR TITLE
simplify configuring account prefix

### DIFF
--- a/starport/templates/app/templates/app/prefix.go.plush
+++ b/starport/templates/app/templates/app/prefix.go.plush
@@ -4,13 +4,16 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
+const (
 	AccountAddressPrefix   = "<%= AddressPrefix %>"
-	AccountPubKeyPrefix    = "<%= AddressPrefix %>pub"
-	ValidatorAddressPrefix = "<%= AddressPrefix %>valoper"
-	ValidatorPubKeyPrefix  = "<%= AddressPrefix %>valoperpub"
-	ConsNodeAddressPrefix  = "<%= AddressPrefix %>valcons"
-	ConsNodePubKeyPrefix   = "<%= AddressPrefix %>valconspub"
+)
+
+var (
+	AccountPubKeyPrefix    = AccountAddressPrefix + "pub"
+	ValidatorAddressPrefix = AccountAddressPrefix + "valoper"
+	ValidatorPubKeyPrefix  = AccountAddressPrefix + "valoperpub"
+	ConsNodeAddressPrefix  = AccountAddressPrefix + "valcons"
+	ConsNodePubKeyPrefix   = AccountAddressPrefix + "valconspub"
 )
 
 func SetConfig() {


### PR DESCRIPTION
related to https://github.com/tendermint/starport/issues/181.

there seems to be no strightforward way of configuring the prefix by a single constant that can be applied to both backend and frontend. so both needs to be updated individually. 