### PR TITLE
Fix templates for CosmWasm 0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200822124328-c89045814202 // indirect
-	golang.org/x/sync v0.0.0-20200930132711-30421366ff76
-	golang.org/x/sys v0.0.0-20201008064518-c1f3e3309c71 // indirect
+	golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520
+	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200930132711-30421366ff76 h1:JnxiSYT3Nm0BT2a8CyvYyM6cnrWpidecD1UuSYbhKm0=
-golang.org/x/sync v0.0.0-20200930132711-30421366ff76/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520 h1:Bx6FllMpG4NWDOfhMBz1VR2QYNp/SAOHPIAsaVmxfPo=
+golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -363,8 +363,8 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201008064518-c1f3e3309c71 h1:ZPX6UakxrJCxWiyGWpXtFY+fp86Esy7xJT/jJCG8bgU=
-golang.org/x/sys v0.0.0-20201008064518-c1f3e3309c71/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
+golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -10,14 +10,17 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/cosmosver"
 	"github.com/tendermint/starport/starport/pkg/gomodulepath"
 	"github.com/tendermint/starport/starport/templates/module"
 )
 
 const (
-	wasmImport = "github.com/CosmWasm/wasmd"
-	apppkg     = "app"
+	wasmImport        = "github.com/CosmWasm/wasmd"
+	apppkg            = "app"
+	wasmVersionCommit = "b30902fe1fbe5237763775950f729b90bf34d53f"
 )
 
 // ImportModule imports specified module with name to the scaffolded app.
@@ -36,6 +39,13 @@ func (s *Scaffolder) ImportModule(name string) error {
 	if ok {
 		return errors.New("CosmWasm is already imported.")
 	}
+
+	// Import a specific version of ComsWasm
+	err = installWasm()
+	if err != nil {
+		return err
+	}
+
 	path, err := gomodulepath.ParseFile(s.path)
 	if err != nil {
 		return err
@@ -72,4 +82,21 @@ func isWasmImported(appPath string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func installWasm() error {
+	return cmdrunner.
+		New(
+			cmdrunner.DefaultStderr(os.Stderr),
+			// cmdrunner.DefaultWorkdir(absRoot),
+		).
+		Run(context.Background(),
+			step.New(
+				step.Exec(
+					"go",
+					"get",
+					wasmImport+"@"+wasmVersionCommit,
+				),
+			),
+		)
 }

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -88,7 +88,6 @@ func installWasm() error {
 	return cmdrunner.
 		New(
 			cmdrunner.DefaultStderr(os.Stderr),
-			// cmdrunner.DefaultWorkdir(absRoot),
 		).
 		Run(context.Background(),
 			step.New(

--- a/starport/templates/app/launchpad/app/app.go.plush
+++ b/starport/templates/app/launchpad/app/app.go.plush
@@ -46,6 +46,7 @@ var (
 
 	maccPerms = map[string][]string{
 		auth.FeeCollectorName:     nil,
+		// this line is used by starport scaffolding # 2.1
 		staking.BondedPoolName:    {supply.Burner, supply.Staking},
 		staking.NotBondedPoolName: {supply.Burner, supply.Staking},
 	}
@@ -172,9 +173,13 @@ func NewInitApp(
     // this line is used by starport scaffolding # 6
 	)
 
-	app.mm.SetOrderEndBlockers(staking.ModuleName)
+	app.mm.SetOrderEndBlockers(
+		staking.ModuleName,
+		// this line is used by starport scaffolding # 6.1
+	)
 
 	app.mm.SetOrderInitGenesis(
+		// this line is used by starport scaffolding # 6.2
 		staking.ModuleName,
 		auth.ModuleName,
 		bank.ModuleName,

--- a/starport/templates/app/launchpad/app/app.go.plush
+++ b/starport/templates/app/launchpad/app/app.go.plush
@@ -122,6 +122,7 @@ func NewInitApp(
 	app.subspaces[auth.ModuleName] = app.paramsKeeper.Subspace(auth.DefaultParamspace)
 	app.subspaces[bank.ModuleName] = app.paramsKeeper.Subspace(bank.DefaultParamspace)
 	app.subspaces[staking.ModuleName] = app.paramsKeeper.Subspace(staking.DefaultParamspace)
+	// this line is used by starport scaffolding # 5.1
 
 	app.accountKeeper = auth.NewAccountKeeper(
 		app.cdc,
@@ -151,8 +152,12 @@ func NewInitApp(
 		app.subspaces[staking.ModuleName],
 	)
 
+	// this line is used by starport scaffolding # 5.2
+
 	app.stakingKeeper = *stakingKeeper.SetHooks(
-		staking.NewMultiStakingHooks(),
+		staking.NewMultiStakingHooks(
+			// this line is used by starport scaffolding # 5.3
+		),
 	)
 
 	app.<%= AppName %>Keeper = <%= AppName %>keeper.NewKeeper(

--- a/starport/templates/app/launchpad/app/export.go.plush
+++ b/starport/templates/app/launchpad/app/export.go.plush
@@ -56,14 +56,19 @@ func (app *NewApp) prepForZeroHeightGenesis(ctx sdk.Context, jailWhiteList []str
 		whiteListMap[addr] = true
 	}
 
+	// this line is used by starport scaffolding # 1
+
 	// set context height to zero
 	height := ctx.BlockHeight()
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
 	app.stakingKeeper.IterateValidators(ctx, func(_ int64, val staking.ValidatorI) (stop bool) {
+		// this line is used by starport scaffolding # 2
 		return false
 	})
+
+	// this line is used by starport scaffolding # 3
 
 	// reset context height
 	ctx = ctx.WithBlockHeight(height)

--- a/starport/templates/module/new_import.go
+++ b/starport/templates/module/new_import.go
@@ -33,6 +33,9 @@ const placeholder2_1 = "// this line is used by starport scaffolding # 2.1"
 const placeholder3 = "// this line is used by starport scaffolding # 3"
 const placeholder4 = "// this line is used by starport scaffolding # 4"
 const placeholder5 = "// this line is used by starport scaffolding # 5"
+const placeholder5_1 = "// this line is used by starport scaffolding # 5.1"
+const placeholder5_2 = "// this line is used by starport scaffolding # 5.2"
+const placeholder5_3 = "// this line is used by starport scaffolding # 5.3"
 const placeholder6 = "// this line is used by starport scaffolding # 6"
 const placeholder6_1 = "// this line is used by starport scaffolding # 6.1"
 const placeholder6_2 = "// this line is used by starport scaffolding # 6.2"
@@ -72,14 +75,31 @@ func appModify(opts *Options) genny.RunFn {
 		replacement3 := fmt.Sprintf(template3, placeholder3)
 		content = strings.Replace(content, placeholder3, replacement3, 1)
 
-		template4 := placeholder4 + "\n" + `app.distrKeeper = distr.NewKeeper(
+		template5 := `%[1]v
+		distr.StoreKey,
+		wasm.StoreKey,`
+		replacement5 := fmt.Sprintf(template5, placeholder5)
+		content = strings.Replace(content, placeholder5, replacement5, 1)
+
+		template5_1 := `%[1]v
+		app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)`
+		replacement5_1 := fmt.Sprintf(template5_1, placeholder5_1)
+		content = strings.Replace(content, placeholder5_1, replacement5_1, 1)
+
+		template5_2 := `%[1]v
+		app.distrKeeper = distr.NewKeeper(
 			app.cdc, keys[distr.StoreKey], app.subspaces[distr.ModuleName], &stakingKeeper,
 			app.supplyKeeper, auth.FeeCollectorName, app.ModuleAccountAddrs(),
-		)
-		app.stakingKeeper = *stakingKeeper.SetHooks(
-			staking.NewMultiStakingHooks(app.distrKeeper.Hooks()),
-		)` +
-			"\n" +
+		)`
+		replacement5_2 := fmt.Sprintf(template5_2, placeholder5_2)
+		content = strings.Replace(content, placeholder5_2, replacement5_2, 1)
+
+		template5_3 := `%[1]v
+		app.distrKeeper.Hooks(),`
+		replacement5_3 := fmt.Sprintf(template5_3, placeholder5_3)
+		content = strings.Replace(content, placeholder5_3, replacement5_3, 1)
+
+		template4 := placeholder4 + "\n" +
 			"type WasmWrapper struct { Wasm wasm.Config `mapstructure:\"wasm\"`}" + `
 		var wasmRouter = bApp.Router()
 		homeDir := viper.GetString(cli.HomeFlag)
@@ -92,16 +112,9 @@ func appModify(opts *Options) genny.RunFn {
 		}
 		wasmConfig := wasmWrap.Wasm
 		supportedFeatures := "staking"
-		app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
 		app.subspaces[wasm.ModuleName] = app.paramsKeeper.Subspace(wasm.DefaultParamspace)
 		app.wasmKeeper = wasm.NewKeeper(app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName], app.accountKeeper, app.bankKeeper, app.stakingKeeper, app.distrKeeper, wasmRouter, wasmDir, wasmConfig, supportedFeatures, nil, nil)`
 		content = strings.Replace(content, placeholder4, template4, 1)
-
-		template5 := `%[1]v
-		distr.StoreKey,
-		wasm.StoreKey,`
-		replacement5 := fmt.Sprintf(template5, placeholder5)
-		content = strings.Replace(content, placeholder5, replacement5, 1)
 
 		template6 := `%[1]v
 		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),

--- a/starport/templates/module/new_import.go
+++ b/starport/templates/module/new_import.go
@@ -14,6 +14,7 @@ import (
 func NewImport(opts *Options) (*genny.Generator, error) {
 	g := genny.New()
 	g.RunFn(appModify(opts))
+	g.RunFn(exportModify(opts))
 	g.RunFn(cmdMainModify(opts))
 	if err := g.Box(packr.New("wasm", "./wasm")); err != nil {
 		return g, err
@@ -28,12 +29,16 @@ func NewImport(opts *Options) (*genny.Generator, error) {
 
 const placeholder = "// this line is used by starport scaffolding # 1"
 const placeholder2 = "// this line is used by starport scaffolding # 2"
+const placeholder2_1 = "// this line is used by starport scaffolding # 2.1"
 const placeholder3 = "// this line is used by starport scaffolding # 3"
 const placeholder4 = "// this line is used by starport scaffolding # 4"
 const placeholder5 = "// this line is used by starport scaffolding # 5"
 const placeholder6 = "// this line is used by starport scaffolding # 6"
+const placeholder6_1 = "// this line is used by starport scaffolding # 6.1"
+const placeholder6_2 = "// this line is used by starport scaffolding # 6.2"
 const placeholder7 = "// this line is used by starport scaffolding # 7"
 
+// Append CosmWasm and Distr modules in app.go
 func appModify(opts *Options) genny.RunFn {
 	return func(r *genny.Runner) error {
 		path := "app/app.go"
@@ -45,50 +50,142 @@ func appModify(opts *Options) genny.RunFn {
 	"path/filepath"
 	"github.com/CosmWasm/wasmd/x/wasm"
 	"github.com/tendermint/tendermint/libs/cli"
-	"github.com/spf13/viper"`
+	"github.com/spf13/viper"
+	distr "github.com/cosmos/cosmos-sdk/x/distribution"`
 		replacement := fmt.Sprintf(template, placeholder)
 		content := strings.Replace(f.String(), placeholder, replacement, 1)
 
 		template2 := `%[1]v
+		distr.AppModuleBasic{},
 		wasm.AppModuleBasic{},`
 		replacement2 := fmt.Sprintf(template2, placeholder2)
 		content = strings.Replace(content, placeholder2, replacement2, 1)
 
+		template2_1 := `%[1]v
+		distr.ModuleName: nil,`
+		replacement2_1 := fmt.Sprintf(template2_1, placeholder2_1)
+		content = strings.Replace(content, placeholder2_1, replacement2_1, 1)
+
 		template3 := `%[1]v
-	wasmKeeper    wasm.Keeper`
+		distrKeeper    distr.Keeper
+		wasmKeeper    wasm.Keeper`
 		replacement3 := fmt.Sprintf(template3, placeholder3)
 		content = strings.Replace(content, placeholder3, replacement3, 1)
 
-		template4 := placeholder4 + "\n" + "type WasmWrapper struct { Wasm wasm.WasmConfig `mapstructure:\"wasm\"`}" + `
-	var wasmRouter = bApp.Router()
-	homeDir := viper.GetString(cli.HomeFlag)
-	wasmDir := filepath.Join(homeDir, "wasm")
+		template4 := placeholder4 + "\n" + `app.distrKeeper = distr.NewKeeper(
+			app.cdc, keys[distr.StoreKey], app.subspaces[distr.ModuleName], &stakingKeeper,
+			app.supplyKeeper, auth.FeeCollectorName, app.ModuleAccountAddrs(),
+		)
+		app.stakingKeeper = *stakingKeeper.SetHooks(
+			staking.NewMultiStakingHooks(app.distrKeeper.Hooks()),
+		)` +
+			"\n" +
+			"type WasmWrapper struct { Wasm wasm.Config `mapstructure:\"wasm\"`}" + `
+		var wasmRouter = bApp.Router()
+		homeDir := viper.GetString(cli.HomeFlag)
+		wasmDir := filepath.Join(homeDir, "wasm")
 
-	wasmWrap := WasmWrapper{Wasm: wasm.DefaultWasmConfig()}
-	err := viper.Unmarshal(&wasmWrap)
-	if err != nil {
-		panic("error while reading wasm config: " + err.Error())
-	}
-	wasmConfig := wasmWrap.Wasm
-	supportedFeatures := "staking"
-	app.subspaces[wasm.ModuleName] = app.paramsKeeper.Subspace(wasm.DefaultParamspace)
-	app.wasmKeeper = wasm.NewKeeper(app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName], app.accountKeeper, app.bankKeeper, app.stakingKeeper, wasmRouter, wasmDir, wasmConfig, supportedFeatures, nil, nil)`
+		wasmWrap := WasmWrapper{Wasm: wasm.DefaultWasmConfig()}
+		err := viper.Unmarshal(&wasmWrap)
+		if err != nil {
+			panic("error while reading wasm config: " + err.Error())
+		}
+		wasmConfig := wasmWrap.Wasm
+		supportedFeatures := "staking"
+		app.subspaces[distr.ModuleName] = app.paramsKeeper.Subspace(distr.DefaultParamspace)
+		app.subspaces[wasm.ModuleName] = app.paramsKeeper.Subspace(wasm.DefaultParamspace)
+		app.wasmKeeper = wasm.NewKeeper(app.cdc, keys[wasm.StoreKey], app.subspaces[wasm.ModuleName], app.accountKeeper, app.bankKeeper, app.stakingKeeper, app.distrKeeper, wasmRouter, wasmDir, wasmConfig, supportedFeatures, nil, nil)`
 		content = strings.Replace(content, placeholder4, template4, 1)
 
 		template5 := `%[1]v
+		distr.StoreKey,
 		wasm.StoreKey,`
 		replacement5 := fmt.Sprintf(template5, placeholder5)
 		content = strings.Replace(content, placeholder5, replacement5, 1)
 
 		template6 := `%[1]v
+		distr.NewAppModule(app.distrKeeper, app.accountKeeper, app.supplyKeeper, app.stakingKeeper),
 		wasm.NewAppModule(app.wasmKeeper),`
 		replacement6 := fmt.Sprintf(template6, placeholder6)
 		content = strings.Replace(content, placeholder6, replacement6, 1)
+
+		template6_1 := `%[1]v
+		distr.ModuleName,`
+		replacement6_1 := fmt.Sprintf(template6_1, placeholder6_1)
+		content = strings.Replace(content, placeholder6_1, replacement6_1, 1)
+
+		template6_2 := `%[1]v
+		distr.ModuleName,`
+		replacement6_2 := fmt.Sprintf(template6_2, placeholder6_2)
+		content = strings.Replace(content, placeholder6_2, replacement6_2, 1)
 
 		template7 := `%[1]v
 		wasm.ModuleName,`
 		replacement7 := fmt.Sprintf(template7, placeholder7)
 		content = strings.Replace(content, placeholder7, replacement7, 1)
+
+		newFile := genny.NewFileS(path, content)
+		return r.File(newFile)
+	}
+}
+
+// Append Distr modules in export.go
+func exportModify(opts *Options) genny.RunFn {
+	return func(r *genny.Runner) error {
+		path := "app/export.go"
+		f, err := r.Disk.Find(path)
+		if err != nil {
+			return err
+		}
+
+		template := `%[1]v
+		/* Handle fee distribution state. */
+
+		// withdraw all validator commission
+		app.stakingKeeper.IterateValidators(ctx, func(_ int64, val staking.ValidatorI) (stop bool) {
+			_, err := app.distrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
+			if err != nil {
+				log.Fatal(err)
+			}
+			return false
+		})
+
+		// withdraw all delegator rewards
+		dels := app.stakingKeeper.GetAllDelegations(ctx)
+		for _, delegation := range dels {
+			_, err := app.distrKeeper.WithdrawDelegationRewards(ctx, delegation.DelegatorAddress, delegation.ValidatorAddress)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		// clear validator slash events
+		app.distrKeeper.DeleteAllValidatorSlashEvents(ctx)
+
+		// clear validator historical rewards
+		app.distrKeeper.DeleteAllValidatorHistoricalRewards(ctx)`
+		replacement := fmt.Sprintf(template, placeholder)
+		content := strings.Replace(f.String(), placeholder, replacement, 1)
+
+		template2 := `%[1]v
+		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
+		scraps := app.distrKeeper.GetValidatorOutstandingRewards(ctx, val.GetOperator())
+		feePool := app.distrKeeper.GetFeePool(ctx)
+		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
+		app.distrKeeper.SetFeePool(ctx, feePool)
+
+		app.distrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())`
+		replacement2 := fmt.Sprintf(template2, placeholder2)
+		content = strings.Replace(content, placeholder2, replacement2, 1)
+
+		template3 := `%[1]v
+		// reinitialize all delegations
+		for _, del := range dels {
+			app.distrKeeper.Hooks().BeforeDelegationCreated(ctx, del.DelegatorAddress, del.ValidatorAddress)
+			app.distrKeeper.Hooks().AfterDelegationModified(ctx, del.DelegatorAddress, del.ValidatorAddress)
+		}`
+		replacement3 := fmt.Sprintf(template3, placeholder3)
+		content = strings.Replace(content, placeholder3, replacement3, 1)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)


### PR DESCRIPTION
Update templates for CosmWasm 0.11
Add `distr` module along with `wasm` module
Keep a fixed commit hash for the CosmWasm version to avoid an incompatible version

I arbitrarily took shortcuts for the placeholder names in the templates, this should be refactored: #319