### PR TITLE
fix: fix tx_test.go and proto generation for Launchpad version

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -48,8 +48,7 @@ jobs:
 
       - name: Install Starport
         working-directory: ${{ env.working-directory }}
-        run: |
-          go install ./...
+        run: make
 
       - name: Run Integration Tests
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -48,7 +48,8 @@ jobs:
 
       - name: Install Starport
         working-directory: ${{ env.working-directory }}
-        run: make
+        run: |
+          go install ./...
 
       - name: Run Integration Tests
         working-directory: ${{ env.working-directory }}

--- a/go.mod
+++ b/go.mod
@@ -48,8 +48,8 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d // indirect
-	golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b // indirect
+	golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f // indirect
+	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -937,12 +937,12 @@ golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f h1:QdHQnPce6K4XQewki9WNbG5KOROuDzqO3NaYjI1cXJ0=
+golang.org/x/sys v0.0.0-20201211090839-8ad439b19e0f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
-golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b h1:a0ErnNnPKmhDyIXQvdZr+Lq8dc8xpMeqkF8y5PgQU4Q=
-golang.org/x/term v0.0.0-20201207232118-ee85cb95a76b/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
+golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/go.sum
+++ b/go.sum
@@ -967,6 +967,7 @@ golang.org/x/tools v0.0.0-20191224055732-dd894d0a8a40/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200308013534-11ec41452d41 h1:9Di9iYgOt9ThCipBxChBVhgNipDoE5mxO84rQV7D0FE=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/integration/cmd_serve_test.go
+++ b/integration/cmd_serve_test.go
@@ -38,3 +38,25 @@ func TestServeAppWithCosmWasm(t *testing.T) {
 
 	require.NoError(t, isBackendAliveErr, "app cannot get online in time")
 }
+
+func TestServeAppStargate(t *testing.T) {
+	t.Parallel()
+
+	var (
+		env     = newEnv(t)
+		apath   = env.Scaffold("sgblog", Stargate)
+		servers = env.RandomizeServerPorts(apath)
+	)
+
+	var (
+		ctx, cancel       = context.WithTimeout(env.Ctx(), serveTimeout)
+		isBackendAliveErr error
+	)
+	go func() {
+		defer cancel()
+		isBackendAliveErr = env.IsAppServed(ctx, servers)
+	}()
+	env.Must(env.Serve("should serve with Stargate version", apath, ExecCtx(ctx)))
+
+	require.NoError(t, isBackendAliveErr, "app cannot get online in time")
+}

--- a/integration/tx_test.go
+++ b/integration/tx_test.go
@@ -128,6 +128,11 @@ func TestGetTxViaGRPCGateway(t *testing.T) {
 					}
 					defer resp.Body.Close()
 
+					// Send error if the request failed
+					if resp.StatusCode != http.StatusOK {
+						return errors.New(resp.Status)
+					}
+
 					if err := json.NewDecoder(resp.Body).Decode(&txBody); err != nil {
 						return err
 					}

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -87,22 +87,22 @@ func (s *Chain) buildSteps(ctx context.Context, conf starportconf.Config) (
 		Add(step.Stderr(buildErr))...,
 	))
 
-	scriptPath := filepath.Join(s.app.Path, "scripts/protocgen")
-	steps.Add(step.New(step.NewOptions().
-		Add(
-			step.Exec(
-				"/bin/bash",
-				scriptPath,
-			),
-			step.PreExec(func() error {
-				fmt.Fprintln(s.stdLog(logStarport).out, "🛠️  Building proto...")
-				return nil
-			}),
-			step.PostExec(captureBuildErr),
-		).
-		Add(s.stdSteps(logStarport)...).
-		Add(step.Stderr(buildErr))...,
-	))
+	//scriptPath := filepath.Join(s.app.Path, "scripts/protocgen")
+	//steps.Add(step.New(step.NewOptions().
+	//	Add(
+	//		step.Exec(
+	//			"/bin/bash",
+	//			scriptPath,
+	//		),
+	//		step.PreExec(func() error {
+	//			fmt.Fprintln(s.stdLog(logStarport).out, "🛠️  Building proto...")
+	//			return nil
+	//		}),
+	//		step.PostExec(captureBuildErr),
+	//	).
+	//	Add(s.stdSteps(logStarport)...).
+	//	Add(step.Stderr(buildErr))...,
+	//))
 
 	steps.Add(step.New(step.NewOptions().
 		Add(

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -87,22 +88,25 @@ func (s *Chain) buildSteps(ctx context.Context, conf starportconf.Config) (
 		Add(step.Stderr(buildErr))...,
 	))
 
-	//scriptPath := filepath.Join(s.app.Path, "scripts/protocgen")
-	//steps.Add(step.New(step.NewOptions().
-	//	Add(
-	//		step.Exec(
-	//			"/bin/bash",
-	//			scriptPath,
-	//		),
-	//		step.PreExec(func() error {
-	//			fmt.Fprintln(s.stdLog(logStarport).out, "🛠️  Building proto...")
-	//			return nil
-	//		}),
-	//		step.PostExec(captureBuildErr),
-	//	).
-	//	Add(s.stdSteps(logStarport)...).
-	//	Add(step.Stderr(buildErr))...,
-	//))
+	// If protocgen exists, compile the proto file
+	protoScriptPath := filepath.Join(s.app.Path, "scripts/protocgen")
+	if _, err := os.Stat(protoScriptPath); !os.IsNotExist(err) {
+		steps.Add(step.New(step.NewOptions().
+			Add(
+				step.Exec(
+					"/bin/bash",
+					protoScriptPath,
+				),
+				step.PreExec(func() error {
+					fmt.Fprintln(s.stdLog(logStarport).out, "🛠️  Building proto...")
+					return nil
+				}),
+				step.PostExec(captureBuildErr),
+			).
+			Add(s.stdSteps(logStarport)...).
+			Add(step.Stderr(buildErr))...,
+		))
+	}
 
 	steps.Add(step.New(step.NewOptions().
 		Add(


### PR DESCRIPTION
- Fix proto generation:
The proto generation step was performed with Launchpad version, `starport serve` was not working anymore for Launchpad version

- Add an integration test for `starport server` for Stargate version

- Fix `tx_test.go `:
`TestGetTxViaGRPCGateway` sends a message to get the tx of the grpc server and retry until it succeed. We didn't handle the server error therefore it was directly considered as successful and performed checks on incorrect retrieved data
- [ ] Updated changelog.