### PR TITLE
docs: gopath for build from source

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * Added `config/app.toml` and `config/config.toml` configurability for appd under new `init.app` and `init.config` sections of `config.yml`.
 * Point to Stargate as default SDK version for scaffolding.
 * Covered CRUD operations for Stargate scaffolding.
+* Added docs on gopath to build from source directions
 
 ## `v0.12.0`
 

--- a/docs/1 Introduction/2 Install.md
+++ b/docs/1 Introduction/2 Install.md
@@ -6,7 +6,7 @@
 
 ### NPM
 
-```
+```bash
 npm i -g @tendermint/starport
 ```
 
@@ -18,7 +18,7 @@ brew install tendermint/tap/starport
 
 <!-- ### Debian/Ubuntu with Snapcraft
 
-```
+```bash
 snap install --classic node
 ```
 
@@ -28,8 +28,19 @@ Append your current working directory to the environment variable `PATH`:
 export PATH=$PATH:$PWD/node_modules/.bin/
 ``` -->
 
-### Build from source
+### Build from source on Mac, Linux, and WSL
 
-```
+```bash
 git clone https://github.com/tendermint/starport && cd starport && make
 ```
+You'll find a freshly-baked `starport` binary in the build folder.
+
+
+Note: When building from source, it is important to have your GOPATH set correctly.  When in doubt, the folllowing should do:
+
+```bash
+mkdir ~/go
+export GOPATH=~/go
+```
+
+


### PR DESCRIPTION
When building from source we need a gopath, and this has thrown off some friends of mine.  I've added GOPATH to the build from source directions including a simple example.


- [x] Updated changelog.