### PR TITLE
feat(network/chain/create): support Git urls

### DIFF
--- a/starport/interface/cli/starport/cmd/network_chain_create.go
+++ b/starport/interface/cli/starport/cmd/network_chain_create.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/events"
+	"github.com/tendermint/starport/starport/pkg/xurl"
 	"github.com/tendermint/starport/starport/services/networkbuilder"
 )
 
@@ -35,9 +36,16 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	path := args[0]
+	address := args[0]
 
-	blockchain, err := nb.InitBlockchainFromPath(cmd.Context(), path, true)
+	initChain := func() (*networkbuilder.Blockchain, error) {
+		if xurl.IsLocalPath(address) {
+			return nb.InitBlockchainFromPath(cmd.Context(), address, true)
+		}
+		return nb.InitBlockchainFromURL(cmd.Context(), address, "", true)
+	}
+
+	blockchain, err := initChain()
 
 	// handle if data dir for the chain already exists.
 	var e *networkbuilder.DataDirExistsError
@@ -60,7 +68,7 @@ func networkChainCreateHandler(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		blockchain, err = nb.InitBlockchainFromPath(cmd.Context(), path, true)
+		blockchain, err = initChain()
 	}
 
 	if err == context.Canceled {

--- a/starport/pkg/xurl/xurl.go
+++ b/starport/pkg/xurl/xurl.go
@@ -33,3 +33,17 @@ func Address(address string) string {
 	}
 	return address
 }
+
+// IsLocalPath checks if given address is a local fs path or a URL.
+func IsLocalPath(address string) bool {
+	for _, pattern := range []string{
+		"http://",
+		"https://",
+		"git@",
+	} {
+		if strings.HasPrefix(address, pattern) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
resolves #484.

following supported:
- network chain create https://github.com/org/repo
- network chain create git@github.com:org/repo.git

following not interpreted as a Git url because it can point to a local path in the fs:
- network chain create github.com/org/repo



- [ ] Updated changelog.