### PR TITLE
refactor(network): to match with the latest workflow +fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612
+	github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756
 	github.com/tendermint/tendermint v0.34.0-rc6
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/mod v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -733,8 +733,8 @@ github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 h1:hqAk8riJvK4RM
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM70uOnk8h0pjJYlj3zdYwi9l03By6iAIF5j/Pk=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
-github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612 h1:gV5X2/pJRs9vo8bcAyoAN98qqeo65itPCSzrSLTNN4Q=
-github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
+github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756 h1:Ukjw+1mmXvFDEkKxRUqXPWsMfBXhXJVvLxDASOplMyk=
+github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/starport v0.12.0/go.mod h1:iKwUbPpZeAe79FYGZDC85zV5sMLeVGH4zlWb4EiaoBU=
 github.com/tendermint/tendermint v0.34.0-rc4/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
 github.com/tendermint/tendermint v0.34.0-rc6 h1:SVuKGvvE22KxfuK8QUHctUrmOWJsncZSYXIYtcnoKN0=

--- a/starport/interface/cli/starport/cmd/build.go
+++ b/starport/interface/cli/starport/cmd/build.go
@@ -29,7 +29,7 @@ func buildHandler(cmd *cobra.Command, args []string) error {
 		ImportPath: path.RawPath,
 	}
 
-	s, err := chain.New(app, logLevel(cmd))
+	s, err := chain.New(app, false, logLevel(cmd))
 	if err != nil {
 		return err
 	}

--- a/starport/interface/cli/starport/cmd/network_chain_create.go
+++ b/starport/interface/cli/starport/cmd/network_chain_create.go
@@ -97,7 +97,7 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	// create blockchain.
-	if err := blockchain.Create(cmd.Context(), info.Genesis); err != nil {
+	if err := blockchain.Create(cmd.Context()); err != nil {
 		return err
 	}
 

--- a/starport/interface/cli/starport/cmd/network_chain_join.go
+++ b/starport/interface/cli/starport/cmd/network_chain_join.go
@@ -96,7 +96,7 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 	if err := cliquiz.Ask(questions...); err != nil {
 		return err
 	}
-	gentx, address, mnemonic, err := blockchain.IssueGentx(cmd.Context(), account, proposal)
+	gentx, a, err := blockchain.IssueGentx(cmd.Context(), account, proposal)
 	if err != nil {
 		return err
 	}
@@ -129,12 +129,12 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := blockchain.Join(cmd.Context(), address, publicAddress, coins, gentx, selfDelegation); err != nil {
+	if err := blockchain.Join(cmd.Context(), a.Address, publicAddress, coins, gentx, selfDelegation); err != nil {
 		return err
 	}
 
-	if mnemonic != "" {
-		fmt.Printf("\n*** IMPORTANT - Save your mnemonic in a secret place:\n%s\n", mnemonic)
+	if a.Mnemonic != "" {
+		fmt.Printf("\n*** IMPORTANT - Save your mnemonic in a secret place:\n%s\n", a.Mnemonic)
 	}
 
 	fmt.Println("\n📜 Proposed validator to join to network")

--- a/starport/interface/cli/starport/cmd/relayer.go
+++ b/starport/interface/cli/starport/cmd/relayer.go
@@ -47,7 +47,7 @@ func relayerInfoHandler(cmd *cobra.Command, args []string) error {
 		Path: appPath,
 	}
 
-	s, err := chain.New(app, logLevel(cmd))
+	s, err := chain.New(app, false, logLevel(cmd))
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func relayerAddHandler(cmd *cobra.Command, args []string) error {
 		Path: appPath,
 	}
 
-	s, err := chain.New(app, logLevel(cmd))
+	s, err := chain.New(app, false, logLevel(cmd))
 	if err != nil {
 		return err
 	}

--- a/starport/interface/cli/starport/cmd/serve.go
+++ b/starport/interface/cli/starport/cmd/serve.go
@@ -31,7 +31,7 @@ func serveHandler(cmd *cobra.Command, args []string) error {
 		ImportPath: path.RawPath,
 	}
 
-	s, err := chain.New(app, logLevel(cmd))
+	s, err := chain.New(app, false, logLevel(cmd))
 	if err != nil {
 		return err
 	}

--- a/starport/pkg/spn/spn.go
+++ b/starport/pkg/spn/spn.go
@@ -161,7 +161,7 @@ func (c *Client) AccountImport(accountName, privateKey, password string) error {
 }
 
 // ChainCreate creates a new chain.
-func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, genesis []byte, sourceURL, sourceHash string) error {
+func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, sourceURL, sourceHash string) error {
 	clientCtx, err := c.buildClientCtx(accountName)
 	if err != nil {
 		return err
@@ -171,7 +171,6 @@ func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, g
 		clientCtx.GetFromAddress(),
 		sourceURL,
 		sourceHash,
-		genesis,
 	))
 }
 
@@ -306,7 +305,6 @@ type GenesisAccount struct {
 type Chain struct {
 	URL             string
 	Hash            string
-	Genesis         jsondoc.Doc
 	Peers           []string
 	GenesisAccounts []GenesisAccount
 	GenTxs          [][]byte
@@ -352,7 +350,6 @@ func (c *Client) ChainGet(ctx context.Context, accountName, chainID string) (Cha
 	return Chain{
 		URL:             res.Chain.SourceURL,
 		Hash:            res.Chain.SourceHash,
-		Genesis:         launchInformationRes.InitialGenesis,
 		Peers:           launchInformationRes.Peers,
 		GenesisAccounts: genesisAccounts,
 		GenTxs:          launchInformationRes.GenTxs,

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -54,7 +54,9 @@ type Chain struct {
 	stdout, stderr io.Writer
 }
 
-func New(app App, logLevel LogLevel) (*Chain, error) {
+// TODO document noCheck (basically it stands to enable Chain initialization without
+// need of source code)
+func New(app App, noCheck bool, logLevel LogLevel) (*Chain, error) {
 	s := &Chain{
 		app:            app,
 		logLevel:       logLevel,
@@ -70,18 +72,20 @@ func New(app App, logLevel LogLevel) (*Chain, error) {
 
 	var err error
 
-	if _, err := s.Config(); err != nil {
-		return nil, errors.New("could not locate a config.yml in your chain. please follow the link for how-to: https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/4%20Configuration.md")
-	}
+	if !noCheck {
+		if _, err := s.Config(); err != nil {
+			return nil, errors.New("could not locate a config.yml in your chain. please follow the link for how-to: https://github.com/tendermint/starport/blob/develop/docs/1%20Introduction/4%20Configuration.md")
+		}
 
-	s.version, err = s.appVersion()
-	if err != nil && err != git.ErrRepositoryNotExists {
-		return nil, err
-	}
+		s.version, err = s.appVersion()
+		if err != nil && err != git.ErrRepositoryNotExists {
+			return nil, err
+		}
 
-	s.plugin, err = s.pickPlugin()
-	if err != nil {
-		return nil, err
+		s.plugin, err = s.pickPlugin()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return s, nil

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -164,12 +164,20 @@ func (s *Chain) serve(ctx context.Context) error {
 	}
 
 	for _, account := range conf.Accounts {
-		if _, _, err := s.CreateAccount(ctx, account.Name, "", account.Coins, false); err != nil {
+		acc, err := s.CreateAccount(ctx, account.Name, "", account.Coins, false)
+		if err != nil {
+			return err
+		}
+		if err := s.AddGenesisAccount(ctx, acc); err != nil {
 			return err
 		}
 	}
 	for _, account := range sconf.Accounts {
-		if _, _, err := s.CreateAccount(ctx, account.Name, account.Mnemonic, account.Coins, false); err != nil {
+		acc, err := s.CreateAccount(ctx, account.Name, account.Mnemonic, account.Coins, false)
+		if err != nil {
+			return err
+		}
+		if err := s.AddGenesisAccount(ctx, acc); err != nil {
 			return err
 		}
 	}

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -49,7 +49,7 @@ func (b *Blockchain) init(ctx context.Context, mustNotInitializedBefore bool) er
 		Path: b.appPath,
 	}
 
-	c, err := chain.New(app, false, chain.LogVerbose)
+	c, err := chain.New(app, false, chain.LogSilent)
 	if err != nil {
 		return err
 	}

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -49,7 +49,7 @@ func (b *Blockchain) init(ctx context.Context, mustNotInitializedBefore bool) er
 		Path: b.appPath,
 	}
 
-	c, err := chain.New(app, chain.LogSilent)
+	c, err := chain.New(app, false, chain.LogVerbose)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (b *Blockchain) Info() (BlockchainInfo, error) {
 }
 
 // Create submits Genesis to SPN to announce a new network.
-func (b *Blockchain) Create(ctx context.Context, genesis jsondoc.Doc) error {
+func (b *Blockchain) Create(ctx context.Context) error {
 	account, err := b.builder.AccountInUse()
 	if err != nil {
 		return err
@@ -132,7 +132,7 @@ func (b *Blockchain) Create(ctx context.Context, genesis jsondoc.Doc) error {
 	if err != nil {
 		return err
 	}
-	return b.builder.spnclient.ChainCreate(ctx, account.Name, chainID, genesis, b.url, b.hash)
+	return b.builder.spnclient.ChainCreate(ctx, account.Name, chainID, b.url, b.hash)
 }
 
 // Proposal holds proposal info of validator candidate to join to a network.
@@ -154,18 +154,21 @@ type Account struct {
 }
 
 // IssueGentx creates a Genesis transaction for account with proposal.
-func (b *Blockchain) IssueGentx(ctx context.Context, account Account, proposal Proposal) (gentx jsondoc.Doc, address, mnemonic string, err error) {
+func (b *Blockchain) IssueGentx(ctx context.Context, account Account, proposal Proposal) (gentx jsondoc.Doc, acc chain.Account, err error) {
 	proposal.Validator.Name = account.Name
-	address, mnemonic, err = b.chain.CreateAccount(ctx, account.Name, account.Mnemonic, strings.Split(account.Coins, ","), false)
+	acc, err = b.chain.CreateAccount(ctx, account.Name, account.Mnemonic, strings.Split(account.Coins, ","), false)
 	if err != nil {
-		return nil, "", "", err
+		return nil, chain.Account{}, err
+	}
+	if err := b.chain.AddGenesisAccount(ctx, acc); err != nil {
+		return nil, chain.Account{}, err
 	}
 	gentxPath, err := b.chain.Gentx(ctx, proposal.Validator)
 	if err != nil {
-		return nil, "", "", err
+		return nil, chain.Account{}, err
 	}
 	gentx, err = ioutil.ReadFile(gentxPath)
-	return gentx, address, mnemonic, err
+	return gentx, acc, err
 }
 
 // Join proposes a validator to a network.

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -154,7 +154,7 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 	app := chain.App{
 		Name: chainID,
 	}
-	chain, err := chain.New(app, chain.LogSilent)
+	c, err := chain.New(app, true, chain.LogVerbose)
 	if err != nil {
 		return err
 	}
@@ -168,19 +168,17 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 		return err
 	}
 
-	// update genesis.
 	homedir, err := os.UserHomeDir()
 	if err != nil {
-		return err
-	}
-	genesisPath := filepath.Join(homedir, app.ND(), "config/genesis.json")
-	if err := ioutil.WriteFile(genesisPath, launchInformation.Genesis, 0666); err != nil {
 		return err
 	}
 
 	// add the genesis accounts
 	for _, account := range launchInformation.GenesisAccounts {
-		if err = chain.AddGenesisAccount(ctx, account); err != nil {
+		if err = c.AddGenesisAccount(ctx, chain.Account{
+			Address: account.Address.String(),
+			Coins:   account.Coins.String(),
+		}); err != nil {
 			return err
 		}
 	}
@@ -204,7 +202,7 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 			return err
 		}
 	}
-	if err = chain.CollectGentx(ctx); err != nil {
+	if err = c.CollectGentx(ctx); err != nil {
 		return err
 	}
 

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -154,7 +154,7 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 	app := chain.App{
 		Name: chainID,
 	}
-	c, err := chain.New(app, true, chain.LogVerbose)
+	c, err := chain.New(app, true, chain.LogSilent)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
* updated to latest SPN.

* removed the required of a source code for `network chain start` by
  making `chain.New()` to not depend on a source code.

* fixed add-genesis-account for `network chain start` by not failing if
  it is already added(it is already added by `network chain join`).

* move away add genesis account logic from `chain.CreateAccount()`.

solves #457.

tested with single validator. 


- [ ] Updated changelog.