### PR TITLE
appcli checks min. args for create-x cmd

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Fixes:
 
 * Running `starport add type...` multiple times no longer breaks the app
+* Running `appcli tx app create-x` now checks for all required args. -#173.
 
 ## `v0.0.10-rc.3`
 

--- a/starport/templates/typed/templates/x/{{appName}}/client/cli/tx{{TypeName}}.go.plush
+++ b/starport/templates/typed/templates/x/{{appName}}/client/cli/tx{{TypeName}}.go.plush
@@ -17,7 +17,7 @@ func GetCmdCreate<%= title(TypeName) %>(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "create-<%= TypeName %><%= for (i, field) in Fields { %> [<%= field.Name %>]<% } %>",
 		Short: "Creates a new <%= TypeName %>",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
       <%= for (i, field) in Fields { %>args<%= title(field.Name) %><%= if (field.Datatype != "string") {%>, _<%}%> := <%= if (field.Datatype == "string") {%>string<%} else {%>strconv.Parse<%= title(field.Datatype) %><%}%>(args[<%= i %>])
       <% } %>


### PR DESCRIPTION
fixes #173.

- [x] Updated changelog.