### PR TITLE
feat(config.yml): make sdk configs configurable 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 ### Features:
 * Upgraded Stargate's version to v0.40.0-rc3.
 * Added a gRPC-Web proxy which is available under http://localhost:12345/grpc.
+* Added chain id configurability by recognizing `chain_id` from `genesis` section of `config.yml`.
+* Added `config/app.toml` and `config/config.toml` configurability for appd under new `init.app` and `init.config` sections of `config.yml`.
 
 ## `v0.12.0`
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-git/go-git/v5 v5.1.0
 	github.com/gobuffalo/envy v1.9.0 // indirect
 	github.com/gobuffalo/genny v0.6.0
-	github.com/gobuffalo/packr/v2 v2.8.0
+	github.com/gobuffalo/packr/v2 v2.8.1
 	github.com/gobuffalo/plush v3.8.3+incompatible
 	github.com/gobuffalo/plushgen v0.1.2
 	github.com/goccy/go-yaml v1.8.0
@@ -41,7 +41,7 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf // indirect
+	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
-github.com/gobuffalo/packr/v2 v2.8.0 h1:IULGd15bQL59ijXLxEvA5wlMxsmx/ZkQv9T282zNVIY=
-github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
+github.com/gobuffalo/packr/v2 v2.8.1 h1:tkQpju6i3EtMXJ9uoF5GT6kB+LMTimDWD8Xvbz6zDVA=
+github.com/gobuffalo/packr/v2 v2.8.1/go.mod h1:c/PLlOuTU+p3SybaJATW3H6lX/iK7xEz5OeMf+NnJpg=
 github.com/gobuffalo/plush v3.8.3+incompatible h1:kzvUTnFPhwyfPEsx7U7LI05/IIslZVGnAlMA1heWub8=
 github.com/gobuffalo/plush v3.8.3+incompatible/go.mod h1:rQ4zdtUUyZNqULlc6bqd5scsPfLKfT0+TGMChgduDvI=
 github.com/gobuffalo/plushgen v0.1.2 h1:s4yAgNdfNMyMQ7o+Is4f1VlH2L1tKosT+m7BF28C8H4=
@@ -230,7 +230,7 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/karrick/godirwalk v1.15.3/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
 github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
@@ -492,8 +492,8 @@ golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf h1:kt3wY1Lu5MJAnKTfoMR52Cu4gwvna4VTzNOiT8tY73s=
-golang.org/x/sys v0.0.0-20201107080550-4d91cf3a1aaf/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
+golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -605,5 +605,6 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -1,0 +1,74 @@
+// +build !relayer
+
+package integration_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/starport/starport/pkg/confile"
+	"github.com/tendermint/starport/starport/pkg/randstr"
+	"github.com/tendermint/starport/starport/services/chain/conf"
+)
+
+func TestOverwriteSDKConfigsAndChainID(t *testing.T) {
+	t.Parallel()
+
+	for _, sdkVersion := range []string{Launchpad, Stargate} {
+		sdkVersion := sdkVersion
+		t.Run(sdkVersion, func(t *testing.T) {
+			t.Parallel()
+
+			testOverwriteSDKConfigsAndChainID(t, sdkVersion)
+		})
+	}
+}
+
+func testOverwriteSDKConfigsAndChainID(t *testing.T, sdkVersion string) {
+	var (
+		env               = newEnv(t)
+		appname           = randstr.Runes(10)
+		path              = env.Scaffold(appname, sdkVersion)
+		servers           = env.RandomizeServerPorts(path)
+		ctx, cancel       = context.WithCancel(env.Ctx())
+		isBackendAliveErr error
+	)
+
+	var c conf.Config
+
+	cf := confile.New(confile.DefaultYAMLEncodingCreator, filepath.Join(path, "config.yml"))
+	require.NoError(t, cf.Load(&c))
+
+	c.Genesis = map[string]interface{}{"chain_id": "cosmos"}
+	c.Init.App = map[string]interface{}{"hello": "cosmos"}
+	c.Init.Config = map[string]interface{}{"fast_sync": false}
+
+	require.NoError(t, cf.Save(c))
+
+	go func() {
+		defer cancel()
+		isBackendAliveErr = env.IsAppServed(ctx, servers)
+	}()
+	env.Must(env.Serve("should serve", path, ExecCtx(ctx)))
+	require.NoError(t, isBackendAliveErr, "app cannot get online in time")
+
+	configs := []struct {
+		ec          confile.EncodingCreator
+		relpath     string
+		key         string
+		expectedVal interface{}
+	}{
+		{confile.DefaultJSONEncodingCreator, "config/genesis.json", "chain_id", "cosmos"},
+		{confile.DefaultTOMLEncodingCreator, "config/app.toml", "hello", "cosmos"},
+		{confile.DefaultTOMLEncodingCreator, "config/config.toml", "fast_sync", false},
+	}
+
+	for _, c := range configs {
+		var conf map[string]interface{}
+		cf := confile.New(c.ec, filepath.Join(env.AppdHome(appname, sdkVersion), c.relpath))
+		require.NoError(t, cf.Load(&conf))
+		require.Equal(t, c.expectedVal, conf[c.key])
+	}
+}

--- a/integration/env_test.go
+++ b/integration/env_test.go
@@ -268,3 +268,14 @@ func (e env) Home() string {
 	require.NoError(e.t, err)
 	return home
 }
+
+// AppHome returns appd's home dir.
+func (e env) AppdHome(name, sdkVersion string) string {
+	switch sdkVersion {
+	case Stargate:
+		return filepath.Join(e.Home(), fmt.Sprintf("%sd", name))
+	case Launchpad:
+		return filepath.Join(e.Home(), fmt.Sprintf(".%sd", name))
+	}
+	return ""
+}

--- a/starport/pkg/confile/confile.go
+++ b/starport/pkg/confile/confile.go
@@ -1,0 +1,44 @@
+// Package confile is helper to load and overwrite configuration files.
+package confile
+
+import "os"
+
+// ConfigFile represents a configuration file.
+type ConfigFile struct {
+	creator EncodingCreator
+	path    string
+}
+
+// New starts a new ConfigFile by using creator as underlying EncodingCreator to encode and
+// decode config file that presents or will present on path.
+func New(creator EncodingCreator, path string) *ConfigFile {
+	return &ConfigFile{
+		creator: creator,
+		path:    path,
+	}
+}
+
+// Load loads content of config file into v if file exist on path.
+// otherwise nothing loaded into v and no error is returned.
+func (c *ConfigFile) Load(v interface{}) error {
+	file, err := os.Open(c.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	return c.creator.Create(file).Decode(v)
+}
+
+// Save saves v into config file by overwriting the previous content it also creates the
+// config file if it wasn't exist.
+func (c *ConfigFile) Save(v interface{}) error {
+	file, err := os.OpenFile(c.path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return c.creator.Create(file).Encode(v)
+}

--- a/starport/pkg/confile/confile_test.go
+++ b/starport/pkg/confile/confile_test.go
@@ -1,0 +1,56 @@
+package confile
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAll(t *testing.T) {
+	cases := []struct {
+		name         string
+		ec           EncodingCreator
+		hellocontent string
+	}{
+		{"json", DefaultJSONEncodingCreator, `{"hello":"world"}`},
+		{"yaml", DefaultYAMLEncodingCreator, `hello: world`},
+		{"toml", DefaultTOMLEncodingCreator, `hello = "world"`},
+	}
+
+	type data struct {
+		Hello string `json:"hello" yaml:"hello" toml:"hello"`
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			file, err := ioutil.TempFile("", "")
+			require.NoError(t, err)
+			defer func() {
+				file.Close()
+				os.Remove(file.Name())
+			}()
+
+			_, err = io.Copy(file, strings.NewReader(tt.hellocontent))
+			require.NoError(t, err)
+
+			cf := New(tt.ec, file.Name())
+			var d data
+			require.NoError(t, cf.Load(&d))
+			require.Equal(t, "world", d.Hello)
+
+			d.Hello = "cosmos"
+			require.NoError(t, cf.Save(d))
+
+			cf2 := New(tt.ec, file.Name())
+			var d2 data
+			require.NoError(t, cf2.Load(&d2))
+			require.Equal(t, "cosmos", d2.Hello)
+		})
+	}
+
+}

--- a/starport/pkg/confile/encoding.go
+++ b/starport/pkg/confile/encoding.go
@@ -1,0 +1,75 @@
+package confile
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/goccy/go-yaml"
+	"github.com/pelletier/go-toml"
+)
+
+// EncodingCreator defines a constructor to create an EncodingCreator from
+// an io.ReadWriter.
+type EncodingCreator interface {
+	Create(io.ReadWriter) EncodeDecoder
+}
+
+// EncodeDecoder combines Encoder and Decoder.
+type EncodeDecoder interface {
+	Encoder
+	Decoder
+}
+
+// Encoder should encode a v into io.Writer given to EncodingCreator.
+type Encoder interface {
+	Encode(v interface{}) error
+}
+
+// Decoder should decode a v from io.Reader given to EncodingCreator.
+type Decoder interface {
+	Decode(v interface{}) error
+}
+
+// Encoding implements EncodeDecoder
+type Encoding struct {
+	Encoder
+	Decoder
+}
+
+// NewEncoding returns a new EncodeDecoder implementation from e end d.
+func NewEncoding(e Encoder, d Decoder) EncodeDecoder {
+	return &Encoding{
+		Encoder: e,
+		Decoder: d,
+	}
+}
+
+// DefaultJSONEncodingCreator implements EncodingCreator for JSON encoding.
+var DefaultJSONEncodingCreator = &JSONEncodingCreator{}
+
+// DefaultYAMLEncodingCreator implements EncodingCreator for YAML encoding.
+var DefaultYAMLEncodingCreator = &YAMLEncodingCreator{}
+
+// DefaultTOMLEncodingCreator implements EncodingCreator for TOML encoding.
+var DefaultTOMLEncodingCreator = &TOMLEncodingCreator{}
+
+// JSONEncodingCreator implements EncodingCreator for JSON encoding.
+type JSONEncodingCreator struct{}
+
+func (e *JSONEncodingCreator) Create(rw io.ReadWriter) EncodeDecoder {
+	return NewEncoding(json.NewEncoder(rw), json.NewDecoder(rw))
+}
+
+// YAMLEncodingCreator implements EncodingCreator for JSON encoding.
+type YAMLEncodingCreator struct{}
+
+func (e *YAMLEncodingCreator) Create(rw io.ReadWriter) EncodeDecoder {
+	return NewEncoding(yaml.NewEncoder(rw), yaml.NewDecoder(rw))
+}
+
+// TOMLEncodingCreator implements EncodingCreator for JSON encoding.
+type TOMLEncodingCreator struct{}
+
+func (e *TOMLEncodingCreator) Create(rw io.ReadWriter) EncodeDecoder {
+	return NewEncoding(toml.NewEncoder(rw), toml.NewDecoder(rw))
+}

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -116,4 +117,36 @@ func (s *Chain) config() (conf.Config, error) {
 	}
 	defer confFile.Close()
 	return conf.Parse(confFile)
+}
+
+// ID returns the chain's id.
+func (s *Chain) ID() (string, error) {
+	id := s.app.n()
+	c, err := s.config()
+	if err != nil {
+		return "", err
+	}
+	genid, ok := c.Genesis["chain_id"]
+	if ok {
+		id = genid.(string)
+	}
+	return id, nil
+}
+
+// GenesisPath returns genesis.json path of the app.
+func (c *Chain) GenesisPath() string {
+	home, _ := c.plugin.Home()
+	return fmt.Sprintf("%s/config/genesis.json", home)
+}
+
+// AppTOMLPath returns app.toml path of the app.
+func (c *Chain) AppTOMLPath() string {
+	home, _ := c.plugin.Home()
+	return fmt.Sprintf("%s/config/app.toml", home)
+}
+
+// ConfigTOMLPath returns config.toml path of the app.
+func (c *Chain) ConfigTOMLPath() string {
+	home, _ := c.plugin.Home()
+	return fmt.Sprintf("%s/config/config.toml", home)
 }

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -31,6 +31,7 @@ var (
 type Config struct {
 	Accounts  []Account              `yaml:"accounts"`
 	Validator Validator              `yaml:"validator"`
+	Init      Init                   `yaml:"init"`
 	Genesis   map[string]interface{} `yaml:"genesis"`
 	Servers   Servers                `yaml:"servers"`
 }
@@ -49,6 +50,15 @@ type Account struct {
 type Validator struct {
 	Name   string `yaml:"name"`
 	Staked string `yaml:"staked"`
+}
+
+// Init overwrites sdk configurations with given values.
+type Init struct {
+	// App overwrites appd's config/app.toml configs.
+	App map[string]interface{} `yaml:"app"`
+
+	// Config overwrites appd's config/config.toml configs.
+	Config map[string]interface{} `yaml:"config"`
 }
 
 // Servers keeps configuration related to started servers.

--- a/starport/services/chain/plugin-launchpad.go
+++ b/starport/services/chain/plugin-launchpad.go
@@ -110,7 +110,7 @@ func (p *launchpadPlugin) ShowAccountCommand(accountName string) step.Option {
 	)
 }
 
-func (p *launchpadPlugin) ConfigCommands() []step.Option {
+func (p *launchpadPlugin) ConfigCommands(chainID string) []step.Option {
 	return []step.Option{
 		step.Exec(
 			p.app.cli(),
@@ -122,7 +122,7 @@ func (p *launchpadPlugin) ConfigCommands() []step.Option {
 			p.app.cli(),
 			"config",
 			"chain-id",
-			p.app.n(),
+			chainID,
 		),
 		step.Exec(
 			p.app.cli(),
@@ -145,7 +145,7 @@ func (p *launchpadPlugin) ConfigCommands() []step.Option {
 	}
 }
 
-func (p *launchpadPlugin) GentxCommand(conf starportconf.Config) step.Option {
+func (p *launchpadPlugin) GentxCommand(_ string, conf starportconf.Config) step.Option {
 	return step.Exec(
 		p.app.d(),
 		"gentx",
@@ -218,8 +218,12 @@ func (p *launchpadPlugin) StoragePaths() []string {
 	}
 }
 
-func (p *launchpadPlugin) GenesisPath() string {
-	return fmt.Sprintf(".%s/config/genesis.json", p.app.nd())
+func (p *launchpadPlugin) Home() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "."+p.app.nd()), nil
 }
 
 func (p *launchpadPlugin) Version() cosmosver.MajorVersion { return cosmosver.Launchpad }

--- a/starport/services/chain/plugin-stargate.go
+++ b/starport/services/chain/plugin-stargate.go
@@ -2,7 +2,6 @@ package chain
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -88,15 +87,15 @@ func (p *stargatePlugin) ShowAccountCommand(accountName string) step.Option {
 	)
 }
 
-func (p *stargatePlugin) ConfigCommands() []step.Option {
+func (p *stargatePlugin) ConfigCommands(_ string) []step.Option {
 	return nil
 }
 
-func (p *stargatePlugin) GentxCommand(conf starportconf.Config) step.Option {
+func (p *stargatePlugin) GentxCommand(chainID string, conf starportconf.Config) step.Option {
 	return step.Exec(
 		p.app.d(),
 		"gentx", conf.Validator.Name,
-		"--chain-id", p.app.n(),
+		"--chain-id", chainID,
 		"--keyring-backend", "test",
 		"--amount", conf.Validator.Staked,
 	)
@@ -182,8 +181,12 @@ func (p *stargatePlugin) StoragePaths() []string {
 	}
 }
 
-func (p *stargatePlugin) GenesisPath() string {
-	return fmt.Sprintf("%s/config/genesis.json", p.app.nd())
+func (p *stargatePlugin) Home() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, p.app.nd()), nil
 }
 
 func (p *stargatePlugin) Version() cosmosver.MajorVersion { return cosmosver.Stargate }

--- a/starport/services/chain/plugin.go
+++ b/starport/services/chain/plugin.go
@@ -30,10 +30,10 @@ type Plugin interface {
 	ShowAccountCommand(accountName string) step.Option
 
 	// ConfigCommands returns step.Exec configuration for config commands.
-	ConfigCommands() []step.Option
+	ConfigCommands(chainID string) []step.Option
 
 	// GentxCommand returns step.Exec configuration for gentx command.
-	GentxCommand(starportconf.Config) step.Option
+	GentxCommand(chainID string, c starportconf.Config) step.Option
 
 	// PostInit hook.
 	PostInit(starportconf.Config) error
@@ -44,8 +44,8 @@ type Plugin interface {
 	// StoragePaths returns a list of where persistent data kept.
 	StoragePaths() []string
 
-	// GenesisPath returns path of genesis.json.
-	GenesisPath() string
+	// Home returns the root config dir's path of app.
+	Home() (string, error)
 
 	// Version of the plugin.
 	Version() cosmosver.MajorVersion

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+	"github.com/tendermint/starport/starport/pkg/confile"
 	"github.com/tendermint/starport/starport/pkg/fswatcher"
 	"github.com/tendermint/starport/starport/pkg/xexec"
 	"github.com/tendermint/starport/starport/pkg/xos"
@@ -181,6 +182,11 @@ func (s *Chain) serve(ctx context.Context) error {
 }
 
 func (s *Chain) initSteps(ctx context.Context, conf conf.Config) (steps step.Steps, err error) {
+	chainID, err := s.ID()
+	if err != nil {
+		return nil, err
+	}
+
 	sconf, err := secretconf.Open(s.app.Path)
 	if err != nil {
 		return nil, err
@@ -205,40 +211,39 @@ func (s *Chain) initSteps(ctx context.Context, conf conf.Config) (steps step.Ste
 				s.app.d(),
 				"init",
 				"mynode",
-				"--chain-id", s.app.n(),
+				"--chain-id", chainID,
 			),
+			// overwrite configuration changes from Starport's config.yml to
+			// over app's sdk configs.
 			step.PostExec(func(err error) error {
-				// overwrite Genesis with user configs.
 				if err != nil {
 					return err
 				}
-				if conf.Genesis == nil {
-					return nil
+
+				appconfigs := []struct {
+					ec      confile.EncodingCreator
+					path    string
+					changes map[string]interface{}
+				}{
+					{confile.DefaultJSONEncodingCreator, s.GenesisPath(), conf.Genesis},
+					{confile.DefaultTOMLEncodingCreator, s.AppTOMLPath(), conf.Init.App},
+					{confile.DefaultTOMLEncodingCreator, s.ConfigTOMLPath(), conf.Init.Config},
 				}
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return err
+
+				for _, ac := range appconfigs {
+					cf := confile.New(ac.ec, ac.path)
+					var conf map[string]interface{}
+					if err := cf.Load(&conf); err != nil {
+						return err
+					}
+					if err := mergo.Merge(&conf, ac.changes, mergo.WithOverride); err != nil {
+						return err
+					}
+					if err := cf.Save(conf); err != nil {
+						return err
+					}
 				}
-				path := filepath.Join(home, s.plugin.GenesisPath())
-				file, err := os.OpenFile(path, os.O_RDWR, 644)
-				if err != nil {
-					return err
-				}
-				defer file.Close()
-				var genesis map[string]interface{}
-				if err := json.NewDecoder(file).Decode(&genesis); err != nil {
-					return err
-				}
-				if err := mergo.Merge(&genesis, conf.Genesis, mergo.WithOverride); err != nil {
-					return err
-				}
-				if err := file.Truncate(0); err != nil {
-					return err
-				}
-				if _, err := file.Seek(0, 0); err != nil {
-					return err
-				}
-				return json.NewEncoder(file).Encode(&genesis)
+				return nil
 			}),
 			step.PostExec(func(err error) error {
 				if err != nil {
@@ -277,7 +282,7 @@ func (s *Chain) initSteps(ctx context.Context, conf conf.Config) (steps step.Ste
 		fmt.Fprintf(s.stdLog(logStarport).out, "⚠️ Relayer error: %s\n", err)
 	}
 
-	for _, execOption := range s.plugin.ConfigCommands() {
+	for _, execOption := range s.plugin.ConfigCommands(chainID) {
 		execOption := execOption
 		steps.Add(step.New(step.NewOptions().
 			Add(execOption).
@@ -286,7 +291,7 @@ func (s *Chain) initSteps(ctx context.Context, conf conf.Config) (steps step.Ste
 	}
 
 	steps.Add(step.New(step.NewOptions().
-		Add(s.plugin.GentxCommand(conf)).
+		Add(s.plugin.GentxCommand(chainID, conf)).
 		Add(s.stdSteps(logAppd)...)...,
 	))
 	steps.Add(step.New(step.NewOptions().


### PR DESCRIPTION
through Starport's config.yml.

* added chain id configurability by `chain_id` prop in the top level of `config.yml`.
* added `config/app.toml` and `config/config.toml` configurability for appd under new `init.app` and `init.config` sections of `config.yml`.
* made some refactoring.

closes #337.



- [x] Updated changelog.