### PR TITLE
refactor(network): reset genesis on starport network chain start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612
+	github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80
 	github.com/tendermint/tendermint v0.34.0-rc6
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/mod v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201130072748-111129e158e2 // indirect
+	golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 // indirect
+	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/rs/cors v1.7.0
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
-	github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80
+	github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756
 	github.com/tendermint/tendermint v0.34.0-rc6
 	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 // indirect
 	golang.org/x/mod v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -733,10 +733,6 @@ github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 h1:hqAk8riJvK4RM
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM70uOnk8h0pjJYlj3zdYwi9l03By6iAIF5j/Pk=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
-github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612 h1:gV5X2/pJRs9vo8bcAyoAN98qqeo65itPCSzrSLTNN4Q=
-github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
-github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80 h1:NNX1O1o85T2+Xs3WLJKIkh3uRRKlawh9rEd21G3Xk3s=
-github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756 h1:Ukjw+1mmXvFDEkKxRUqXPWsMfBXhXJVvLxDASOplMyk=
 github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/starport v0.12.0/go.mod h1:iKwUbPpZeAe79FYGZDC85zV5sMLeVGH4zlWb4EiaoBU=
@@ -921,8 +917,8 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201130072748-111129e158e2 h1:zXpk15uCEAaaJcTxBqQacweHUQ0HDhDOzupNGFs4imE=
-golang.org/x/sys v0.0.0-20201130072748-111129e158e2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 h1:dMDtAap8F/+vsyXblqK90iTzYJjNix5MsXDicSYol6w=
+golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/go.sum
+++ b/go.sum
@@ -735,6 +735,8 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612 h1:gV5X2/pJRs9vo8bcAyoAN98qqeo65itPCSzrSLTNN4Q=
 github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
+github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80 h1:NNX1O1o85T2+Xs3WLJKIkh3uRRKlawh9rEd21G3Xk3s=
+github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/starport v0.12.0/go.mod h1:iKwUbPpZeAe79FYGZDC85zV5sMLeVGH4zlWb4EiaoBU=
 github.com/tendermint/tendermint v0.34.0-rc4/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
 github.com/tendermint/tendermint v0.34.0-rc6 h1:SVuKGvvE22KxfuK8QUHctUrmOWJsncZSYXIYtcnoKN0=

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,8 @@ github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612 h1:gV5X2/pJRs9vo8bc
 github.com/tendermint/spn v0.0.0-20201130065511-9ab122293612/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80 h1:NNX1O1o85T2+Xs3WLJKIkh3uRRKlawh9rEd21G3Xk3s=
 github.com/tendermint/spn v0.0.0-20201201072342-1e2063432c80/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
+github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756 h1:Ukjw+1mmXvFDEkKxRUqXPWsMfBXhXJVvLxDASOplMyk=
+github.com/tendermint/spn v0.0.0-20201201085940-4919f18f0756/go.mod h1:OfG8YK8yabQk08QLpneLSMf/FN0d+DmFcQfijTJalA8=
 github.com/tendermint/starport v0.12.0/go.mod h1:iKwUbPpZeAe79FYGZDC85zV5sMLeVGH4zlWb4EiaoBU=
 github.com/tendermint/tendermint v0.34.0-rc4/go.mod h1:yotsojf2C1QBOw4dZrTcxbyxmPUrT4hNuOQWX9XUwB4=
 github.com/tendermint/tendermint v0.34.0-rc6 h1:SVuKGvvE22KxfuK8QUHctUrmOWJsncZSYXIYtcnoKN0=

--- a/go.sum
+++ b/go.sum
@@ -917,8 +917,8 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5 h1:dMDtAap8F/+vsyXblqK90iTzYJjNix5MsXDicSYol6w=
-golang.org/x/sys v0.0.0-20201130171929-760e229fe7c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/starport/interface/cli/starport/cmd/network_chain_create.go
+++ b/starport/interface/cli/starport/cmd/network_chain_create.go
@@ -74,15 +74,6 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 
 	s.Stop()
 
-	prompt := promptui.Prompt{
-		Label:     "Do you confirm the Genesis above",
-		IsConfirm: true,
-	}
-	if _, err := prompt.Run(); err != nil {
-		fmt.Println("said no")
-		return nil
-	}
-
 	// create blockchain.
 	if err := blockchain.Create(cmd.Context()); err != nil {
 		return err

--- a/starport/interface/cli/starport/cmd/network_chain_create.go
+++ b/starport/interface/cli/starport/cmd/network_chain_create.go
@@ -72,20 +72,7 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 	}
 	defer blockchain.Cleanup()
 
-	info, err := blockchain.Info()
-	if err != nil {
-		return err
-	}
-
 	s.Stop()
-
-	// ask to confirm genesis.
-	prettyGenesis, err := info.Genesis.Pretty()
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("\nGenesis: \n\n%s\n\n", prettyGenesis)
 
 	prompt := promptui.Prompt{
 		Label:     "Do you confirm the Genesis above",
@@ -97,7 +84,7 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	// create blockchain.
-	if err := blockchain.Create(cmd.Context(), info.Genesis); err != nil {
+	if err := blockchain.Create(cmd.Context()); err != nil {
 		return err
 	}
 

--- a/starport/interface/cli/starport/cmd/network_proposal_list.go
+++ b/starport/interface/cli/starport/cmd/network_proposal_list.go
@@ -49,7 +49,7 @@ func networkProposalListHandler(cmd *cobra.Command, args []string) error {
 		case p.Account != nil:
 			content = fmt.Sprintf("Add Account   | %s, %s", p.Account.Address, p.Account.Coins.String())
 		case p.Validator != nil:
-			content = fmt.Sprintf("Add Validator | (run 'chain describe' to see gentx), %s", p.Validator.P2PAddress)
+			content = fmt.Sprintf("Add Validator | (run 'proposal show' to see gentx), %s", p.Validator.P2PAddress)
 		}
 		fmt.Fprintf(w, "%d\t%s\t%s\n", p.ID, strings.Title(string(p.Status)), content)
 	}

--- a/starport/pkg/spn/spn.go
+++ b/starport/pkg/spn/spn.go
@@ -161,7 +161,7 @@ func (c *Client) AccountImport(accountName, privateKey, password string) error {
 }
 
 // ChainCreate creates a new chain.
-func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, genesis []byte, sourceURL, sourceHash string) error {
+func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, sourceURL, sourceHash string) error {
 	clientCtx, err := c.buildClientCtx(accountName)
 	if err != nil {
 		return err
@@ -171,7 +171,6 @@ func (c *Client) ChainCreate(ctx context.Context, accountName, chainID string, g
 		clientCtx.GetFromAddress(),
 		sourceURL,
 		sourceHash,
-		genesis,
 	))
 }
 
@@ -304,7 +303,6 @@ type GenesisAccount struct {
 type Chain struct {
 	URL             string
 	Hash            string
-	Genesis         jsondoc.Doc
 	Peers           []string
 	GenesisAccounts []GenesisAccount
 	GenTxs          [][]byte
@@ -350,7 +348,6 @@ func (c *Client) ChainGet(ctx context.Context, accountName, chainID string) (Cha
 	return Chain{
 		URL:     res.Chain.SourceURL,
 		Hash:    res.Chain.SourceHash,
-		Genesis: launchInformationRes.InitialGenesis,
 		Peers:   launchInformationRes.Peers,
 		GenesisAccounts: genesisAccounts,
 		GenTxs: launchInformationRes.GenTxs,

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -174,3 +174,8 @@ func (c *Chain) AppTOMLPath() string {
 func (c *Chain) ConfigTOMLPath() string {
 	return fmt.Sprintf("%s/config/config.toml", c.Home())
 }
+
+// InitialGenesisPath returns initialGenesis.json path of the app.
+func (c *Chain) InitialGenesisPath() string {
+	return fmt.Sprintf("%s/config/initialGenesis.json", c.Home())
+}

--- a/starport/services/chain/command.go
+++ b/starport/services/chain/command.go
@@ -1,0 +1,92 @@
+package chain
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/tendermint/starport/starport/pkg/spn"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+	"io"
+	"regexp"
+	"strings"
+)
+
+type Validator struct {
+	Name                    string
+	Moniker                 string
+	StakingAmount           string
+	CommissionRate          string
+	CommissionMaxRate       string
+	CommissionMaxChangeRate string
+	MinSelfDelegation       string
+	GasPrices               string
+}
+
+var gentxRe = regexp.MustCompile(`(?m)"(.+?)"`)
+
+// Gentx generates a gentx for v.
+func (c *Chain) Gentx(ctx context.Context, v Validator) (gentxPath string, err error) {
+	chainID, err := c.ID()
+	if err != nil {
+		return "", err
+	}
+
+	gentxPathMessage := &bytes.Buffer{}
+	if err := cmdrunner.
+		New(c.cmdOptions()...).
+		Run(ctx, step.New(
+			c.plugin.GentxCommand(chainID, v),
+			step.Stderr(io.MultiWriter(gentxPathMessage, c.stdLog(logAppd).err)),
+			step.Stdout(io.MultiWriter(gentxPathMessage, c.stdLog(logAppd).out)),
+		)); err != nil {
+		return "", err
+	}
+	return gentxRe.FindStringSubmatch(gentxPathMessage.String())[1], nil
+}
+
+// AddGenesisAccount add a genesis account in the chain
+func (c *Chain) AddGenesisAccount(ctx context.Context, account spn.GenesisAccount) error {
+	return cmdrunner.
+		New(c.cmdOptions()...).
+		Run(ctx, step.New(step.NewOptions().
+			Add(step.Exec(
+				c.app.D(),
+				"add-genesis-account",
+				account.Address.String(),
+				account.Coins.String(),
+			)).
+			Add(c.stdSteps(logAppd)...)...,
+		))
+}
+
+// CollectGentx collects gentxs on chain.
+func (c *Chain) CollectGentx(ctx context.Context) error {
+	return cmdrunner.
+		New(c.cmdOptions()...).
+		Run(ctx, step.New(step.NewOptions().
+			Add(step.Exec(
+				c.app.D(),
+				"collect-gentxs",
+			)).
+			Add(c.stdSteps(logAppd)...)...,
+		))
+}
+
+// ShowNodeID shows node's id.
+func (c *Chain) ShowNodeID(ctx context.Context) (string, error) {
+	key := &bytes.Buffer{}
+	err := cmdrunner.
+		New(c.cmdOptions()...).
+		Run(ctx,
+			step.New(
+				step.Exec(
+					c.app.D(),
+					"tendermint",
+					"show-node-id",
+				),
+				step.Stdout(key),
+			),
+		)
+	return strings.TrimSpace(key.String()), err
+}

--- a/starport/services/chain/command.go
+++ b/starport/services/chain/command.go
@@ -3,13 +3,10 @@ package chain
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"io"
+	"io/ioutil"
 	"regexp"
 	"strings"
 )
@@ -105,36 +102,7 @@ func (c *Chain) ShowNodeID(ctx context.Context) (string, error) {
 }
 
 // GetInitialGenesis gets the initial genesis of the chain
-// Currently the only way to get the initial genesis of a chain through its CLI is by running the init command
-// Therefore, we run the init command in a temporary directory and then delete it
 func (c *Chain) GetInitialGenesis(ctx context.Context, chainID string) ([]byte, error) {
-	// Generate the temporary dir
-	tmpDir, err := ioutil.TempDir("/tmp", "prefix")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Init command
-	err = cmdrunner.
-		New(c.cmdOptions()...).
-		Run(ctx,
-			step.New(
-				step.Exec(
-					c.app.D(),
-					"init",
-					"moniker",
-					"--chain-id",
-					chainID,
-					"--home",
-					tmpDir,
-				),
-			),
-		)
-	if err != nil {
-		return nil, err
-	}
-
-	// Read and return the genesis file
-	return ioutil.ReadFile(filepath.Join(tmpDir, "config/genesis.json"))
+	// Read and return the genesis initial genesis file
+	return ioutil.ReadFile(c.InitialGenesisPath())
 }

--- a/starport/services/chain/command.go
+++ b/starport/services/chain/command.go
@@ -6,7 +6,6 @@ import (
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 )
@@ -99,10 +98,4 @@ func (c *Chain) ShowNodeID(ctx context.Context) (string, error) {
 			),
 		)
 	return strings.TrimSpace(key.String()), err
-}
-
-// GetInitialGenesis gets the initial genesis of the chain
-func (c *Chain) GetInitialGenesis(ctx context.Context, chainID string) ([]byte, error) {
-	// Read and return the genesis initial genesis file
-	return ioutil.ReadFile(c.InitialGenesisPath())
 }

--- a/starport/services/chain/command.go
+++ b/starport/services/chain/command.go
@@ -99,7 +99,7 @@ func (c *Chain) ShowNodeID(ctx context.Context) (string, error) {
 // Therefore, we run the init command in a temporary directory and then delete it
 func (c *Chain) GetInitialGenesis(ctx context.Context, chainID string) ([]byte, error) {
 	// Generate the temporary dir
-	tmpDir, err := ioutil.TempDir("appd", "prefix")
+	tmpDir, err := ioutil.TempDir("/tmp", "prefix")
 	if err != nil {
 		return nil, err
 	}

--- a/starport/services/chain/init.go
+++ b/starport/services/chain/init.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -80,6 +81,23 @@ func (c *Chain) Init(ctx context.Context) error {
 					if err := cf.Save(conf); err != nil {
 						return err
 					}
+				}
+
+				// Save a copy of the generated genesis
+				genesisData, err := ioutil.ReadFile(c.GenesisPath())
+				if err != nil {
+					return err
+				}
+				err = ioutil.WriteFile(c.InitialGenesisPath(), genesisData, 0644)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			}),
+			step.PostExec(func(err error) error {
+				if err != nil {
+					return err
 				}
 				return nil
 			}),

--- a/starport/services/chain/init.go
+++ b/starport/services/chain/init.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"regexp"
 	"strings"
 
 	"github.com/imdario/mergo"
@@ -15,7 +13,6 @@ import (
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/confile"
 	"github.com/tendermint/starport/starport/pkg/xos"
-	"github.com/tendermint/starport/starport/pkg/spn"
 	"github.com/tendermint/starport/starport/services/chain/conf"
 )
 
@@ -212,81 +209,3 @@ func (s *Chain) CreateAccount(ctx context.Context, name, mnemonic string, coins 
 	return address, user.Mnemonic, nil
 }
 
-type Validator struct {
-	Name                    string
-	Moniker                 string
-	StakingAmount           string
-	CommissionRate          string
-	CommissionMaxRate       string
-	CommissionMaxChangeRate string
-	MinSelfDelegation       string
-	GasPrices               string
-}
-
-var gentxRe = regexp.MustCompile(`(?m)"(.+?)"`)
-
-// Gentx generates a gentx for v.
-func (c *Chain) Gentx(ctx context.Context, v Validator) (gentxPath string, err error) {
-	chainID, err := c.ID()
-	if err != nil {
-		return "", err
-	}
-
-	gentxPathMessage := &bytes.Buffer{}
-	if err := cmdrunner.
-		New(c.cmdOptions()...).
-		Run(ctx, step.New(
-			c.plugin.GentxCommand(chainID, v),
-			step.Stderr(io.MultiWriter(gentxPathMessage, c.stdLog(logAppd).err)),
-			step.Stdout(io.MultiWriter(gentxPathMessage, c.stdLog(logAppd).out)),
-		)); err != nil {
-		return "", err
-	}
-	return gentxRe.FindStringSubmatch(gentxPathMessage.String())[1], nil
-}
-
-// AddGenesisAccount add a genesis account in the chain
-func (c *Chain) AddGenesisAccount(ctx context.Context, account spn.GenesisAccount) error {
-	return cmdrunner.
-		New(c.cmdOptions()...).
-		Run(ctx, step.New(step.NewOptions().
-			Add(step.Exec(
-				c.app.D(),
-				"add-genesis-account",
-				account.Address.String(),
-				account.Coins.String(),
-			)).
-			Add(c.stdSteps(logAppd)...)...,
-		))
-}
-
-// CollectGentx collects gentxs on chain.
-func (c *Chain) CollectGentx(ctx context.Context) error {
-	return cmdrunner.
-		New(c.cmdOptions()...).
-		Run(ctx, step.New(step.NewOptions().
-			Add(step.Exec(
-				c.app.D(),
-				"collect-gentxs",
-			)).
-			Add(c.stdSteps(logAppd)...)...,
-		))
-}
-
-// ShowNodeID shows node's id.
-func (c *Chain) ShowNodeID(ctx context.Context) (string, error) {
-	key := &bytes.Buffer{}
-	err := cmdrunner.
-		New(c.cmdOptions()...).
-		Run(ctx,
-			step.New(
-				step.Exec(
-					c.app.D(),
-					"tendermint",
-					"show-node-id",
-				),
-				step.Stdout(key),
-			),
-		)
-	return strings.TrimSpace(key.String()), err
-}

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -90,17 +90,12 @@ func (b *Blockchain) init(ctx context.Context, mustNotInitializedBefore bool) er
 type BlockchainInfo struct {
 	ID               string
 	Home             string
-	Genesis          jsondoc.Doc
 	Config           conf.Config
 	RPCPublicAddress string
 }
 
 // Info returns information about the blockchain.
 func (b *Blockchain) Info() (BlockchainInfo, error) {
-	genesis, err := ioutil.ReadFile(b.chain.GenesisPath())
-	if err != nil {
-		return BlockchainInfo{}, err
-	}
 	config, err := b.chain.Config()
 	if err != nil {
 		return BlockchainInfo{}, err
@@ -116,14 +111,13 @@ func (b *Blockchain) Info() (BlockchainInfo, error) {
 	return BlockchainInfo{
 		ID:               chainID,
 		Home:             b.chain.Home(),
-		Genesis:          genesis,
 		Config:           config,
 		RPCPublicAddress: paddr,
 	}, nil
 }
 
 // Create submits Genesis to SPN to announce a new network.
-func (b *Blockchain) Create(ctx context.Context, genesis jsondoc.Doc) error {
+func (b *Blockchain) Create(ctx context.Context) error {
 	account, err := b.builder.AccountInUse()
 	if err != nil {
 		return err
@@ -132,7 +126,7 @@ func (b *Blockchain) Create(ctx context.Context, genesis jsondoc.Doc) error {
 	if err != nil {
 		return err
 	}
-	return b.builder.spnclient.ChainCreate(ctx, account.Name, chainID, genesis, b.url, b.hash)
+	return b.builder.spnclient.ChainCreate(ctx, account.Name, chainID, b.url, b.hash)
 }
 
 // Proposal holds proposal info of validator candidate to join to a network.

--- a/starport/services/networkbuilder/chain.go
+++ b/starport/services/networkbuilder/chain.go
@@ -7,10 +7,10 @@ import (
 )
 
 // ChainShow shows details of a chain.
-func (b *Builder) ChainShow(ctx context.Context, chainID string) (spn.Chain, error) {
+func (b *Builder) ChainShow(ctx context.Context, chainID string) (spn.ChainInformation, error) {
 	account, err := b.AccountInUse()
 	if err != nil {
-		return spn.Chain{}, err
+		return spn.ChainInformation{}, err
 	}
-	return b.spnclient.GetChain(ctx, account.Name, chainID)
+	return b.spnclient.GetChainInformation(ctx, account.Name, chainID)
 }

--- a/starport/services/networkbuilder/chain.go
+++ b/starport/services/networkbuilder/chain.go
@@ -12,5 +12,5 @@ func (b *Builder) ChainShow(ctx context.Context, chainID string) (spn.Chain, err
 	if err != nil {
 		return spn.Chain{}, err
 	}
-	return b.spnclient.ChainGet(ctx, account.Name, chainID)
+	return b.spnclient.GetChain(ctx, account.Name, chainID)
 }

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -171,11 +171,13 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 		return err
 	}
 
-	initialGenesis, err := c.GetInitialGenesis(ctx, chainID)
+	initialGenesisPath := filepath.Join(homedir, app.ND(), "config/initialGenesis.json")
+	initialGenesis, err := ioutil.ReadFile(initialGenesisPath)
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(c.GenesisPath(), initialGenesis, 0666); err != nil {
+	genesisPath := filepath.Join(homedir, app.ND(), "config/genesis.json")
+	if err := ioutil.WriteFile(genesisPath, initialGenesis, 0666); err != nil {
 		return err
 	}
 

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -164,21 +164,27 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 		return err
 	}
 
-	// fet teh launch information
+
+	// reset the genesis in its initial form to ensure a deterministic generation
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	initialGenesis, err := chain.GetInitialGenesis(ctx, chainID)
+	if err != nil {
+		return err
+	}
+	genesisPath := filepath.Join(homedir, app.ND(), "config/genesis.json")
+	if err := ioutil.WriteFile(genesisPath, initialGenesis, 0666); err != nil {
+		return err
+	}
+
+	// fetch the launch information
 	launchInformation, err := b.spnclient.GetLaunchInformation(ctx, account.Name, chainID)
 	if err != nil {
 		return err
 	}
 
-	// update genesis.
-	homedir, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-	genesisPath := filepath.Join(homedir, app.ND(), "config/genesis.json")
-	if err := ioutil.WriteFile(genesisPath, launchInformation.Genesis, 0666); err != nil {
-		return err
-	}
 
 	// add the genesis accounts
 	for _, account := range launchInformation.GenesisAccounts {

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -171,12 +171,11 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 		return err
 	}
 
-	initialGenesis, err := chain.GetInitialGenesis(ctx, chainID)
+	initialGenesis, err := c.GetInitialGenesis(ctx, chainID)
 	if err != nil {
 		return err
 	}
-	genesisPath := filepath.Join(homedir, app.ND(), "config/genesis.json")
-	if err := ioutil.WriteFile(genesisPath, initialGenesis, 0666); err != nil {
+	if err := ioutil.WriteFile(c.GenesisPath(), initialGenesis, 0666); err != nil {
 		return err
 	}
 

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -52,11 +52,11 @@ func (b *Builder) InitBlockchainFromChainID(ctx context.Context, chainID string,
 	if err != nil {
 		return nil, err
 	}
-	chain, err := b.spnclient.ChainGet(ctx, account.Name, chainID)
+	chainInfo, err := b.spnclient.GetChainInformation(ctx, account.Name, chainID)
 	if err != nil {
 		return nil, err
 	}
-	return b.InitBlockchainFromURL(ctx, chain.URL, chain.Hash, mustNotInitializedBefore)
+	return b.InitBlockchainFromURL(ctx, chainInfo.URL, chainInfo.Hash, mustNotInitializedBefore)
 }
 
 // InitBlockchainFromURL initializes blockchain from a remote git repo.
@@ -163,7 +163,9 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 	if err != nil {
 		return err
 	}
-	launchInformation, err := b.spnclient.ChainGet(ctx, account.Name, chainID)
+
+	// fet teh launch information
+	launchInformation, err := b.spnclient.GetLaunchInformation(ctx, account.Name, chainID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Following the new refactoring on `spnd` we don't send and store in memory the genesis data.
- We also automatically reset the genesis on `starport network chain start` command to ensure the genesis is properly initialized with the launch information
- Some refactoring has been done to the chain package based on this change

- [ ] Updated changelog.