### PR TITLE
fix: prevent duplicated fields in type command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 * Removed "Starport Pi"
 * Removed Makefile from Downstream Pi
 * Fixed downstream pi image Github Action
+* Prevent duplicated fields with `type` command
 
 ## `v0.11.1`
 

--- a/integration/cmd_type_test.go
+++ b/integration/cmd_type_test.go
@@ -21,6 +21,14 @@ func TestGenerateAnAppWithTypeAndVerify(t *testing.T) {
 		),
 	)
 
+	env.Exec("should prevent creating a type with duplicated fields",
+		step.New(
+			step.Exec("starport", "type", "company", "name", "name"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
+	)
+
 	env.Exec("should prevent creating an existing type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
@@ -45,6 +53,14 @@ func TestGenerateAnAppWithStargateWithTypeAndVerify(t *testing.T) {
 			step.Exec("starport", "type", "user", "email"),
 			step.Workdir(path),
 		),
+	)
+
+	env.Exec("should prevent creating a type with duplicated fields",
+		step.New(
+			step.Exec("starport", "type", "company", "name", "name"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
 	)
 
 	env.Exec("should prevent creating an existing type",

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -46,10 +46,20 @@ func (s *Scaffolder) AddType(moduleName string, stype string, fields ...string) 
 	if ok {
 		return fmt.Errorf("%s type is already added.", stype)
 	}
+
+	// Used to check duplicated field
+	existingFields := make(map[string]bool)
+
 	var tfields []typed.Field
 	for _, f := range fields {
 		fs := strings.Split(f, ":")
 		name := fs[0]
+
+		if _, exists := existingFields[name]; exists {
+			return fmt.Errorf("The field %s is duplicated.", name)
+		}
+		existingFields[name] = true
+
 		datatypeName, datatype := "string", "string"
 		acceptedTypes := map[string]string{
 			"string": "string",


### PR DESCRIPTION
`starport type user email email` shows an error