### PR TITLE
fix(template): non-deterministic id for scaffolded types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## Fixes:
 * Routing REST API endpoints of querier on Stargate.
 * Evaluate `--address-prefix` option when scaffolding for Stargate.
+* Use a deterministic method to generate scaffolded type ids
 
 ### Features:
 * Upgraded Stargate's version to v0.40.0-rc3.

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,8 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/sys v0.0.0-20201126233918-771906719818 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.32.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,12 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201126233918-771906719818 h1:f1CIuDlJhwANEC2MM87MBEVMr3jl5bifgsfj90XAF9c=
+golang.org/x/sys v0.0.0-20201126233918-771906719818/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/starport/templates/typed/launchpad/x/{{moduleName}}/handlerMsgCreate{{TypeName}}.go.plush
+++ b/starport/templates/typed/launchpad/x/{{moduleName}}/handlerMsgCreate{{TypeName}}.go.plush
@@ -8,12 +8,7 @@ import (
 )
 
 func handleMsgCreate<%= title(TypeName) %>(ctx sdk.Context, k keeper.Keeper, msg types.MsgCreate<%= title(TypeName) %>) (*sdk.Result, error) {
-	var <%= TypeName %> = types.<%= title(TypeName) %>{
-		Creator: msg.Creator,
-		ID:      msg.ID,<%= for (field) in Fields { %>
-    	<%= title(field.Name) %>: msg.<%= title(field.Name) %>,<% } %>
-	}
-	k.Create<%= title(TypeName) %>(ctx, <%= TypeName %>)
+	k.Create<%= title(TypeName) %>(ctx, msg)
 
 	return &sdk.Result{Events: ctx.EventManager().Events()}, nil
 }

--- a/starport/templates/typed/launchpad/x/{{moduleName}}/keeper/{{typeName}}.go.plush
+++ b/starport/templates/typed/launchpad/x/{{moduleName}}/keeper/{{typeName}}.go.plush
@@ -3,17 +3,60 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"strconv"
 
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
     "github.com/cosmos/cosmos-sdk/codec"
 )
 
+// Get<%= title(TypeName) %>Count get the total number of <%= TypeName %>
+func (k Keeper) Get<%= title(TypeName) %>Count(ctx sdk.Context) int64 {
+	store := ctx.KVStore(k.storeKey)
+	byteKey := []byte(types.<%= title(TypeName) %>CountPrefix)
+	bz := store.Get(byteKey)
+
+	// Count doesn't exist: no element
+	if bz == nil {
+		return 0
+	}
+
+	// Parse bytes
+	count, err := strconv.ParseInt(string(bz), 10, 64)
+	if err != nil {
+		// Panic because the count should be always formattable to int64
+		panic("cannot decode count")
+	}
+
+	return count
+}
+
+// Set<%= title(TypeName) %>Count set the total number of <%= TypeName %>
+func (k Keeper) Set<%= title(TypeName) %>Count(ctx sdk.Context, count int64)  {
+	store := ctx.KVStore(k.storeKey)
+	byteKey := []byte(types.<%= title(TypeName) %>CountPrefix)
+	bz := []byte(strconv.FormatInt(count, 10))
+	store.Set(byteKey, bz)
+}
+
 // Create<%= title(TypeName) %> creates a <%= TypeName %>
-func (k Keeper) Create<%= title(TypeName) %>(ctx sdk.Context, <%= TypeName %> types.<%= title(TypeName) %>) {
+func (k Keeper) Create<%= title(TypeName) %>(ctx sdk.Context, msg types.MsgCreate<%= title(TypeName) %>) {
+	// Create the <%= TypeName %>
+	count := k.Get<%= title(TypeName) %>Count(ctx)
+    var <%= TypeName %> = types.<%= title(TypeName) %>{
+        Creator: msg.Creator,
+        ID:      strconv.FormatInt(count, 10),<%= for (field) in Fields { %>
+        <%= title(field.Name) %>: msg.<%= title(field.Name) %>,<% } %>
+    }
+
+
+
 	store := ctx.KVStore(k.storeKey)
 	key := []byte(types.<%= title(TypeName) %>Prefix + <%= TypeName %>.ID)
 	value := k.cdc.MustMarshalBinaryLengthPrefixed(<%= TypeName %>)
 	store.Set(key, value)
+
+	// Update user count
+    k.Set<%= title(TypeName) %>Count(ctx, count+1)
 }
 
 // Get<%= title(TypeName) %> returns the <%= TypeName %> information

--- a/starport/templates/typed/launchpad/x/{{moduleName}}/keeper/{{typeName}}.go.plush
+++ b/starport/templates/typed/launchpad/x/{{moduleName}}/keeper/{{typeName}}.go.plush
@@ -48,14 +48,12 @@ func (k Keeper) Create<%= title(TypeName) %>(ctx sdk.Context, msg types.MsgCreat
         <%= title(field.Name) %>: msg.<%= title(field.Name) %>,<% } %>
     }
 
-
-
 	store := ctx.KVStore(k.storeKey)
 	key := []byte(types.<%= title(TypeName) %>Prefix + <%= TypeName %>.ID)
 	value := k.cdc.MustMarshalBinaryLengthPrefixed(<%= TypeName %>)
 	store.Set(key, value)
 
-	// Update user count
+	// Update <%= TypeName %> count
     k.Set<%= title(TypeName) %>Count(ctx, count+1)
 }
 

--- a/starport/templates/typed/launchpad/x/{{moduleName}}/types/MsgCreate{{TypeName}}.go.plush
+++ b/starport/templates/typed/launchpad/x/{{moduleName}}/types/MsgCreate{{TypeName}}.go.plush
@@ -3,20 +3,17 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/google/uuid"
 )
 
 var _ sdk.Msg = &MsgCreate<%= title(TypeName) %>{}
 
 type MsgCreate<%= title(TypeName) %> struct {
-  ID      string
   Creator sdk.AccAddress `json:"creator" yaml:"creator"`<%= for (field) in Fields { %>
   <%= title(field.Name) %> <%= field.Datatype %> `json:"<%= field.Name %>" yaml:"<%= field.Name %>"`<% } %>
 }
 
 func NewMsgCreate<%= title(TypeName) %>(creator sdk.AccAddress<%= for (field) in Fields { %>, <%= field.Name %> <%= field.Datatype %><% } %>) MsgCreate<%= title(TypeName) %> {
   return MsgCreate<%= title(TypeName) %>{
-    ID: uuid.New().String(),
 		Creator: creator,<%= for (field) in Fields { %>
     <%= title(field.Name) %>: <%= field.Name %>,<% } %>
 	}

--- a/starport/templates/typed/new_launchpad.go
+++ b/starport/templates/typed/new_launchpad.go
@@ -57,7 +57,8 @@ func (t *typedLaunchpad) typesKeyModify(opts *Options) genny.RunFn {
 		}
 		content := f.String() + fmt.Sprintf(`
 const (
-	%[2]vPrefix = "%[1]v-"
+	%[2]vPrefix = "%[1]v-value-"
+	%[2]vCountPrefix = "%[1]v-count-"
 )
 		`, opts.TypeName, strings.Title(opts.TypeName))
 		newFile := genny.NewFileS(path, content)

--- a/starport/templates/typed/new_stargate.go
+++ b/starport/templates/typed/new_stargate.go
@@ -165,9 +165,10 @@ func (t *typedStargate) typesKeyModify(opts *Options) genny.RunFn {
 		}
 		content := f.String() + fmt.Sprintf(`
 const (
-	%sKey= "%s"
+	%[1]vKey= "%[1]v-value-"
+	%[1]vCountKey= "%[1]v-count-"
 )
-`, strings.Title(opts.TypeName), strings.Title(opts.TypeName))
+`, strings.Title(opts.TypeName))
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
 	}

--- a/starport/templates/typed/stargate/x/{{moduleName}}/handler_{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate/x/{{moduleName}}/handler_{{typeName}}.go.plush
@@ -5,17 +5,10 @@ import (
     sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 	"<%= ModulePath %>/x/<%= ModuleName %>/keeper"
-	"github.com/google/uuid"
 )
 
 func handleMsgCreate<%= title(TypeName) %>(ctx sdk.Context, k keeper.Keeper, msg *types.MsgCreate<%= title(TypeName) %>) (*sdk.Result, error) {
-	var <%= TypeName %> = types.<%= title(TypeName) %>{
-		Creator: msg.Creator,
-        Id: uuid.New().String(),<%= for (field) in Fields { %>
-    	<%= title(field.Name) %>: msg.<%= title(field.Name) %>,<% } %>
-	}
-    
-	k.Create<%= title(TypeName) %>(ctx, <%= TypeName %>)
+	k.Create<%= title(TypeName) %>(ctx, *msg)
 
 	return &sdk.Result{Events: ctx.EventManager().ABCIEvents()}, nil
 }

--- a/starport/templates/typed/stargate/x/{{moduleName}}/keeper/{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate/x/{{moduleName}}/keeper/{{typeName}}.go.plush
@@ -4,12 +4,54 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 	"github.com/cosmos/cosmos-sdk/store/prefix"
+	"strconv"
 )
 
-func (k Keeper) Create<%= title(TypeName) %>(ctx sdk.Context, <%= TypeName %> types.<%= title(TypeName) %>) {
-	store :=  prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= title(TypeName) %>Key))
-	b := k.cdc.MustMarshalBinaryBare(&<%= TypeName %>)
-	store.Set(types.KeyPrefix(types.<%= title(TypeName) %>Key + <%= TypeName %>.Id), b)
+// Get<%= title(TypeName) %>Count get the total number of <%= TypeName %>
+func (k Keeper) Get<%= title(TypeName) %>Count(ctx sdk.Context) int64 {
+	store :=  prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= title(TypeName) %>CountKey))
+	byteKey := types.KeyPrefix(types.<%= title(TypeName) %>CountKey)
+	bz := store.Get(byteKey)
+
+	// Count doesn't exist: no element
+	if bz == nil {
+		return 0
+	}
+
+	// Parse bytes
+	count, err := strconv.ParseInt(string(bz), 10, 64)
+	if err != nil {
+		// Panic because the count should be always formattable to int64
+		panic("cannot decode count")
+	}
+
+	return count
+}
+
+// Set<%= title(TypeName) %>Count set the total number of <%= TypeName %>
+func (k Keeper) Set<%= title(TypeName) %>Count(ctx sdk.Context, count int64)  {
+	store :=  prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= title(TypeName) %>CountKey))
+	byteKey := types.KeyPrefix(types.<%= title(TypeName) %>CountKey)
+	bz := []byte(strconv.FormatInt(count, 10))
+	store.Set(byteKey, bz)
+}
+
+func (k Keeper) Create<%= title(TypeName) %>(ctx sdk.Context, msg types.MsgCreate<%= title(TypeName) %>) {
+	// Create the <%= TypeName %>
+    count := k.Get<%= title(TypeName) %>Count(ctx)
+    var <%= TypeName %> = types.<%= title(TypeName) %>{
+        Creator: msg.Creator,
+        Id:      strconv.FormatInt(count, 10),<%= for (field) in Fields { %>
+        <%= title(field.Name) %>: msg.<%= title(field.Name) %>,<% } %>
+    }
+
+    store :=  prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= title(TypeName) %>Key))
+    key := types.KeyPrefix(types.<%= title(TypeName) %>Key + <%= TypeName %>.Id)
+    value := k.cdc.MustMarshalBinaryBare(&<%= TypeName %>)
+    store.Set(key, value)
+
+    // Update <%= TypeName %> count
+    k.Set<%= title(TypeName) %>Count(ctx, count+1)
 }
 
 func (k Keeper) Update<%= title(TypeName) %>(ctx sdk.Context, <%= TypeName %> types.<%= title(TypeName) %>) {


### PR DESCRIPTION
For both Stargate and Launchpad, use a deterministic way to generate the ID of types on-chain (auto-incremented number)

- [x] Updated changelog.