### PR TITLE
feat(cmd/app): point to Stargate as default sdk version

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 ### Features:
 * Upgraded Stargate's version to v0.40.0-rc3.
 * Added a gRPC-Web proxy which is available under http://localhost:12345/grpc.
-* Point to Starport as default SDK version for scaffolding.
+* Point to Stargate as default SDK version for scaffolding.
 
 ## `v0.12.0`
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 ### Features:
 * Upgraded Stargate's version to v0.40.0-rc3.
 * Added a gRPC-Web proxy which is available under http://localhost:12345/grpc.
+* Point to Starport as default SDK version for scaffolding.
 
 ## `v0.12.0`
 

--- a/starport/interface/cli/starport/cmd/app.go
+++ b/starport/interface/cli/starport/cmd/app.go
@@ -53,7 +53,7 @@ NOTE: add --verbose flag for verbose (detailed) output.
 }
 
 func addSdkVersionFlag(c *cobra.Command) {
-	c.Flags().String(sdkVersionFlag, string(cosmosver.Launchpad), fmt.Sprintf("Target Cosmos-SDK Version %s", cosmosver.MajorVersions))
+	c.Flags().String(sdkVersionFlag, string(cosmosver.Stargate), fmt.Sprintf("Target Cosmos-SDK Version %s", cosmosver.MajorVersions))
 }
 
 func sdkVersion(c *cobra.Command) (cosmosver.MajorVersion, error) {


### PR DESCRIPTION
resolves #409.



- [x] Updated changelog.