### PR TITLE
fix(template): use HomeDir from clientCtx RegisterTxService

### DIFF
--- a/starport/templates/app/stargate/app/app.go.plush
+++ b/starport/templates/app/stargate/app/app.go.plush
@@ -542,7 +542,7 @@ func (app *App) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.APIConfig
 func (app *App) RegisterTxService(clientCtx client.Context) {
 	// TODO remove this workaround after https://github.com/cosmos/cosmos-sdk/pull/7840 has merged.
 	// -- right now, clientCtx does not have a Client set. this workaround fixes that.
-	config, err := toml.LoadFile(filepath.Join(DefaultNodeHome(""), "config/config.toml"))
+	config, err := toml.LoadFile(filepath.Join(clientCtx.HomeDir, "config/config.toml"))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Remove the fixed home directory we use in the workaround

Removing the workaround need to update the Cosmos SDK version https://github.com/tendermint/starport/pull/622, this is not possible now because the command line interface of the blockchain daemon has changed so we need to be able to support different command line interface depending on the Cosmos SDK version. I create an issue for this.