### PR TITLE
feat(pkg/gomodulepath): add tests for paths with versions

### DIFF
--- a/starport/pkg/gomodulepath/gomodulepath.go
+++ b/starport/pkg/gomodulepath/gomodulepath.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/parser"
 	"go/token"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -77,7 +78,7 @@ func validatePackageName(name string) error {
 func root(path string) string {
 	sp := strings.Split(path, "/")
 	name := sp[len(sp)-1]
-	if strings.HasPrefix(name, "v") { // omit versions.
+	if hasVer, _ := regexp.MatchString(`^v\d+$`, name); hasVer { // omit versions.
 		name = sp[len(sp)-2]
 	}
 	return name

--- a/starport/pkg/gomodulepath/gomodulepath_test.go
+++ b/starport/pkg/gomodulepath/gomodulepath_test.go
@@ -28,6 +28,12 @@ func TestParse(t *testing.T) {
 			"github.com/a/b/c@", Path{}, fmt.Errorf("app name is an invalid go module name: %w",
 				errors.New(`malformed module path "github.com/a/b/c@": invalid char '@'`)),
 		},
+		{"name starting with the letter v",
+			"github.com/a/vote", Path{"github.com/a/vote", "vote", "vote"}, nil,
+		},
+		{"with version",
+			"github.com/a/b/v2", Path{"github.com/a/b/v2", "b", "b"}, nil,
+		},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Now, if you try to run `starport app github.com/alice/voter --sdk-version="launchpad"`, you will get project named "alice", not "voter".