### PR TITLE
fix: prevent using reserved word as type name or field name

### DIFF
--- a/integration/cmd_type_test.go
+++ b/integration/cmd_type_test.go
@@ -61,6 +61,22 @@ func TestGenerateAnAppWithTypeAndVerify(t *testing.T) {
 		ExecShouldError(),
 	))
 
+	env.Must(env.Exec("should prevent creating a type whose name is a reserved word",
+		step.New(
+			step.Exec("starport", "type", "map", "size:int"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
+	))
+
+	env.Must(env.Exec("should prevent creating a type containing a field with a reserved word",
+		step.New(
+			step.Exec("starport", "type", "document", "type:int"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
+	))
+
 	env.EnsureAppIsSteady(path)
 }
 
@@ -112,6 +128,22 @@ func TestGenerateAnAppWithStargateWithTypeAndVerify(t *testing.T) {
 	env.Must(env.Exec("should prevent creating an existing type",
 		step.New(
 			step.Exec("starport", "type", "user", "email"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
+	))
+
+	env.Must(env.Exec("should prevent creating a type whose name is a reserved word",
+		step.New(
+			step.Exec("starport", "type", "map", "size:int"),
+			step.Workdir(path),
+		),
+		ExecShouldError(),
+	))
+
+	env.Must(env.Exec("should prevent creating a type containing a field with a reserved word",
+		step.New(
+			step.Exec("starport", "type", "document", "type:int"),
 			step.Workdir(path),
 		),
 		ExecShouldError(),

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -39,6 +39,11 @@ func (s *Scaffolder) AddType(moduleName string, stype string, fields ...string) 
 		return fmt.Errorf("The module %s doesn't exist.", moduleName)
 	}
 
+	// Ensure the type name is not a Go reserved name, it would generate an incorrect code
+	if isGoReservedWord(stype) {
+		return fmt.Errorf("%s can't be used as a type name.", stype)
+	}
+
 	ok, err = isTypeCreated(s.path, moduleName, stype)
 	if err != nil {
 		return err
@@ -55,6 +60,12 @@ func (s *Scaffolder) AddType(moduleName string, stype string, fields ...string) 
 		fs := strings.Split(f, ":")
 		name := fs[0]
 
+		// Ensure the field name is not a Go reserved name, it would generate an incorrect code
+		if isGoReservedWord(name) {
+			return fmt.Errorf("%s can't be used as a field name.", name)
+		}
+
+		// Ensure the field is not duplicated
 		if _, exists := existingFields[name]; exists {
 			return fmt.Errorf("The field %s is duplicated.", name)
 		}
@@ -142,4 +153,72 @@ func isTypeCreated(appPath, moduleName, typeName string) (isCreated bool, err er
 		}
 	}
 	return
+}
+
+func isGoReservedWord(name string) bool {
+	switch name {
+	case
+		"type",
+		"package",
+		"import",
+		"go",
+		"func",
+		"return",
+		"case",
+		"select",
+		"break",
+		"default",
+		"fallthrough",
+		"continue",
+		"if",
+		"else",
+		"goto",
+		"for",
+		"range",
+		"var",
+		"const",
+		"map",
+		"struct",
+		"interface",
+		"chan",
+		"defer",
+		"panic",
+		"recover",
+		"append",
+		"bool",
+		"byte",
+		"cap",
+		"close",
+		"complex",
+		"complex64",
+		"complex128",
+		"uint16",
+		"copy",
+		"false",
+		"float32",
+		"float64",
+		"imag",
+		"int",
+		"int8",
+		"int16",
+		"uint32",
+		"int32",
+		"int64",
+		"iota",
+		"len",
+		"make",
+		"new",
+		"nil",
+		"uint64",
+		"print",
+		"println",
+		"real",
+		"string",
+		"true",
+		"uint",
+		"uint8",
+		"uintptr":
+		return true
+	}
+	return false
 }

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -156,32 +156,15 @@ func isTypeCreated(appPath, moduleName, typeName string) (isCreated bool, err er
 }
 
 func isGoReservedWord(name string) bool {
+
+	// Check keyword or literal
+	if token.Lookup(name).IsKeyword() {
+		return true
+	}
+
+	// Check with builtin identifier
 	switch name {
 	case
-		"type",
-		"package",
-		"import",
-		"go",
-		"func",
-		"return",
-		"case",
-		"select",
-		"break",
-		"default",
-		"fallthrough",
-		"continue",
-		"if",
-		"else",
-		"goto",
-		"for",
-		"range",
-		"var",
-		"const",
-		"map",
-		"struct",
-		"interface",
-		"chan",
-		"defer",
 		"panic",
 		"recover",
 		"append",


### PR DESCRIPTION
Prevent using Go reserved word for type name or field name in the command `starport type` as it would generate a code with errors