### PR TITLE
refactor: use stable version of Starport in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,12 +2,12 @@
 
 Starport is the easiest way to build a blockchain. It is a developer-friendly interface to the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk), the world's most widely-used blockchain application framework. Starport generates boilerplate code for you, so you can focus on writing business logic.
 
-* [**Build a blockchain with Starport in a web-based IDE**](https://gitpod.io/#https://github.com/tendermint/starport/)
+* [**Build a blockchain with Starport in a web-based IDE** ~stable](https://gitpod.io/#https://github.com/tendermint/starport/tree/master) or use [~nightly](https://gitpod.io/#https://github.com/tendermint/starport/)
 * [Check out the latest features in v0.13](https://www.youtube.com/watch?v=DhciTJHxvAY)
 
 ## Quick start
 
-Open Starport [in your browser](https://gitpod.io/#https://github.com/tendermint/starport/), or [install it](/docs/1%20Introduction/2%20Install.md). Then:
+Open Starport [in your browser](https://gitpod.io/#https://github.com/tendermint/starport/tree/master), or [install it](/docs/1%20Introduction/2%20Install.md). Then:
 
 ```
 starport app github.com/foo/mychain

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Starport is the easiest way to build a blockchain. It is a developer-friendly interface to the [Cosmos SDK](https://github.com/cosmos/cosmos-sdk), the world's most widely-used blockchain application framework. Starport generates boilerplate code for you, so you can focus on writing business logic.
 
-* [**Build a blockchain with Starport in a web-based IDE** ~stable](https://gitpod.io/#https://github.com/tendermint/starport/tree/master) or use [~nightly](https://gitpod.io/#https://github.com/tendermint/starport/)
+* [**Build a blockchain with Starport in a web-based IDE** (stable)](https://gitpod.io/#https://github.com/tendermint/starport/tree/master) or use [nightly version](https://gitpod.io/#https://github.com/tendermint/starport/)
 * [Check out the latest features in v0.13](https://www.youtube.com/watch?v=DhciTJHxvAY)
 
 ## Quick start


### PR DESCRIPTION
develop branch tends to change a lot, and it is expected have some temporary bugs before each release. it would be nice to have docs to use the stable version by default.