### PR TITLE
refactor: use a fixed-name dir for Starport Network chain sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20201223074533-0d417f636930 // indirect
+	golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -45,11 +45,11 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/tendermint/spn v0.0.0-20201215081711-b9ec9286ed83
 	github.com/tendermint/tendermint v0.34.0-rc6
-	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 // indirect
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 // indirect
+	golang.org/x/sys v0.0.0-20201223074533-0d417f636930 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201223074533-0d417f636930 h1:vRgIt+nup/B/BwIS0g2oC0haq0iqbV3ZA+u6+0TlNCo=
-golang.org/x/sys v0.0.0-20201223074533-0d417f636930/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210105210732-16f7687f5001 h1:/dSxr6gT0FNI1MO5WLJo8mTmItROeOKTkDn+7OwWBos=
+golang.org/x/sys v0.0.0-20210105210732-16f7687f5001/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/go.sum
+++ b/go.sum
@@ -804,8 +804,8 @@ golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 h1:3wPMTskHO3+O6jqTEXyFcsnuxMQOqYSaHsDxcbUXpqA=
-golang.org/x/crypto v0.0.0-20201217014255-9d1352758620/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -928,8 +928,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 h1:n+DPcgTwkgWzIFpLmoimYR2K2b0Ga5+Os4kayIN0vGo=
-golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930 h1:vRgIt+nup/B/BwIS0g2oC0haq0iqbV3ZA+u6+0TlNCo=
+golang.org/x/sys v0.0.0-20201223074533-0d417f636930/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -186,8 +186,20 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	// as well as validators.
 	default:
 		// use a tempdir to clone the source code inside.
-		if path, err = ioutil.TempDir("", ""); err != nil {
-			return nil, err
+		tmpDir := os.TempDir()
+		path = filepath.Join(tmpDir, "spn-" + chainID)
+		if err := os.Mkdir(path, 0700); err != nil {
+			if os.IsExist(err) {
+				// if the directory already exists, we overwrite it to ensure we have the last version
+				if err := os.RemoveAll(path); err != nil {
+					return nil, err
+				}
+				if err := os.Mkdir(path, 0700); err != nil {
+					return nil, err
+				}
+			} else {
+				return nil, err
+			}
 		}
 
 		// prepare clone options.

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -39,7 +39,7 @@ const (
 )
 
 var (
-	sourcePath        = filepath.Join(starportConfDir, "spn-chains")
+	sourcePath = filepath.Join(starportConfDir, "spn-chains")
 )
 
 // Builder is network builder.

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -38,6 +38,10 @@ const (
 	tendermintrpcAddr = "http://localhost:26657"
 )
 
+var (
+	sourcePath        = filepath.Join(starportConfDir, "spn-chains")
+)
+
 // Builder is network builder.
 type Builder struct {
 	ev        events.Bus
@@ -186,8 +190,7 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	// as well as validators.
 	default:
 		// use a tempdir to clone the source code inside.
-		tmpDir := os.TempDir()
-		path = filepath.Join(tmpDir, "spn-"+chainID)
+		path = filepath.Join(sourcePath, chainID)
 		if err := os.Mkdir(path, 0700); err != nil {
 			if os.IsExist(err) {
 				// if the directory already exists, we overwrite it to ensure we have the last version

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -187,7 +187,7 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	default:
 		// use a tempdir to clone the source code inside.
 		tmpDir := os.TempDir()
-		path = filepath.Join(tmpDir, "spn-" + chainID)
+		path = filepath.Join(tmpDir, "spn-"+chainID)
 		if err := os.Mkdir(path, 0700); err != nil {
 			if os.IsExist(err) {
 				// if the directory already exists, we overwrite it to ensure we have the last version

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -190,7 +190,7 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	// as well as validators.
 	default:
 		// ensure the path for chain source exists
-		if err := os.MkdirAll(sourcePath, 0700); err != nil {
+		if err := os.MkdirAll(sourcePath, 0700); err != nil &&  !os.IsExist(err) {
 			if !os.IsExist(err) {
 				return nil, err
 			}

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -190,7 +190,7 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	// as well as validators.
 	default:
 		// ensure the path for chain source exists
-		if err := os.MkdirAll(sourcePath, 0700); err != nil &&  !os.IsExist(err) {
+		if err := os.MkdirAll(sourcePath, 0700); err != nil && !os.IsExist(err) {
 			if !os.IsExist(err) {
 				return nil, err
 			}


### PR DESCRIPTION
Use `[tmp]/spn-[chain-id]` for the directory of the source of the chain
The directory is overwrite if it already exist

This allows having less directories created and is convenient for Starport Network integration tests to modify the `config.yml` because the source path is deterministic