### PR TITLE
fix: web scaffold working on Gitpod

### DIFF
--- a/starport/templates/app/stargate/vue/package-lock.json
+++ b/starport/templates/app/stargate/vue/package-lock.json
@@ -1099,13 +1099,13 @@
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-Aw3qmMzmzOdL+8aGY5ZbVZlIx4iiWwFBEkdF8MKIktnsstW2UpQDscfOWE3lxzRabFrt0LznWbkeIbV+Pn5CAQ==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-uyN0L2nneUxYqlnFeL0lG2Ceu1gAqDghDmV69216IfgePJMqCXG7gszRd/4K+WP15ch2eS6+Pe97+At5PLMUcA==",
       "requires": {
-        "@cosmjs/encoding": "^0.24.0-alpha.10",
-        "@cosmjs/math": "^0.24.0-alpha.10",
-        "@cosmjs/utils": "^0.24.0-alpha.10",
+        "@cosmjs/encoding": "^0.24.0-alpha.11",
+        "@cosmjs/math": "^0.24.0-alpha.11",
+        "@cosmjs/utils": "^0.24.0-alpha.11",
         "bip39": "^3.0.2",
         "bn.js": "^4.11.8",
         "elliptic": "^6.5.3",
@@ -1116,6 +1116,18 @@
         "sha.js": "^2.4.11",
         "type-tagger": "^1.0.0",
         "unorm": "^1.5.0"
+      },
+      "dependencies": {
+        "@cosmjs/encoding": {
+          "version": "0.24.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.24.0-alpha.11.tgz",
+          "integrity": "sha512-RYPObd4/AR7G6C0ARnnnvfoZ/ngpV7eu9aDw5/9lDRz9ELgTzaYhxXoCjLG/Vgx2DBwfz3srka+3dN2bOFoTGg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        }
       }
     },
     "@cosmjs/encoding": {
@@ -1129,11 +1141,11 @@
       }
     },
     "@cosmjs/json-rpc": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-ymcTaBoPZGwdPNZupcHbKRouyfDFLpYIPwQkdT3NAw3xmFQmA7Q09xOqb4IfJTUnpaIMIThJVoAIhNXf50ssRQ==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-3uPh9rrNiDvo/D0IwXcHOSZRskms1oPlHW/c4kW69wsmCjBfbjmuXJnPRy4Cz1sqWl6eoJj46PvS5ezo7CUDJg==",
       "requires": {
-        "@cosmjs/stream": "^0.24.0-alpha.10",
+        "@cosmjs/stream": "^0.24.0-alpha.11",
         "xstream": "^11.14.0"
       }
     },
@@ -1160,9 +1172,9 @@
       }
     },
     "@cosmjs/math": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-Ydkd3o3mYFBGgDHWi5JLlvfVz7EafszxAHkwXVn8W5QuJJ7R16ukMn4Dd2N/vNjd4y7bxuKWmM3bW3aML9XTjQ==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-LdJq4rfl2XyYZIveupWCT744FSz2oMXpEqKof50pUcJrc+cvVv5svNCnOHQnSpvviFkcNNehiTlJswokeIhJcg==",
       "requires": {
         "bn.js": "^4.11.8"
       }
@@ -1178,11 +1190,11 @@
       }
     },
     "@cosmjs/socket": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-iJYNTVLnJOcEV4RoXpUtWdHuzu6eVcORF0tx+u/SR32AB1iQdP8a0HosbXyPsu4o4PkVt4HbJ65nPtb8ZCUGIA==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-706wfdLDAWUPf5Rzb1pGiA7rLXrawpC19TzR5hpcH91HK0AWSRDDTElIpBtY5LizXNgM52ZrayxiI/k9SGmFjA==",
       "requires": {
-        "@cosmjs/stream": "^0.24.0-alpha.10",
+        "@cosmjs/stream": "^0.24.0-alpha.11",
         "isomorphic-ws": "^4.0.1",
         "ws": "^6.2.0",
         "xstream": "^11.14.0"
@@ -1206,30 +1218,40 @@
       }
     },
     "@cosmjs/stream": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-50DqgGAiE6Mk6NGSYspvc9RZfV6XuLNP9/IWuqt9X0lnQ5YYzoJN91irihMzrvNH5szgOj8CNObiHu2Cp3J4+w==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-RtTVSL2vC0aOuHELE/9V0NDnpZBLTXL5O0ZJOWBVt+wt+8CcE2n/NOfUI5ng3faJLOG83wel5TUtNhVXOfhyWQ==",
       "requires": {
         "xstream": "^11.14.0"
       }
     },
     "@cosmjs/tendermint-rpc": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-7BoHOi0yps0TAa5k8sH3eEi2LScZf3vCn2HVoYMRDHIvUvNKuw+5659BYqAJ/6oELYXq7+PpPb2zIJkQj6ZCFw==",
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-O0sgqr23d1UJYIoSRDxWGGjjCMmwlDKXaKNiYwCPyBE9IjJ7oHA625V3NE6mNeu7GED+ahECG+GLe7zpYlyZbA==",
       "requires": {
-        "@cosmjs/crypto": "^0.24.0-alpha.10",
-        "@cosmjs/encoding": "^0.24.0-alpha.10",
-        "@cosmjs/json-rpc": "^0.24.0-alpha.10",
-        "@cosmjs/math": "^0.24.0-alpha.10",
-        "@cosmjs/socket": "^0.24.0-alpha.10",
-        "@cosmjs/stream": "^0.24.0-alpha.10",
+        "@cosmjs/crypto": "^0.24.0-alpha.11",
+        "@cosmjs/encoding": "^0.24.0-alpha.11",
+        "@cosmjs/json-rpc": "^0.24.0-alpha.11",
+        "@cosmjs/math": "^0.24.0-alpha.11",
+        "@cosmjs/socket": "^0.24.0-alpha.11",
+        "@cosmjs/stream": "^0.24.0-alpha.11",
         "axios": "^0.19.0",
         "readonly-date": "^1.0.0",
         "type-tagger": "^1.0.0",
         "xstream": "^11.14.0"
       },
       "dependencies": {
+        "@cosmjs/encoding": {
+          "version": "0.24.0-alpha.11",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.24.0-alpha.11.tgz",
+          "integrity": "sha512-RYPObd4/AR7G6C0ARnnnvfoZ/ngpV7eu9aDw5/9lDRz9ELgTzaYhxXoCjLG/Vgx2DBwfz3srka+3dN2bOFoTGg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
         "axios": {
           "version": "0.19.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
@@ -1241,9 +1263,9 @@
       }
     },
     "@cosmjs/utils": {
-      "version": "0.24.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.24.0-alpha.10.tgz",
-      "integrity": "sha512-SfsJOpthTUQLcU4HLfU1I7xnVvy1bqvY3DJnOvCdRsHmmiTVtFwoKZLAjkUv3rarMtg7qiZxdUvnUAbaQf0Wyw=="
+      "version": "0.24.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.24.0-alpha.11.tgz",
+      "integrity": "sha512-Tv9GlSMj85mLfcFwNOqZ6KHwN+nLW2UaPRxodBwOJfJNBuPwhkbFVcXMoObHqQjwo2wORk+sQlbAw4/Vaj4Tvg=="
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -1425,14 +1447,14 @@
       "dev": true
     },
     "@tendermint/vue": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@tendermint/vue/-/vue-0.1.11.tgz",
-      "integrity": "sha512-BjwMvz4/j8MDLOcnqbQKpvMKdo5Nln+vwHfdnDky0n6Ljq7FUC88TmSAlgb+Q8GoPmYh57BrKEQgpx8Q+0iY6w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@tendermint/vue/-/vue-0.1.12.tgz",
+      "integrity": "sha512-rlRwUQSeRNhKMHF3T3ind2hyRTMBdYeW8B1rFVZOAjcpR5f1uFM8W8TTqPDs/4u9Z+PyEBtNAvjLXpDkoD7BYA==",
       "requires": {
-        "@cosmjs/encoding": "^0.24.0-alpha.10",
-        "@cosmjs/launchpad": "^0.24.0-alpha.10",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.10",
-        "@cosmjs/stargate": "^0.24.0-alpha.10",
+        "@cosmjs/encoding": "0.24.0-alpha.10",
+        "@cosmjs/launchpad": "0.24.0-alpha.10",
+        "@cosmjs/proto-signing": "0.24.0-alpha.10",
+        "@cosmjs/stargate": "0.24.0-alpha.10",
         "axios": "^0.20.0",
         "bip39": "^3.0.2",
         "core-js": "^3.6.5",
@@ -1957,16 +1979,6 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "cacache": {
           "version": "13.0.1",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
@@ -1992,34 +2004,6 @@
             "ssri": "^7.0.0",
             "unique-filename": "^1.1.1"
           }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
         },
         "debug": {
           "version": "4.2.0",
@@ -2049,25 +2033,6 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
           }
         },
         "locate-path": {
@@ -2140,16 +2105,6 @@
             "minipass": "^3.1.1"
           }
         },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
         "terser-webpack-plugin": {
           "version": "2.3.8",
           "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
@@ -2165,18 +2120,6 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.1",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.1.tgz",
-          "integrity": "sha512-wz/+HFg/3SBayHWAlZXARcnDTl3VOChrfW9YnxvAweiuyKX/7IGx1ad/4yJHmwhgWlOVYMAbTiI7GV8G33PfGQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
           }
         }
       }
@@ -11074,6 +11017,87 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.1.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },

--- a/starport/templates/app/stargate/vue/package.json
+++ b/starport/templates/app/stargate/vue/package.json
@@ -8,7 +8,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@tendermint/vue": "0.1.11",
+    "@tendermint/vue": "0.1.12",
     "core-js": "^3.6.5",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",


### PR DESCRIPTION
On the current version of `@tendermint/vue` web scaffold doesn't work on Gitpod, because API URL is not properly constructed. This fixes the problem.