### PR TITLE
integration: fail tests on failed assertions

### DIFF
--- a/integration/cmd_type_test.go
+++ b/integration/cmd_type_test.go
@@ -16,42 +16,42 @@ func TestGenerateAnAppWithTypeAndVerify(t *testing.T) {
 		path = env.Scaffold("blog", Launchpad)
 	)
 
-	env.Exec("create a type",
+	env.Must(env.Exec("create a type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("create a type with int",
+	env.Must(env.Exec("create a type with int",
 		step.New(
 			step.Exec("starport", "type", "employee", "name:string", "level:int"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("create a type with bool",
+	env.Must(env.Exec("create a type with bool",
 		step.New(
 			step.Exec("starport", "type", "document", "signed:bool"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("should prevent creating a type with duplicated fields",
+	env.Must(env.Exec("should prevent creating a type with duplicated fields",
 		step.New(
 			step.Exec("starport", "type", "company", "name", "name"),
 			step.Workdir(path),
 		),
 		ExecShouldError(),
-	)
+	))
 
-	env.Exec("should prevent creating an existing type",
+	env.Must(env.Exec("should prevent creating an existing type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
 			step.Workdir(path),
 		),
 		ExecShouldError(),
-	)
+	))
 
 	env.EnsureAppIsSteady(path)
 }
@@ -64,42 +64,42 @@ func TestGenerateAnAppWithStargateWithTypeAndVerify(t *testing.T) {
 		path = env.Scaffold("blog", Stargate)
 	)
 
-	env.Exec("create a type",
+	env.Must(env.Exec("create a type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("create a type with int",
+	env.Must(env.Exec("create a type with int",
 		step.New(
 			step.Exec("starport", "type", "employee", "name:string", "level:int"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("create a type with bool",
+	env.Must(env.Exec("create a type with bool",
 		step.New(
 			step.Exec("starport", "type", "document", "signed:bool"),
 			step.Workdir(path),
 		),
-	)
+	))
 
-	env.Exec("should prevent creating a type with duplicated fields",
+	env.Must(env.Exec("should prevent creating a type with duplicated fields",
 		step.New(
 			step.Exec("starport", "type", "company", "name", "name"),
 			step.Workdir(path),
 		),
 		ExecShouldError(),
-	)
+	))
 
-	env.Exec("should prevent creating an existing type",
+	env.Must(env.Exec("should prevent creating an existing type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
 			step.Workdir(path),
 		),
 		ExecShouldError(),
-	)
+	))
 
 	env.EnsureAppIsSteady(path)
 }


### PR DESCRIPTION
with the recent changes, env.Exec() and env.Serve() needs to be covered
by a env.Must() in the main goroutine of the test.



- [ ] Updated changelog.