### PR TITLE
feat: add cosmosfaucet

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,3 +38,4 @@ ports:
   - port: 26657
   - port: 8080
   - port: 7575 
+  - port: 4500 

--- a/go.mod
+++ b/go.mod
@@ -49,8 +49,9 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 // indirect
+	golang.org/x/sys v0.0.0-20210112080510-489259a85091 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
+	golang.org/x/tools v0.0.0-20210111221946-d33bae441459 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.mod
+++ b/go.mod
@@ -49,9 +49,8 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20210112080510-489259a85091 // indirect
+	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
-	golang.org/x/tools v0.0.0-20210111221946-d33bae441459 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,7 @@ github.com/gobuffalo/logger v1.0.3/go.mod h1:SoeejUwldiS7ZsyCBphOGURmWdwUFXs0J7T
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
+github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
 github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
 github.com/gobuffalo/packr/v2 v2.8.1 h1:tkQpju6i3EtMXJ9uoF5GT6kB+LMTimDWD8Xvbz6zDVA=
@@ -761,6 +762,7 @@ github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0B
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -877,6 +879,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -930,6 +933,8 @@ golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 h1:DQmQoKxQWtyybCtX/3dIuDBcAhFszqq8YiNeS6sNu1c=
 golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
+golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -971,6 +976,8 @@ golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41 h1:9Di9iYgOt9ThCipBxChBVhgNipDoE5mxO84rQV7D0FE=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20210111221946-d33bae441459 h1:/pJfBBZw1zeMQA6vRpalDcuw4VJ/B6+N5obtmG0Xiv8=
+golang.org/x/tools v0.0.0-20210111221946-d33bae441459/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -255,7 +255,6 @@ github.com/gobuffalo/logger v1.0.3/go.mod h1:SoeejUwldiS7ZsyCBphOGURmWdwUFXs0J7T
 github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b36chA3Q=
 github.com/gobuffalo/packd v1.0.0 h1:6ERZvJHfe24rfFmA9OaoKBdC7+c9sydrytMg8SdFGBM=
 github.com/gobuffalo/packd v1.0.0/go.mod h1:6VTc4htmJRFB7u1m/4LeMTWjFoYrUiBkU9Fdec9hrhI=
-github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr/v2 v2.7.1/go.mod h1:qYEvAazPaVxy7Y7KR0W8qYEE+RymX74kETFqjFoFlOc=
 github.com/gobuffalo/packr/v2 v2.8.0/go.mod h1:PDk2k3vGevNE3SwVyVRgQCCXETC9SaONCNSXT1Q8M1g=
 github.com/gobuffalo/packr/v2 v2.8.1 h1:tkQpju6i3EtMXJ9uoF5GT6kB+LMTimDWD8Xvbz6zDVA=
@@ -762,7 +761,6 @@ github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0B
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zondax/hid v0.9.0 h1:eiT3P6vNxAEVxXMw66eZUAAnU2zD33JBkfG/EnfAKl8=
 github.com/zondax/hid v0.9.0/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -879,7 +877,6 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201008141435-b3e1573b7520/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -931,10 +928,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061 h1:DQmQoKxQWtyybCtX/3dIuDBcAhFszqq8YiNeS6sNu1c=
-golang.org/x/sys v0.0.0-20210110051926-789bb1bd4061/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
-golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -976,8 +971,6 @@ golang.org/x/tools v0.0.0-20200110213125-a7a6caa82ab2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200207183749-b753a1ba74fa/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41 h1:9Di9iYgOt9ThCipBxChBVhgNipDoE5mxO84rQV7D0FE=
 golang.org/x/tools v0.0.0-20200308013534-11ec41452d41/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
-golang.org/x/tools v0.0.0-20210111221946-d33bae441459 h1:/pJfBBZw1zeMQA6vRpalDcuw4VJ/B6+N5obtmG0Xiv8=
-golang.org/x/tools v0.0.0-20210111221946-d33bae441459/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/starport/interface/cli/starport/cmd/build.go
+++ b/starport/interface/cli/starport/cmd/build.go
@@ -19,7 +19,7 @@ func NewBuild() *cobra.Command {
 }
 
 func buildHandler(cmd *cobra.Command, args []string) error {
-	s, err := chain.New(appPath, chain.LogLevel(logLevel(cmd)))
+	s, err := chain.New(cmd.Context(), appPath, chain.LogLevel(logLevel(cmd)))
 	if err != nil {
 		return err
 	}

--- a/starport/interface/cli/starport/cmd/relayer.go
+++ b/starport/interface/cli/starport/cmd/relayer.go
@@ -41,7 +41,7 @@ func NewRelayerAdd() *cobra.Command {
 }
 
 func relayerInfoHandler(cmd *cobra.Command, args []string) error {
-	s, err := chain.New(appPath, chain.LogLevel(logLevel(cmd)))
+	s, err := chain.New(cmd.Context(), appPath, chain.LogLevel(logLevel(cmd)))
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func relayerInfoHandler(cmd *cobra.Command, args []string) error {
 }
 
 func relayerAddHandler(cmd *cobra.Command, args []string) error {
-	s, err := chain.New(appPath, chain.LogLevel(logLevel(cmd)))
+	s, err := chain.New(cmd.Context(), appPath, chain.LogLevel(logLevel(cmd)))
 	if err != nil {
 		return err
 	}

--- a/starport/interface/cli/starport/cmd/serve.go
+++ b/starport/interface/cli/starport/cmd/serve.go
@@ -21,7 +21,7 @@ func NewServe() *cobra.Command {
 }
 
 func serveHandler(cmd *cobra.Command, args []string) error {
-	s, err := chain.New(appPath, chain.LogLevel(logLevel(cmd)))
+	s, err := chain.New(cmd.Context(), appPath, chain.LogLevel(logLevel(cmd)))
 	if err != nil {
 		return err
 	}

--- a/starport/pkg/chaincmd/chaincmd.go
+++ b/starport/pkg/chaincmd/chaincmd.go
@@ -409,7 +409,7 @@ func (c ChainCmd) BankSendCommand(fromAddress, toAddress, amount string) step.Op
 		fromAddress,
 		toAddress,
 		amount,
-		"--yes",
+		optionYes,
 	)
 
 	command = c.attachChainID(command)
@@ -418,6 +418,7 @@ func (c ChainCmd) BankSendCommand(fromAddress, toAddress, amount string) step.Op
 	return c.cliCommand(command)
 }
 
+// QueryTxEventsCommand returns the command to query events.
 func (c ChainCmd) QueryTxEventsCommand(query string) step.Option {
 	command := []string{
 		commandQuery,
@@ -455,6 +456,7 @@ func (c ChainCmd) LaunchpadRestServerCommand(apiAddress string, rpcAddress strin
 	return c.launchpadRestServerCommand(apiAddress, rpcAddress)
 }
 
+// StatusCommand returns the command that fetches node's status.
 func (c ChainCmd) StatusCommand() step.Option {
 	command := []string{
 		commandStatus,

--- a/starport/pkg/chaincmd/runner/account.go
+++ b/starport/pkg/chaincmd/runner/account.go
@@ -10,6 +10,11 @@ import (
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 
+var (
+	// ErrAccountAlreadyExists returned when an already exists account attempted to be imported.
+	ErrAccountAlreadyExists = errors.New("account already exists")
+)
+
 // AddAccount creates a new account or imports an account when mnemonic is provided.
 // returns with an error if the operation went unsuccessful or an account with the provided name
 // already exists.
@@ -26,7 +31,7 @@ func (r Runner) AddAccount(ctx context.Context, name, mnemonic string) (Account,
 	}
 	for _, account := range accounts {
 		if account.Name == name {
-			return Account{}, errors.New("account already exists")
+			return Account{}, ErrAccountAlreadyExists
 		}
 	}
 	b.Reset()

--- a/starport/pkg/chaincmd/runner/account.go
+++ b/starport/pkg/chaincmd/runner/account.go
@@ -13,6 +13,9 @@ import (
 var (
 	// ErrAccountAlreadyExists returned when an already exists account attempted to be imported.
 	ErrAccountAlreadyExists = errors.New("account already exists")
+
+	// ErrAccountDoesNotExist returned when account does not exit.
+	ErrAccountDoesNotExist = errors.New("account does not exit")
 )
 
 // AddAccount creates a new account or imports an account when mnemonic is provided.
@@ -82,9 +85,14 @@ type Account struct {
 // ShowAccount shows details of an account.
 func (r Runner) ShowAccount(ctx context.Context, name string) (Account, error) {
 	b := &bytes.Buffer{}
+
 	if err := r.run(ctx, runOptions{stdout: b}, r.cc.ShowKeyAddressCommand(name)); err != nil {
+		if strings.Contains(err.Error(), "item could not be found") {
+			return Account{}, ErrAccountDoesNotExist
+		}
 		return Account{}, err
 	}
+
 	return Account{
 		Name:    name,
 		Address: strings.TrimSpace(b.String()),

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -3,10 +3,14 @@ package chaincmdrunner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
+	"github.com/tendermint/starport/starport/pkg/cosmosver"
 )
 
 // Start starts the blockchain.
@@ -75,4 +79,159 @@ func (r Runner) ShowNodeID(ctx context.Context) (nodeID string, err error) {
 	err = r.run(ctx, runOptions{stdout: b}, r.cc.ShowNodeIDCommand())
 	nodeID = strings.TrimSpace(b.String())
 	return
+}
+
+type NodeStatus struct {
+	ChainID string
+}
+
+func (r Runner) Status(ctx context.Context) (NodeStatus, error) {
+	b := &bytes.Buffer{}
+
+	if err := r.run(ctx, runOptions{stdout: b, stderr: b}, r.cc.StatusCommand()); err != nil {
+		return NodeStatus{}, err
+	}
+
+	var chainID string
+
+	if r.cc.SDKVersion().Major().Is(cosmosver.Stargate) {
+		out := struct {
+			NodeInfo struct {
+				Network string `json:"network"`
+			} `json:"NodeInfo"`
+		}{}
+
+		if err := json.NewDecoder(b).Decode(&out); err != nil {
+			return NodeStatus{}, err
+		}
+
+		chainID = out.NodeInfo.Network
+	} else {
+		out := struct {
+			NodeInfo struct {
+				Network string `json:"network"`
+			} `json:"node_info"`
+		}{}
+
+		if err := json.NewDecoder(b).Decode(&out); err != nil {
+			return NodeStatus{}, err
+		}
+
+		chainID = out.NodeInfo.Network
+	}
+
+	return NodeStatus{
+		ChainID: chainID,
+	}, nil
+}
+
+//BankSend sends amount from fromAccount to toAccount.
+func (r Runner) BankSend(ctx context.Context, fromAccount, toAccount, amount string) error {
+	b := &bytes.Buffer{}
+
+	if err := r.run(ctx, runOptions{stdout: b}, r.cc.BankSendCommand(fromAccount, toAccount, amount)); err != nil {
+		if strings.Contains(err.Error(), "key not found") || // stargate
+			strings.Contains(err.Error(), "unknown address") || // launchpad
+			strings.Contains(b.String(), "item could not be found") { // launchpad
+			return errors.New("account doesn't have any balances")
+		}
+
+		return err
+	}
+
+	out := struct {
+		Code  int    `json:"code"` // TODO LP with code 19.
+		Error string `json:"raw_log"`
+	}{}
+
+	if err := json.NewDecoder(b).Decode(&out); err != nil {
+		return err
+	}
+
+	if out.Code > 0 {
+		return errors.New(out.Error)
+	}
+
+	return nil
+}
+
+type EventSelector struct {
+	typ   string
+	attr  string
+	value string
+}
+
+func NewEventSelector(typ, addr, value string) EventSelector {
+	return EventSelector{typ, addr, value}
+}
+
+type Event struct {
+	Type       string
+	Attributes []EventAttribute
+}
+
+type EventAttribute struct {
+	Key   string
+	Value string
+}
+
+func (r Runner) QueryTxEvents(ctx context.Context, event EventSelector, moreEvents ...EventSelector) ([]Event, error) {
+	// prepare the slector.
+	var list []string
+
+	eventsSelectors := append([]EventSelector{event}, moreEvents...)
+
+	for _, event := range eventsSelectors {
+		list = append(list, fmt.Sprintf("%s.%s=%s", event.typ, event.attr, event.value))
+	}
+
+	query := strings.Join(list, "&")
+
+	// execute the commnd and parse the output.
+	b := &bytes.Buffer{}
+
+	if err := r.run(ctx, runOptions{stdout: b}, r.cc.QueryTxEventsCommand(query)); err != nil {
+		return nil, err
+	}
+
+	out := struct {
+		Txs []struct {
+			Logs []struct {
+				Events []struct {
+					Type  string `json:"type"`
+					Attrs []struct {
+						Key   string `json:"key"`
+						Value string `json:"value"`
+					} `json:"attributes"`
+				} `json:"events"`
+			} `json:"logs"`
+		} `json:"txs"`
+	}{}
+
+	if err := json.NewDecoder(b).Decode(&out); err != nil {
+		return nil, err
+	}
+
+	var events []Event
+
+	for _, tx := range out.Txs {
+		for _, log := range tx.Logs {
+			for _, e := range log.Events {
+				var attrs []EventAttribute
+				for _, attr := range e.Attrs {
+					attrs = append(attrs, EventAttribute{
+						Key:   attr.Key,
+						Value: attr.Value,
+					})
+				}
+
+				events = append(events, Event{
+					Type:       e.Type,
+					Attributes: attrs,
+				})
+			}
+		}
+	}
+
+	return events, nil
 }

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -140,7 +140,7 @@ func (r Runner) BankSend(ctx context.Context, fromAccount, toAccount, amount str
 	}
 
 	out := struct {
-		Code  int    `json:"code"` // TODO LP with code 19.
+		Code  int    `json:"code"`
 		Error string `json:"raw_log"`
 	}{}
 
@@ -149,7 +149,7 @@ func (r Runner) BankSend(ctx context.Context, fromAccount, toAccount, amount str
 	}
 
 	if out.Code > 0 {
-		return errors.New(out.Error)
+		return fmt.Errorf("cannot send tokens (SDK code %d): %s", out.Code, out.Error)
 	}
 
 	return nil

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -81,10 +81,12 @@ func (r Runner) ShowNodeID(ctx context.Context) (nodeID string, err error) {
 	return
 }
 
+// NodeStatus keeps info about node's status.
 type NodeStatus struct {
 	ChainID string
 }
 
+// Status returns the node's status.
 func (r Runner) Status(ctx context.Context) (NodeStatus, error) {
 	b := &bytes.Buffer{}
 
@@ -155,31 +157,36 @@ func (r Runner) BankSend(ctx context.Context, fromAccount, toAccount, amount str
 	return nil
 }
 
+// EventSelector is used to query events.
 type EventSelector struct {
 	typ   string
 	attr  string
 	value string
 }
 
+// NewEventSelector creates a new event selector.
 func NewEventSelector(typ, addr, value string) EventSelector {
 	return EventSelector{typ, addr, value}
 }
 
+// Event represents a TX event.
 type Event struct {
 	Type       string
 	Attributes []EventAttribute
 }
 
+// EventAttribute holds event's attributes.
 type EventAttribute struct {
 	Key   string
 	Value string
 }
 
-func (r Runner) QueryTxEvents(ctx context.Context, event EventSelector, moreEvents ...EventSelector) ([]Event, error) {
+// QueryTxEvents queries tx events by event selectors.
+func (r Runner) QueryTxEvents(ctx context.Context, selector EventSelector, moreSelectors ...EventSelector) ([]Event, error) {
 	// prepare the slector.
 	var list []string
 
-	eventsSelectors := append([]EventSelector{event}, moreEvents...)
+	eventsSelectors := append([]EventSelector{selector}, moreSelectors...)
 
 	for _, event := range eventsSelectors {
 		list = append(list, fmt.Sprintf("%s.%s=%s", event.typ, event.attr, event.value))

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -96,8 +96,8 @@ func (r Runner) Status(ctx context.Context) (NodeStatus, error) {
 
 	var chainID string
 
+	//nolint:gocritic // this is a false positive, json tags are actually different.
 	if r.cc.SDKVersion().Major().Is(cosmosver.Stargate) {
-		// nolint:gocritic
 		out := struct {
 			NodeInfo struct {
 				Network string `json:"network"`

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -97,6 +97,7 @@ func (r Runner) Status(ctx context.Context) (NodeStatus, error) {
 	var chainID string
 
 	if r.cc.SDKVersion().Major().Is(cosmosver.Stargate) {
+		// nolint:gocritic
 		out := struct {
 			NodeInfo struct {
 				Network string `json:"network"`

--- a/starport/pkg/cosmoscoin/coin.go
+++ b/starport/pkg/cosmoscoin/coin.go
@@ -1,0 +1,40 @@
+// Package cosmoscoin provides utilities to deal with SDK coins.
+package cosmoscoin
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+)
+
+var (
+	errInvalidCoin = errors.New("coin is invalid")
+)
+
+var (
+	reDnmString = `[a-zA-Z][a-zA-Z0-9/]{2,127}`
+	reDecAmt    = `[[:digit:]]+(?:\.[[:digit:]]+)?|\.[[:digit:]]+`
+	reSpc       = `[[:space:]]*`
+	pattern     = fmt.Sprintf(`^(%s)%s(%s)$`, reDecAmt, reSpc, reDnmString)
+	parseRe     = regexp.MustCompile(pattern)
+)
+
+// Parse parses a coin into amount and denom.
+func Parse(c string) (amount uint64, denom string, err error) {
+	parsed := parseRe.FindStringSubmatch(c)
+
+	if len(parsed) != 3 {
+		return 0, "", errInvalidCoin
+	}
+
+	amountStr := parsed[1]
+	denom = parsed[2]
+
+	amount, err = strconv.ParseUint(amountStr, 10, 64)
+	if err != nil {
+		return 0, "", errInvalidCoin
+	}
+
+	return
+}

--- a/starport/pkg/cosmoscoin/coin_test.go
+++ b/starport/pkg/cosmoscoin/coin_test.go
@@ -1,0 +1,19 @@
+package cosmoscoin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	amount, denom, err := Parse("100token")
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), amount)
+	require.Equal(t, "token", denom)
+}
+
+func TestParseInvalid(t *testing.T) {
+	_, _, err := Parse("!100token")
+	require.Equal(t, errInvalidCoin, err)
+}

--- a/starport/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/starport/pkg/cosmosfaucet/cosmosfaucet.go
@@ -30,9 +30,6 @@ type Faucet struct {
 	// accountName to transfer tokens from.
 	accountName string
 
-	// accountAddress to transfer tokens from.
-	accountAddress string
-
 	// accountMnemonic is the mnemonic of the account.
 	accountMnemonic string
 
@@ -93,17 +90,12 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 		apply(&f)
 	}
 
-	account, err := f.runner.AddAccount(ctx, f.accountName, f.accountMnemonic)
-	if err != nil && err != chaincmdrunner.ErrAccountAlreadyExists {
-		return Faucet{}, err
+	if f.accountMnemonic != "" {
+		_, err := f.runner.AddAccount(ctx, f.accountName, f.accountMnemonic)
+		if err != nil && err != chaincmdrunner.ErrAccountAlreadyExists {
+			return Faucet{}, err
+		}
 	}
-
-	account, err = f.runner.ShowAccount(ctx, f.accountName)
-	if err != nil {
-		return Faucet{}, err
-	}
-
-	f.accountAddress = account.Address
 
 	return f, nil
 }

--- a/starport/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/starport/pkg/cosmosfaucet/cosmosfaucet.go
@@ -90,6 +90,7 @@ func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Fau
 		apply(&f)
 	}
 
+	// import the account if mnemonic is provided.
 	if f.accountMnemonic != "" {
 		_, err := f.runner.AddAccount(ctx, f.accountName, f.accountMnemonic)
 		if err != nil && err != chaincmdrunner.ErrAccountAlreadyExists {

--- a/starport/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/starport/pkg/cosmosfaucet/cosmosfaucet.go
@@ -1,0 +1,109 @@
+// Package cosmosfaucet is a faucet to request tokens for sdk accounts.
+package cosmosfaucet
+
+import (
+	"context"
+
+	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
+)
+
+const (
+	// DefaultAccountName is the default account to transfer tokens from.
+	DefaultAccountName = "faucet"
+
+	// DefaultDenom is the default denomination to distribute.
+	DefaultDenom = "uatom"
+
+	// DefaultCreditAmount specifies the default amount to transfer to an account
+	// on each request.
+	DefaultCreditAmount = 10000000
+
+	// DefaultMaxCredit specifies the maximum amount that can be tranffered to an
+	// account in all times.
+	DefaultMaxCredit = 100000000
+)
+
+type Faucet struct {
+	// runner used to intereact with blockchain's binary to transfer tokens.
+	runner chaincmdrunner.Runner
+
+	// accountName to transfer tokens from.
+	accountName string
+
+	// accountAddress to transfer tokens from.
+	accountAddress string
+
+	// accountMnemonic is the mnemonic of the account.
+	accountMnemonic string
+
+	// denom is denomination of the coin to be distributed by the faucet.
+	denom string
+
+	// creditAmount is the amount to credit in each request.
+	creditAmount uint64
+
+	// maxCredit is the maximum credit per account.
+	maxCredit uint64
+}
+
+// Option configures the faucetOptions.
+type Option func(*Faucet)
+
+// Account provides the account information to transfer tokens from.
+// when mnemonic isn't provided, account assumed to be exists in the keyring.
+func Account(name, mnemonic string) Option {
+	return func(f *Faucet) {
+		f.accountName = name
+		f.accountMnemonic = mnemonic
+	}
+}
+
+// Denom set the denomination of the coin to be distributed by the faucet.
+func Denom(denom string) Option {
+	return func(f *Faucet) {
+		f.denom = denom
+	}
+}
+
+// CreditAmount sets the amount to credit in each request.
+func CreditAmount(credit uint64) Option {
+	return func(f *Faucet) {
+		f.creditAmount = credit
+	}
+}
+
+// MaxCredit sets the maximum credit per account.
+func MaxCredit(credit uint64) Option {
+	return func(f *Faucet) {
+		f.maxCredit = credit
+	}
+}
+
+// New creates a new faucet with ccr (to access and use blockchain's CLI) and given options.
+func New(ctx context.Context, ccr chaincmdrunner.Runner, options ...Option) (Faucet, error) {
+	f := Faucet{
+		runner:       ccr,
+		accountName:  DefaultAccountName,
+		denom:        DefaultDenom,
+		creditAmount: DefaultCreditAmount,
+		maxCredit:    DefaultMaxCredit,
+	}
+
+	for _, apply := range options {
+		apply(&f)
+	}
+
+	account, err := f.runner.AddAccount(ctx, f.accountName, f.accountMnemonic)
+	if err != nil && err != chaincmdrunner.ErrAccountAlreadyExists {
+		return Faucet{}, err
+	}
+
+	account, err = f.runner.ShowAccount(ctx, f.accountName)
+	if err != nil {
+		return Faucet{}, err
+	}
+
+	f.accountAddress = account.Address
+
+	return f, nil
+}

--- a/starport/pkg/cosmosfaucet/http.go
+++ b/starport/pkg/cosmosfaucet/http.go
@@ -1,0 +1,64 @@
+package cosmosfaucet
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/cors"
+	"github.com/tendermint/starport/starport/pkg/xhttp"
+)
+
+const (
+	statusOK    = "ok"
+	statusError = "error"
+)
+
+type transferRequest struct {
+	AccountAddress string `json:"address"`
+}
+
+type transferResponse struct {
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+func (f Faucet) handler(w http.ResponseWriter, r *http.Request) {
+	var req transferRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		xhttp.ResponseJSON(w, http.StatusBadRequest, transferResponse{
+			Status: statusError,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	amount := fmt.Sprintf("%d%s", f.creditAmount, f.denom)
+
+	if err := f.Transfer(r.Context(), req.AccountAddress, amount); err != nil {
+		xhttp.ResponseJSON(w, http.StatusInternalServerError, transferResponse{
+			Status: statusError,
+			Error:  err.Error(),
+		})
+		return
+	}
+
+	xhttp.ResponseJSON(w, http.StatusOK, transferResponse{
+		Status: statusOK,
+	})
+}
+
+// ServeHTTP implements http.Handler to expose the functionality of Faucet.Transfer() via HTTP.
+// request/response payloads are compatible with the previous implementation at allinbits/cosmos-faucet.
+func (f Faucet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		xhttp.ResponseJSON(w, http.StatusMethodNotAllowed, transferResponse{
+			Status: statusError,
+			Error:  "method not allowed",
+		})
+		return
+	}
+
+	cors.Default().Handler(http.HandlerFunc(f.handler)).ServeHTTP(w, r)
+}

--- a/starport/pkg/cosmosfaucet/http.go
+++ b/starport/pkg/cosmosfaucet/http.go
@@ -1,6 +1,7 @@
 package cosmosfaucet
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -74,6 +75,10 @@ func (f Faucet) handler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := f.Transfer(r.Context(), req.AccountAddress, coin.amount, coin.denom); err != nil {
+			if err == context.Canceled {
+				return
+			}
+
 			t.Status = statusError
 			t.Error = err.Error()
 		}

--- a/starport/pkg/cosmosfaucet/http.go
+++ b/starport/pkg/cosmosfaucet/http.go
@@ -52,6 +52,7 @@ func (f Faucet) handler(w http.ResponseWriter, r *http.Request) {
 // ServeHTTP implements http.Handler to expose the functionality of Faucet.Transfer() via HTTP.
 // request/response payloads are compatible with the previous implementation at allinbits/cosmos-faucet.
 func (f Faucet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// check method.
 	if r.Method != http.MethodPost {
 		xhttp.ResponseJSON(w, http.StatusMethodNotAllowed, transferResponse{
 			Status: statusError,
@@ -60,5 +61,6 @@ func (f Faucet) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// add CORS.
 	cors.Default().Handler(http.HandlerFunc(f.handler)).ServeHTTP(w, r)
 }

--- a/starport/pkg/cosmosfaucet/transfer.go
+++ b/starport/pkg/cosmosfaucet/transfer.go
@@ -9,6 +9,7 @@ import (
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 )
 
+// TotalTransferredAmount returns the total transferred amount from faucet account to toAccountAddress.
 func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress string) (amount uint64, err error) {
 	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)
 	if err != nil {
@@ -38,6 +39,7 @@ func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress str
 	return amount, nil
 }
 
+// Transfer transfer amount of tokens from the faucet account to toAccountAddress.
 func (f Faucet) Transfer(ctx context.Context, toAccountAddress, amount string) error {
 	totalSent, err := f.TotalTransferredAmount(ctx, toAccountAddress)
 	if err != nil {

--- a/starport/pkg/cosmosfaucet/transfer.go
+++ b/starport/pkg/cosmosfaucet/transfer.go
@@ -45,7 +45,6 @@ func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress, de
 
 // Transfer transfer amount of tokens from the faucet account to toAccountAddress.
 func (f Faucet) Transfer(ctx context.Context, toAccountAddress string, amount uint64, denom string) error {
-	coin := f.coinByDenom(denom)
 	amountStr := fmt.Sprintf("%d%s", amount, denom)
 
 	totalSent, err := f.TotalTransferredAmount(ctx, toAccountAddress, denom)
@@ -53,8 +52,8 @@ func (f Faucet) Transfer(ctx context.Context, toAccountAddress string, amount ui
 		return err
 	}
 
-	if coin.maxAmount != 0 && totalSent >= coin.maxAmount {
-		return fmt.Errorf("account has reached maximum credit allowed per account (%d)", coin.maxAmount)
+	if f.coinsMax[denom] != 0 && totalSent >= f.coinsMax[denom] {
+		return fmt.Errorf("account has reached maximum credit allowed per account (%d)", f.coinsMax[denom])
 	}
 
 	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)

--- a/starport/pkg/cosmosfaucet/transfer.go
+++ b/starport/pkg/cosmosfaucet/transfer.go
@@ -10,8 +10,13 @@ import (
 )
 
 func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress string) (amount uint64, err error) {
+	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)
+	if err != nil {
+		return 0, err
+	}
+
 	events, err := f.runner.QueryTxEvents(ctx,
-		chaincmdrunner.NewEventSelector("message", "sender", f.accountAddress),
+		chaincmdrunner.NewEventSelector("message", "sender", fromAccount.Address),
 		chaincmdrunner.NewEventSelector("transfer", "recipient", toAccountAddress))
 	if err != nil {
 		return 0, err
@@ -43,5 +48,10 @@ func (f Faucet) Transfer(ctx context.Context, toAccountAddress, amount string) e
 		return fmt.Errorf("account has reached maximum credit allowed per account (%d)", f.maxCredit)
 	}
 
-	return f.runner.BankSend(ctx, f.accountAddress, toAccountAddress, amount)
+	fromAccount, err := f.runner.ShowAccount(ctx, f.accountName)
+	if err != nil {
+		return err
+	}
+
+	return f.runner.BankSend(ctx, fromAccount.Address, toAccountAddress, amount)
 }

--- a/starport/pkg/cosmosfaucet/transfer.go
+++ b/starport/pkg/cosmosfaucet/transfer.go
@@ -1,0 +1,47 @@
+package cosmosfaucet
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
+)
+
+func (f Faucet) TotalTransferredAmount(ctx context.Context, toAccountAddress string) (amount uint64, err error) {
+	events, err := f.runner.QueryTxEvents(ctx,
+		chaincmdrunner.NewEventSelector("message", "sender", f.accountAddress),
+		chaincmdrunner.NewEventSelector("transfer", "recipient", toAccountAddress))
+	if err != nil {
+		return 0, err
+	}
+
+	for _, event := range events {
+		if event.Type == "transfer" {
+			for _, attr := range event.Attributes {
+				if attr.Key == "amount" {
+					amountStr := strings.TrimRight(attr.Value, f.denom)
+					if a, err := strconv.ParseUint(amountStr, 10, 64); err == nil {
+						amount += a
+					}
+				}
+			}
+		}
+	}
+
+	return amount, nil
+}
+
+func (f Faucet) Transfer(ctx context.Context, toAccountAddress, amount string) error {
+	totalSent, err := f.TotalTransferredAmount(ctx, toAccountAddress)
+	if err != nil {
+		return err
+	}
+
+	if totalSent >= f.maxCredit {
+		return fmt.Errorf("account has reached maximum credit allowed per account (%d)", f.maxCredit)
+	}
+
+	return f.runner.BankSend(ctx, f.accountAddress, toAccountAddress, amount)
+}

--- a/starport/pkg/fswatcher/fswatcher.go
+++ b/starport/pkg/fswatcher/fswatcher.go
@@ -110,11 +110,10 @@ func (w *watcher) listen() {
 	}
 }
 
-func (w *watcher) addPaths(paths ...string) error {
+func (w *watcher) addPaths(paths ...string) {
 	for _, path := range paths {
 		w.wt.AddRecursive(filepath.Join(w.workdir, path))
 	}
-	return nil
 }
 
 func (w *watcher) isFileIgnored(path string) bool {

--- a/starport/pkg/fswatcher/fswatcher.go
+++ b/starport/pkg/fswatcher/fswatcher.go
@@ -112,9 +112,7 @@ func (w *watcher) listen() {
 
 func (w *watcher) addPaths(paths ...string) error {
 	for _, path := range paths {
-		if err := w.wt.AddRecursive(filepath.Join(w.workdir, path)); err != nil {
-			return err
-		}
+		w.wt.AddRecursive(filepath.Join(w.workdir, path))
 	}
 	return nil
 }

--- a/starport/pkg/xhttp/server.go
+++ b/starport/pkg/xhttp/server.go
@@ -1,0 +1,30 @@
+package xhttp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// ShutdownTimeout is the timeout for waiting all requests to complete.
+const ShutdownTimeout = time.Minute
+
+// Serve starts s server and shutdowns it once the ctx is cancelled.
+func Serve(ctx context.Context, s *http.Server) error {
+	go func() {
+		<-ctx.Done()
+
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)
+		defer cancel()
+
+		s.Shutdown(shutdownCtx)
+	}()
+
+	err := s.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+
+	return err
+}

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -98,7 +98,7 @@ func HomePath(path string) Option {
 }
 
 // New initializes a new Chain with options that its source lives at path.
-func New(path string, options ...Option) (*Chain, error) {
+func New(ctx context.Context, path string, options ...Option) (*Chain, error) {
 	app, err := NewAppAt(path)
 	if err != nil {
 		return nil, err
@@ -164,7 +164,10 @@ func New(path string, options ...Option) (*Chain, error) {
 			chaincmdrunner.CLILogPrefix(c.genPrefix(logAppcli)),
 		)
 	}
-	c.cmd = chaincmdrunner.New(cc, ccroptions...)
+	c.cmd, err = chaincmdrunner.New(ctx, cc, ccroptions...)
+	if err != nil {
+		return nil, err
+	}
 
 	return c, nil
 }

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -182,15 +182,16 @@ func New(ctx context.Context, path string, options ...Option) (*Chain, error) {
 		)
 	}
 
+	config, err := c.Config()
+	if err != nil {
+		return nil, err
+	}
+
 	// use keyring backend if specified
 	if c.options.keyringBackend != chaincmd.KeyringBackendUnspecified {
 		ccoptions = append(ccoptions, chaincmd.WithKeyringBackend(c.options.keyringBackend))
 	} else {
 		// check if keyring backend is specified in config
-		config, err := c.Config()
-		if err != nil {
-			return nil, err
-		}
 		if config.Init.KeyringBackend != "" {
 			configKeyringBackend, err := chaincmd.KeyringBackendFromString(config.Init.KeyringBackend)
 			if err != nil {

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -29,6 +29,11 @@ var (
 			FrontendAddr: "localhost:8080",
 			DevUIAddr:    "localhost:12345",
 		},
+		Faucet: Faucet{
+			Denom:     "token",
+			Credit:    10,
+			MaxCredit: 100,
+		},
 	}
 )
 
@@ -37,6 +42,7 @@ var (
 type Config struct {
 	Accounts  []Account              `yaml:"accounts"`
 	Validator Validator              `yaml:"validator"`
+	Faucet    Faucet                 `yaml:"faucet"`
 	Init      Init                   `yaml:"init"`
 	Genesis   map[string]interface{} `yaml:"genesis"`
 	Servers   Servers                `yaml:"servers"`
@@ -66,6 +72,16 @@ type Account struct {
 type Validator struct {
 	Name   string `yaml:"name"`
 	Staked string `yaml:"staked"`
+}
+
+// Faucet configuration.
+type Faucet struct {
+	// Name is faucet account's name.
+	Name *string `yaml:"name"`
+
+	Denom     string `yaml:"denom"`
+	Credit    uint64 `yaml:"credit"`
+	MaxCredit uint64 `yaml:"max_credit"`
 }
 
 // Init overwrites sdk configurations with given values.

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -30,9 +30,7 @@ var (
 			DevUIAddr:    "0.0.0.0:12345",
 		},
 		Faucet: Faucet{
-			Port:     4500,
-			Coins:    []string{"10token"},
-			CoinsMax: []string{"100token"},
+			Port: 4500,
 		},
 	}
 )

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -30,6 +30,7 @@ var (
 			DevUIAddr:    "localhost:12345",
 		},
 		Faucet: Faucet{
+			Port:      4500,
 			Denom:     "token",
 			Credit:    10,
 			MaxCredit: 100,
@@ -76,6 +77,9 @@ type Validator struct {
 
 // Faucet configuration.
 type Faucet struct {
+	// Port number for faucet server to listen at.
+	Port int `yaml:"port"`
+
 	// Name is faucet account's name.
 	Name *string `yaml:"name"`
 

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -30,10 +30,9 @@ var (
 			DevUIAddr:    "localhost:12345",
 		},
 		Faucet: Faucet{
-			Port:      4500,
-			Denom:     "token",
-			Credit:    10,
-			MaxCredit: 100,
+			Port:     4500,
+			Coins:    []string{"10token"},
+			CoinsMax: []string{"100token"},
 		},
 	}
 )
@@ -83,9 +82,12 @@ type Faucet struct {
 	// Name is faucet account's name.
 	Name *string `yaml:"name"`
 
-	Denom     string `yaml:"denom"`
-	Credit    uint64 `yaml:"credit"`
-	MaxCredit uint64 `yaml:"max_credit"`
+	// Coins holds type of coin denoms and amounts to distribute.
+	Coins []string `yaml:"coins"`
+
+	// CoinsMax holds of chain denoms and their max amounts that can be transferred
+	// to single user.
+	CoinsMax []string `yaml:"coins_max"`
 }
 
 // Init overwrites sdk configurations with given values.

--- a/starport/services/chain/conf/config.go
+++ b/starport/services/chain/conf/config.go
@@ -23,11 +23,11 @@ var (
 		Servers: Servers{
 			RPCAddr:      "0.0.0.0:26657",
 			P2PAddr:      "0.0.0.0:26656",
-			ProfAddr:     "localhost:6060",
+			ProfAddr:     "0.0.0.0:6060",
 			GRPCAddr:     "0.0.0.0:9090",
 			APIAddr:      "0.0.0.0:1317",
-			FrontendAddr: "localhost:8080",
-			DevUIAddr:    "localhost:12345",
+			FrontendAddr: "0.0.0.0:8080",
+			DevUIAddr:    "0.0.0.0:12345",
 		},
 		Faucet: Faucet{
 			Port:     4500,

--- a/starport/services/chain/dev.go
+++ b/starport/services/chain/dev.go
@@ -67,7 +67,7 @@ type Config struct {
 }
 
 // newDevHandler creates a new development server handler for app by given conf.
-func newDevHandler(app App, conf Config, faucetHandler, grpcwebHandler http.Handler) (http.Handler, error) {
+func newDevHandler(app App, conf Config, grpcwebHandler http.Handler) (http.Handler, error) {
 	uifs, err := fs.New()
 	if err != nil {
 		return nil, err
@@ -83,11 +83,6 @@ func newDevHandler(app App, conf Config, faucetHandler, grpcwebHandler http.Hand
 	router := mux.NewRouter()
 	router.Handle("/status", cors(dev.statusHandler())).Methods(http.MethodGet)
 	router.PathPrefix("/grpc").Handler(http.StripPrefix("/grpc", grpcwebHandler))
-
-	if faucetHandler != nil {
-		router.Handle("/faucet", faucetHandler)
-	}
-
 	router.PathPrefix("/").Handler(cors(dev.devAssetsHandler())).Methods(http.MethodGet)
 
 	return router, nil

--- a/starport/services/chain/dev.go
+++ b/starport/services/chain/dev.go
@@ -67,7 +67,7 @@ type Config struct {
 }
 
 // newDevHandler creates a new development server handler for app by given conf.
-func newDevHandler(app App, conf Config, grpcwebHandler http.Handler) (http.Handler, error) {
+func newDevHandler(app App, conf Config, faucetHandler, grpcwebHandler http.Handler) (http.Handler, error) {
 	uifs, err := fs.New()
 	if err != nil {
 		return nil, err
@@ -83,6 +83,11 @@ func newDevHandler(app App, conf Config, grpcwebHandler http.Handler) (http.Hand
 	router := mux.NewRouter()
 	router.Handle("/status", cors(dev.statusHandler())).Methods(http.MethodGet)
 	router.PathPrefix("/grpc").Handler(http.StripPrefix("/grpc", grpcwebHandler))
+
+	if faucetHandler != nil {
+		router.Handle("/faucet", faucetHandler)
+	}
+
 	router.PathPrefix("/").Handler(cors(dev.devAssetsHandler())).Methods(http.MethodGet)
 
 	return router, nil

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -12,14 +12,15 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
+	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
 	"github.com/tendermint/starport/starport/pkg/fswatcher"
 	"github.com/tendermint/starport/starport/pkg/xexec"
+	"github.com/tendermint/starport/starport/pkg/xhttp"
 	"github.com/tendermint/starport/starport/pkg/xos"
 	"github.com/tendermint/starport/starport/pkg/xurl"
 	"github.com/tendermint/starport/starport/services/chain/conf"
@@ -60,6 +61,7 @@ func (c *Chain) Serve(ctx context.Context) error {
 	g.Go(func() error {
 		return c.runDevServer(ctx)
 	})
+
 	g.Go(func() error {
 		c.refreshServe()
 		for {
@@ -229,17 +231,46 @@ func (c *Chain) serve(ctx context.Context) error {
 func (c *Chain) start(ctx context.Context, conf conf.Config) error {
 	g, ctx := errgroup.WithContext(ctx)
 
+	// start the blockchain.
 	g.Go(func() error { return c.plugin.Start(ctx, c.Commands(), conf) })
 
-	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a Cosmos '%[1]v' app with Tendermint at %s.\n", c.app.Name, xurl.HTTP(conf.Servers.RPCAddr))
-	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a server at %s (LCD)\n", xurl.HTTP(conf.Servers.APIAddr))
-	fmt.Fprintf(c.stdLog(logStarport).out, "\n🚀 Get started: %s\n\n", xurl.HTTP(conf.Servers.DevUIAddr))
-
+	// run relayer.
 	go func() {
 		if err := c.initRelayer(ctx, conf); err != nil && ctx.Err() == nil {
 			fmt.Fprintf(c.stdLog(logStarport).err, "could not init relayer: %s", err)
 		}
 	}()
+
+	// start the faucet if enabled.
+	var isFaucedEnabled bool
+
+	if conf.Faucet.Name != nil {
+		if _, err := c.cmd.ShowAccount(ctx, *conf.Faucet.Name); err != nil {
+			if err == chaincmdrunner.ErrAccountDoesNotExist {
+				return &CannotBuildAppError{errors.Wrap(err, "faucet account doesn't exist")}
+			}
+			return err
+		}
+
+		isFaucedEnabled = true
+
+		g.Go(func() (err error) {
+			if err := c.runFaucetServer(ctx); err != nil {
+				return &CannotBuildAppError{err}
+			}
+			return nil
+		})
+	}
+
+	// print the server addresses.
+	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a Cosmos '%[1]v' app with Tendermint at %s.\n", c.app.Name, xurl.HTTP(conf.Servers.RPCAddr))
+	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a server at %s (LCD)\n", xurl.HTTP(conf.Servers.APIAddr))
+
+	if isFaucedEnabled {
+		fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a faucet at http://localhost:%d\n", conf.Faucet.Port)
+	}
+
+	fmt.Fprintf(c.stdLog(logStarport).out, "\n🚀 Get started: %s\n\n", xurl.HTTP(conf.Servers.DevUIAddr))
 
 	return g.Wait()
 }
@@ -296,24 +327,6 @@ func (c *Chain) runDevServer(ctx context.Context) error {
 		return err
 	}
 
-	var faucet http.Handler
-
-	if config.Faucet.Name != nil {
-		if _, err := c.cmd.ShowAccount(ctx, *config.Faucet.Name); err != nil {
-			return errors.Wrap(err, "faucet account doesn't exist")
-		}
-
-		faucet, err = cosmosfaucet.New(ctx, c.cmd,
-			cosmosfaucet.Account(*config.Faucet.Name, ""),
-			cosmosfaucet.Denom(config.Faucet.Denom),
-			cosmosfaucet.CreditAmount(config.Faucet.Credit),
-			cosmosfaucet.MaxCredit(config.Faucet.MaxCredit),
-		)
-		if err != nil {
-			return err
-		}
-	}
-
 	grpcconn, grpcHandler, err := newGRPCWebProxyHandler(config.Servers.GRPCAddr)
 	if err != nil {
 		return err
@@ -326,27 +339,37 @@ func (c *Chain) runDevServer(ctx context.Context) error {
 		AppBackendAddr:  xurl.HTTP(config.Servers.APIAddr),
 		AppFrontendAddr: xurl.HTTP(config.Servers.FrontendAddr),
 	} // TODO get vals from const
-	handler, err := newDevHandler(c.app, conf, faucet, grpcHandler)
+	handler, err := newDevHandler(c.app, conf, grpcHandler)
 	if err != nil {
 		return err
 	}
-	sv := &http.Server{
+
+	return xhttp.Serve(ctx, &http.Server{
 		Addr:    config.Servers.DevUIAddr,
 		Handler: handler,
+	})
+}
+
+func (c *Chain) runFaucetServer(ctx context.Context) error {
+	config, err := c.Config()
+	if err != nil {
+		return err
 	}
 
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancel()
-		sv.Shutdown(shutdownCtx)
-	}()
-
-	err = sv.ListenAndServe()
-	if errors.Is(err, http.ErrServerClosed) {
-		return nil
+	faucet, err := cosmosfaucet.New(ctx, c.cmd,
+		cosmosfaucet.Account(*config.Faucet.Name, ""),
+		cosmosfaucet.Denom(config.Faucet.Denom),
+		cosmosfaucet.CreditAmount(config.Faucet.Credit),
+		cosmosfaucet.MaxCredit(config.Faucet.MaxCredit),
+	)
+	if err != nil {
+		return err
 	}
-	return err
+
+	return xhttp.Serve(ctx, &http.Server{
+		Addr:    fmt.Sprintf(":%d", config.Faucet.Port),
+		Handler: faucet,
+	})
 }
 
 type CannotBuildAppError struct {

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -368,20 +368,21 @@ func (c *Chain) runFaucetServer(ctx context.Context) error {
 			return fmt.Errorf("%s: %s", err, coin)
 		}
 
+		var amountMax uint64
+
 		// find out the max amount for this coin.
 		for _, coinMax := range config.Faucet.CoinsMax {
-			amountMax, denomMax, err := cosmoscoin.Parse(coinMax)
+			var denomMax string
+			amountMax, denomMax, err = cosmoscoin.Parse(coinMax)
 			if err != nil {
 				return fmt.Errorf("%s: %s", err, coin)
 			}
-
-			if denomMax != denom {
-				continue
+			if denomMax == denom {
+				break
 			}
-
-			faucetOptions = append(faucetOptions, cosmosfaucet.Coin(amount, amountMax, denom))
-			break
 		}
+
+		faucetOptions = append(faucetOptions, cosmosfaucet.Coin(amount, amountMax, denom))
 	}
 
 	faucet, err := cosmosfaucet.New(ctx, c.cmd, faucetOptions...)

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -372,12 +372,12 @@ func (c *Chain) runFaucetServer(ctx context.Context) error {
 
 		// find out the max amount for this coin.
 		for _, coinMax := range config.Faucet.CoinsMax {
-			var denomMax string
-			amountMax, denomMax, err = cosmoscoin.Parse(coinMax)
+			amount, denomMax, err := cosmoscoin.Parse(coinMax)
 			if err != nil {
 				return fmt.Errorf("%s: %s", err, coin)
 			}
 			if denomMax == denom {
+				amountMax = amount
 				break
 			}
 		}

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -391,7 +391,7 @@ func (c *Chain) runFaucetServer(ctx context.Context) error {
 	}
 
 	return xhttp.Serve(ctx, &http.Server{
-		Addr:    fmt.Sprintf(":%d", config.Faucet.Port),
+		Addr:    fmt.Sprintf("0.0.0.0:%d", config.Faucet.Port),
 		Handler: faucet,
 	})
 }

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -43,7 +43,7 @@ func newBlockchain(ctx context.Context, builder *Builder, chainID, appPath, url,
 func (b *Blockchain) init(ctx context.Context, chainID string, mustNotInitializedBefore bool) error {
 	b.builder.ev.Send(events.New(events.StatusOngoing, "Initializing the blockchain"))
 
-	c, err := chain.New(b.appPath,
+	c, err := chain.New(ctx, b.appPath,
 		chain.ID(chainID),
 		chain.LogLevel(chain.LogSilent),
 	)

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -298,7 +298,7 @@ func (b *Builder) StartChain(ctx context.Context, chainID string, flags []string
 	}
 
 	appPath := filepath.Join(sourcePath, chainID)
-	chainHandler, err := chain.New(appPath, chain.LogLevel(chain.LogSilent))
+	chainHandler, err := chain.New(ctx, appPath, chain.LogLevel(chain.LogSilent))
 	if err != nil {
 		return err
 	}

--- a/starport/services/networkbuilder/simulation.go
+++ b/starport/services/networkbuilder/simulation.go
@@ -46,7 +46,7 @@ func (b *Builder) VerifyProposals(ctx context.Context, chainID string, proposals
 	defer os.RemoveAll(tmpHome)
 
 	appPath := filepath.Join(sourcePath, chainID)
-	chainHandler, err := chain.New(appPath,
+	chainHandler, err := chain.New(ctx, appPath,
 		chain.HomePath(tmpHome),
 		chain.LogLevel(chain.LogSilent),
 	)


### PR DESCRIPTION
to transfer tokens from the faucet account to the requester account.

refactoring code from the original implementation: https://github.com/allinbits/cosmos-faucet.

related to https://github.com/tendermint/starport/issues/570.

the faucet server runs via Starport's Dev server and it is reachable through `/faucet` endpoint.

usage:

```yaml
...
faucet:
        name: user1
...
```

And then make a _JSON_ `POST` req with following payload:
_http://localhost:12345/faucet_
```
{
    "address": "..."
}
```