### PR TITLE
feat(cmd/network): add support for batch reviewals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201130072748-111129e158e2 // indirect
+	golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201130072748-111129e158e2 h1:zXpk15uCEAaaJcTxBqQacweHUQ0HDhDOzupNGFs4imE=
-golang.org/x/sys v0.0.0-20201130072748-111129e158e2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 h1:dMDtAap8F/+vsyXblqK90iTzYJjNix5MsXDicSYol6w=
+golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/starport/interface/cli/starport/cmd/network_proposal_approve.go
+++ b/starport/interface/cli/starport/cmd/network_proposal_approve.go
@@ -10,7 +10,7 @@ import (
 
 func NewNetworkProposalApprove() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "approve [chain-id] [number<, ...>]",
+		Use:   "approve [chain-id] [number<,...>]",
 		Short: "Approve proposals",
 		RunE:  networkProposalApproveHandler,
 		Args:  cobra.ExactArgs(2),

--- a/starport/interface/cli/starport/cmd/network_proposal_approve.go
+++ b/starport/interface/cli/starport/cmd/network_proposal_approve.go
@@ -2,16 +2,16 @@ package starportcmd
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/numbers"
 	"github.com/tendermint/starport/starport/pkg/spn"
 )
 
 func NewNetworkProposalApprove() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "approve [chain-id] [number]",
-		Short: "Approve a proposal",
+		Use:   "approve [chain-id] [number<, ...>]",
+		Short: "Approve proposals",
 		RunE:  networkProposalApproveHandler,
 		Args:  cobra.ExactArgs(2),
 	}
@@ -19,20 +19,30 @@ func NewNetworkProposalApprove() *cobra.Command {
 }
 
 func networkProposalApproveHandler(cmd *cobra.Command, args []string) error {
+	var (
+		chainID      = args[0]
+		proposalList = args[1]
+	)
+
 	nb, err := newNetworkBuilder()
 	if err != nil {
 		return err
 	}
 
-	id, err := strconv.ParseInt(args[1], 10, 32)
+	var reviewals []spn.Reviewal
+
+	ids, err := numbers.ParseList(proposalList)
 	if err != nil {
 		return err
 	}
+	for _, id := range ids {
+		reviewals = append(reviewals, spn.ApproveProposal(id))
+	}
 
-	if err := nb.SubmitReviewals(cmd.Context(), args[0], spn.ApproveProposal(int(id))); err != nil {
+	if err := nb.SubmitReviewals(cmd.Context(), chainID, reviewals...); err != nil {
 		return err
 	}
 
-	fmt.Printf("Proposal #%d approved ✅\n", id)
+	fmt.Printf("Proposal(s) %s approved ✅\n", numbers.List(ids, "#"))
 	return nil
 }

--- a/starport/interface/cli/starport/cmd/network_proposal_reject.go
+++ b/starport/interface/cli/starport/cmd/network_proposal_reject.go
@@ -2,16 +2,16 @@ package starportcmd
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/numbers"
 	"github.com/tendermint/starport/starport/pkg/spn"
 )
 
 func NewNetworkProposalReject() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "reject [chain-id] [number]",
-		Short: "Reject a proposal",
+		Use:   "reject [chain-id] [number<, ...>]",
+		Short: "Reject proposals",
 		RunE:  networkProposalRejectHandler,
 		Args:  cobra.ExactArgs(2),
 	}
@@ -19,20 +19,30 @@ func NewNetworkProposalReject() *cobra.Command {
 }
 
 func networkProposalRejectHandler(cmd *cobra.Command, args []string) error {
+	var (
+		chainID      = args[0]
+		proposalList = args[1]
+	)
+
 	nb, err := newNetworkBuilder()
 	if err != nil {
 		return err
 	}
 
-	id, err := strconv.ParseInt(args[1], 10, 32)
+	var reviewals []spn.Reviewal
+
+	ids, err := numbers.ParseList(proposalList)
 	if err != nil {
 		return err
 	}
+	for _, id := range ids {
+		reviewals = append(reviewals, spn.RejectProposal(id))
+	}
 
-	if err := nb.SubmitReviewals(cmd.Context(), args[0], spn.RejectProposal(int(id))); err != nil {
+	if err := nb.SubmitReviewals(cmd.Context(), chainID, reviewals...); err != nil {
 		return err
 	}
 
-	fmt.Printf("Proposal #%d rejected ⛔️\n", id)
+	fmt.Printf("Proposal(s) %s rejected ⛔️\n", numbers.List(ids, "#"))
 	return nil
 }

--- a/starport/interface/cli/starport/cmd/network_proposal_reject.go
+++ b/starport/interface/cli/starport/cmd/network_proposal_reject.go
@@ -10,7 +10,7 @@ import (
 
 func NewNetworkProposalReject() *cobra.Command {
 	c := &cobra.Command{
-		Use:   "reject [chain-id] [number<, ...>]",
+		Use:   "reject [chain-id] [number<,...>]",
 		Short: "Reject proposals",
 		RunE:  networkProposalRejectHandler,
 		Args:  cobra.ExactArgs(2),

--- a/starport/pkg/numbers/numbers.go
+++ b/starport/pkg/numbers/numbers.go
@@ -1,0 +1,33 @@
+package numbers
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseList parses comma separeted numbers to ints.
+func ParseList(list string) ([]int, error) {
+	ints := []int{}
+	for _, number := range strings.Split(list, ",") {
+		trimmed := strings.TrimSpace(number)
+		if trimmed == "" {
+			continue
+		}
+		i, err := strconv.ParseInt(trimmed, 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		ints = append(ints, int(i))
+	}
+	return ints, nil
+}
+
+// List creates a comma separeted int list with optional prefix for each int.
+func List(numbers []int, prefix string) string {
+	var s []string
+	for _, n := range numbers {
+		s = append(s, fmt.Sprintf("%s%d", prefix, n))
+	}
+	return strings.Join(s, ", ")
+}

--- a/starport/pkg/numbers/numbers_test.go
+++ b/starport/pkg/numbers/numbers_test.go
@@ -1,0 +1,43 @@
+package numbers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseList(t *testing.T) {
+	cases := []struct {
+		list   string
+		parsed []int
+	}{
+		{"1,2,3", []int{1, 2, 3}},
+		{"1, 2,3 ", []int{1, 2, 3}},
+		{",1, 2,", []int{1, 2}},
+		{",", []int{}},
+	}
+	for i, tt := range cases {
+		t.Run(fmt.Sprintf("no: %d", i), func(t *testing.T) {
+			parsed, err := ParseList(tt.list)
+			require.NoError(t, err)
+			require.Equal(t, tt.parsed, parsed)
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	cases := []struct {
+		parsed []int
+		list   string
+	}{
+		{[]int{1, 2, 3}, "#1, #2, #3"},
+		{[]int{1}, "#1"},
+		{[]int{}, ""},
+	}
+	for i, tt := range cases {
+		t.Run(fmt.Sprintf("no: %d", i), func(t *testing.T) {
+			require.Equal(t, tt.list, List(tt.parsed, "#"))
+		})
+	}
+}


### PR DESCRIPTION
network proposal approve/reject now can accept comma separeted proposal
ids.

resolves #453.



- [ ] Updated changelog.