### PR TITLE
cmd/app: rm unused denom flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 ### Fixes:
 
 * Running `starport add type...` multiple times no longer breaks the app
+* Removed unused `--denom` flag from the `app` command. It previously has moved as a prop to the `config.yml` under `accounts` section.
 
 ## `v0.0.10-rc.3`
 

--- a/starport/interface/cli/starport/cmd/app.go
+++ b/starport/interface/cli/starport/cmd/app.go
@@ -32,7 +32,6 @@ func NewApp() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  appHandler,
 	}
-	c.Flags().StringP("denom", "d", "token", "Token denomination")
 	c.Flags().String("address-prefix", "cosmos", "Address prefix")
 	return c
 }
@@ -42,13 +41,11 @@ func appHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	denom, _ := cmd.Flags().GetString("denom")
 	addressPrefix, _ := cmd.Flags().GetString("address-prefix")
 	g, _ := app.New(&app.Options{
 		ModulePath:       path.RawPath,
 		AppName:          path.Package,
 		BinaryNamePrefix: path.Root,
-		Denom:            denom,
 		AddressPrefix:    addressPrefix,
 	})
 	run := genny.WetRunner(context.Background())

--- a/starport/templates/app/new.go
+++ b/starport/templates/app/new.go
@@ -19,7 +19,6 @@ func New(opts *Options) (*genny.Generator, error) {
 	ctx.Set("ModulePath", opts.ModulePath)
 	ctx.Set("AppName", opts.AppName)
 	ctx.Set("BinaryNamePrefix", opts.BinaryNamePrefix)
-	ctx.Set("Denom", opts.Denom)
 	ctx.Set("AddressPrefix", opts.AddressPrefix)
 	ctx.Set("title", strings.Title)
 

--- a/starport/templates/app/options.go
+++ b/starport/templates/app/options.go
@@ -5,7 +5,6 @@ type Options struct {
 	AppName          string
 	BinaryNamePrefix string
 	ModulePath       string
-	Denom            string
 	AddressPrefix    string
 }
 


### PR DESCRIPTION
it is previously moved as a prop to the `config.yml`.

resolves #159.

- [x] Updated changelog.