### PR TITLE
prof_laddr ==> pprof_laddr

### DIFF
--- a/starport/services/chain/plugin-launchpad.go
+++ b/starport/services/chain/plugin-launchpad.go
@@ -173,7 +173,7 @@ func (p *launchpadPlugin) configtoml(conf starportconf.Config) error {
 	config.Set("rpc.cors_allowed_origins", []string{"*"})
 	config.Set("rpc.laddr", xurl.TCP(conf.Servers.RPCAddr))
 	config.Set("p2p.laddr", xurl.TCP(conf.Servers.P2PAddr))
-	config.Set("rpc.prof_laddr", conf.Servers.ProfAddr)
+	config.Set("rpc.pprof_laddr", conf.Servers.ProfAddr)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 644)
 	if err != nil {
 		return err

--- a/starport/services/chain/plugin-stargate.go
+++ b/starport/services/chain/plugin-stargate.go
@@ -149,7 +149,7 @@ func (p *stargatePlugin) configtoml(conf starportconf.Config) error {
 	config.Set("consensus.timeout_propose", "1s")
 	config.Set("rpc.laddr", xurl.TCP(conf.Servers.RPCAddr))
 	config.Set("p2p.laddr", xurl.TCP(conf.Servers.P2PAddr))
-	config.Set("rpc.prof_laddr", conf.Servers.ProfAddr)
+	config.Set("rpc.pprof_laddr", conf.Servers.ProfAddr)
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 644)
 	if err != nil {
 		return err


### PR DESCRIPTION
Tendermint uses `pprof_laddr` in config.toml.
https://github.com/tendermint/tendermint/blob/6e16df854780f8c50911fdc400843c13ab1b480b/config/config.go#L384