### PR TITLE
fix(chisel): allow same ip address for p2p conns

### DIFF
--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -258,6 +258,7 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 		return err
 	}
 	configToml.Set("p2p.persistent_peers", strings.Join(p2pAddresses, ","))
+	configToml.Set("p2p.allow_duplicate_ip", true)
 	configTomlFile, err := os.OpenFile(configTomlPath, os.O_RDWR|os.O_TRUNC, 644)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #475.

a: self validator
b: other validators

we run a Chisel client for each (b) in the same host where we run (a).
while doing so, every (b) gets same(127.0.0.1) ip address -but with a
unique port number.
this PR enables allowing to use same ip address for each (b).



- [ ] Updated changelog.