### PR TITLE
feat(network): optionally enable Chisel proxy

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,7 @@ tasks:
       # Install Starport
       export BIN_PATH=$GOPATH/bin
       export VUE_APP_CUSTOM_URL=$(gp url)
+      export CHISEL_ADDR=$(gp url 7575)
       mkdir -p $BIN_PATH
       (cd /workspace/starport && ./scripts/install)
       # Install Github CLI
@@ -34,3 +35,4 @@ ports:
   - port: 1317
   - port: 26657
   - port: 8080
+  - port: 7575 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,6 +18,7 @@ tasks:
 
     command: |
       export VUE_APP_CUSTOM_URL=$(gp url)
+      export CHISEL_ADDR=$(gp url 7575)
       export RPC_ADDRESS=$(gp url 26657):443
 
       clear && printf '\e[3J'

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.15.2
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0
+	github.com/jpillora/chisel v1.7.3
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mwitkow/grpc-proxy v0.0.0-20181017164139-0f1106ef9c76
 	github.com/pelletier/go-toml v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2 h1:axBiC50cNZOs7ygH5BgQp4N+aYrZ2DNpWZ1KG3VOSOM=
+github.com/andrew-d/go-termutil v0.0.0-20150726205930-009166a695a2/go.mod h1:jnzFpU88PccN/tPPhCpnNU8mZphvKxYM9lLNkd8e+os=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -420,8 +422,16 @@ github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/ansi v1.0.2 h1:+Ei5HCAH0xsrQRCT2PDr4mq9r4Gm4tg+arNdXRkB22s=
+github.com/jpillora/ansi v1.0.2/go.mod h1:D2tT+6uzJvN1nBVQILYWkIdq7zG+b5gcFN5WI/VyjMY=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
+github.com/jpillora/chisel v1.7.3 h1:6yaUb8/JaWhmkJSQBHsrVMawjgGNsxkkCUUrl07VIjE=
+github.com/jpillora/chisel v1.7.3/go.mod h1:BC2zg11mTIoyGPUjc2EkTgfz3uUUV93+K9tNYCCU/fw=
+github.com/jpillora/requestlog v1.0.0 h1:bg++eJ74T7DYL3DlIpiwknrtfdUA9oP/M4fL+PpqnyA=
+github.com/jpillora/requestlog v1.0.0/go.mod h1:HTWQb7QfDc2jtHnWe2XEIEeJB7gJPnVdpNn52HXPvy8=
+github.com/jpillora/sizestr v1.0.0 h1:4tr0FLxs1Mtq3TnsLDV+GYUWG7Q26a6s+tV5Zfw2ygw=
+github.com/jpillora/sizestr v1.0.0/go.mod h1:bUhLv4ctkknatr6gR42qPxirmd5+ds1u7mzD+MZ33f0=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -743,6 +753,8 @@ github.com/tendermint/tm-db v0.6.2 h1:DOn8jwCdjJblrCFJbtonEIPD1IuJWpbRUUdR8GWE4R
 github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs+yAcLvGI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
+github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -849,6 +861,7 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200930145003-4acb6c075d10/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -864,6 +877,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/starport/interface/cli/starport/cmd/network_chain_join.go
+++ b/starport/interface/cli/starport/cmd/network_chain_join.go
@@ -69,12 +69,6 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 
 	acc, _ := info.Config.AccountByName(info.Config.Validator.Name)
 
-	ip, err := ipify.GetIp()
-	if err != nil {
-		return err
-	}
-	publicAddr := fmt.Sprintf("%s:26656", ip)
-
 	questions := []cliquiz.Question{
 		cliquiz.NewQuestion("Account name", &account.Name, cliquiz.DefaultAnswer(acc.Name)),
 		cliquiz.NewQuestion("Account mnemonic", &account.Mnemonic, cliquiz.DefaultAnswer(acc.Mnemonic)),
@@ -92,6 +86,12 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if !xchisel.IsEnabled() {
+		ip, err := ipify.GetIp()
+		if err != nil {
+			return err
+		}
+		publicAddr := fmt.Sprintf("%s:26656", ip)
+
 		questions = append(questions, cliquiz.NewQuestion("Public address", &publicAddress, cliquiz.DefaultAnswer(publicAddr)))
 	}
 

--- a/starport/interface/cli/starport/cmd/network_chain_join.go
+++ b/starport/interface/cli/starport/cmd/network_chain_join.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/events"
+	"github.com/tendermint/starport/starport/pkg/xchisel"
 	"github.com/tendermint/starport/starport/services/networkbuilder"
 )
 
@@ -77,7 +78,6 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 	questions := []cliquiz.Question{
 		cliquiz.NewQuestion("Account name", &account.Name, cliquiz.DefaultAnswer(acc.Name)),
 		cliquiz.NewQuestion("Account mnemonic", &account.Mnemonic, cliquiz.DefaultAnswer(acc.Mnemonic)),
-		cliquiz.NewQuestion("Public address", &publicAddress, cliquiz.DefaultAnswer(publicAddr)),
 		cliquiz.NewQuestion("Account coins", &account.Coins, cliquiz.DefaultAnswer(strings.Join(acc.Coins, ","))),
 		cliquiz.NewQuestion("Staking amount", &proposal.Validator.StakingAmount, cliquiz.DefaultAnswer("95000000stake")),
 		cliquiz.NewQuestion("Moniker", &proposal.Validator.Moniker, cliquiz.DefaultAnswer("mynode")),
@@ -89,6 +89,10 @@ func networkChainJoinHandler(cmd *cobra.Command, args []string) error {
 		cliquiz.NewQuestion("Website", &proposal.Meta.Website),
 		cliquiz.NewQuestion("Identity", &proposal.Meta.Identity),
 		cliquiz.NewQuestion("Details", &proposal.Meta.Details),
+	}
+
+	if !xchisel.IsEnabled() {
+		questions = append(questions, cliquiz.NewQuestion("Public address", &publicAddress, cliquiz.DefaultAnswer(publicAddr)))
 	}
 
 	s.Stop()

--- a/starport/pkg/xchisel/xchisel.go
+++ b/starport/pkg/xchisel/xchisel.go
@@ -1,0 +1,54 @@
+package xchisel
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	chclient "github.com/jpillora/chisel/client"
+	chserver "github.com/jpillora/chisel/server"
+)
+
+var DefaultServerPort = "7575"
+
+func ServerAddr() string {
+	return os.Getenv("CHISEL_ADDR")
+}
+
+func IsEnabled() bool {
+	return ServerAddr() != ""
+}
+
+func StartServer(ctx context.Context, port string) error {
+	s, err := chserver.NewServer(&chserver.Config{})
+	if err != nil {
+		return err
+	}
+	if err := s.StartContext(ctx, "127.0.0.1", port); err != nil {
+		log.Fatal(err)
+	}
+	if err = s.Wait(); err == context.Canceled {
+		return nil
+	}
+	return err
+}
+
+func StartClient(ctx context.Context, serverAddr, localPort, remotePort string) error {
+	c, err := chclient.NewClient(&chclient.Config{
+		MaxRetryInterval: time.Second,
+		Server:           serverAddr,
+		Remotes:          []string{fmt.Sprintf("127.0.0.1:%s:127.0.0.1:%s", localPort, remotePort)},
+	})
+	if err != nil {
+		return err
+	}
+	if err := c.Start(ctx); err != nil {
+		log.Fatal(err)
+	}
+	if err = c.Wait(); err == context.Canceled {
+		return nil
+	}
+	return err
+}

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tendermint/starport/starport/pkg/gomodulepath"
 	"github.com/tendermint/starport/starport/pkg/jsondoc"
 	"github.com/tendermint/starport/starport/pkg/spn"
+	"github.com/tendermint/starport/starport/pkg/xchisel"
 	"github.com/tendermint/starport/starport/pkg/xos"
 	"github.com/tendermint/starport/starport/services/chain"
 	"github.com/tendermint/starport/starport/services/chain/conf"
@@ -179,6 +180,10 @@ func (b *Blockchain) Join(ctx context.Context, accountAddress, publicAddress str
 	key, err := b.chain.ShowNodeID(ctx)
 	if err != nil {
 		return err
+	}
+
+	if xchisel.IsEnabled() {
+		publicAddress = xchisel.ServerAddr()
 	}
 
 	p2pAddress := fmt.Sprintf("%s@%s", key, publicAddress)

--- a/starport/services/networkbuilder/config.go
+++ b/starport/services/networkbuilder/config.go
@@ -12,7 +12,7 @@ var (
 )
 
 func init() {
-	if err := os.MkdirAll(starportConfDir, 0666); err != nil {
+	if err := os.MkdirAll(starportConfDir, 0755); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
it is enabled automatically when CHISEL_ADDR env variable is set.

solves #455.

note:

I tested this on Gitpod with two validators and it worked as expected. Only thing, I had to copy one of the validator's Genesis to other one's before running `chain start`. Otherwise I receive some errors during start. This might be due to different timestamps (I remember seeing a related error) and/or disorder in the accounts array(need to overwrite with initial Genesis as discussed). cc/ @ltacker @fadeev 


- [ ] Updated changelog.