### PR TITLE
docs: config.yml and --sdk-version

### DIFF
--- a/docs/1 Introduction/1 Introduction.md
+++ b/docs/1 Introduction/1 Introduction.md
@@ -6,9 +6,9 @@ Let us dive into Starport, what we can achieve with it, and which other technolo
 
 Starport is a tool that makes it easier to create blockchains.
 
-Starport uses the Tendermint Consensus engine and the Cosmos SDK to create a blockchain application in the Go programming language. This blockchain has a Proof-of-Stake system with validators (https://en.longhash.com/news/how-cosmos-governance-works-and-how-you-can-become-a-validator) that can be defined in the genesis block.
+Starport uses the Tendermint Consensus engine and the Cosmos SDK to create a blockchain application in the Go programming language. This blockchain has a Proof-of-Stake system with validators that can be defined in the genesis block.
 
-With just a few command lines, you can create a blockchain, launch it, serve it on the cloud and have a GUI ready to start testing your application.
+With just a few commands, you can create a blockchain, launch it, serve it on the cloud and have a GUI ready to start testing your application.
 
 Bootstrapping blockchains was initially the job of the `scaffold` program, which was used to create a blockchain application. Starport takes it to the next level and also creates a user interface with Vue.js, which provides a good starting point for developers creating a browser-based client-side application for your blockchain.
 
@@ -40,6 +40,6 @@ Many of the live blockchains use multiple Cosmos modules. The foundational modul
 ## Summary
 
 - Starport lets you create, develop, and build a blockchain.
-- Starport and Cosmos are written in Go.
+- Starport and Cosmos SDK are written in Go.
 - Today, Cosmos SDK has a unique position worldwide as one of the most successful blockchains.
 - Developers can use different Cosmos SDK modules to customize their blockchain.

--- a/docs/1 Introduction/2 Install.md
+++ b/docs/1 Introduction/2 Install.md
@@ -24,7 +24,7 @@ git clone https://github.com/tendermint/starport && cd starport && make
 
 This will build and install `starport` binary into `$GOBIN`.
 
-Note: When building from source, it is important to have your `$GOPATH` set correctly.  When in doubt, the folllowing should do:
+Note: When building from source, it is important to have your `$GOPATH` set correctly.  When in doubt, the following should do:
 
 ```
 mkdir ~/go

--- a/docs/1 Introduction/3 Quickstart.md
+++ b/docs/1 Introduction/3 Quickstart.md
@@ -1,19 +1,21 @@
 # Quickstart
 
-With `starport` installed on your machine, you can now build your very first blockchain application!
+With `starport` installed on your machine, you can now build your very first blockchain!
 
-```bash
+```
 starport app github.com/username/myapp && cd myapp
 ```
 
-Serve the blockchain application
+This command will create a directory `myapp` and scaffold a Cosmos SDK blockchain.
 
-```bash
+```
 starport serve
 ```
 
-Add a new transaction type to your application
+`serve` will install dependencies, build, initialise and run your blokchain.
 
-```bash
+```
 starport type post title body
 ```
+
+`type` scaffolds functionality to create, read, update and delete for a custom type.

--- a/docs/1 Introduction/4 Configuration.md
+++ b/docs/1 Introduction/4 Configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-When creating a new app with starport, you will see a `config.yml` file in your blockchain application folder. This file defines the genesis file, the network you will be using and the first validators of your blockchain.
+When creating a new app with starport, you will see a `config.yml` file in your blockchain folder. This file defines the genesis file, the network you will be using and the first validators of your blockchain.
 
 Let us examine the parts of the configuration of this file.
 

--- a/docs/2 Architecture/1 Introduction.md
+++ b/docs/2 Architecture/1 Introduction.md
@@ -14,9 +14,10 @@ To create a blockchain application we use the command `app`
 starport app github.com/username/myapp
 ```
 
-| Flag               | Default  | Description                |
-| ------------------ | -------- | -------------------------- |
-| `--address-prefix` | `cosmos` | Prefix, used for addresses |
+| Flag               | Default    | Description                                      |
+| ------------------ | ---------- | ------------------------------------------------ |
+| `--address-prefix` | `cosmos`   | Prefix, used for addresses                       |
+| `--sdk-version`    | `stargate` | Version of Cosmos SDK: `launchpad` or `stargate` |
 
 This will create the folder `myapp` and is a usable blockchain blueprint. If you want to dive directly into looking at the details of your blockchain you can run it with entering your `myapp` folder and use the command `serve` to initialise your blockchain and start it.
 

--- a/docs/2 Architecture/5 Configuration.md
+++ b/docs/2 Architecture/5 Configuration.md
@@ -1,0 +1,90 @@
+# Configuration
+
+With Starport your blockchain can be configured with `config.yml`.
+
+## `accounts`
+
+A list of user accounts created during genesis of your application.
+
+| Key   | Required | Type            | Description                                       |
+| ----- | -------- | --------------- | ------------------------------------------------- |
+| name  | Y        | String          | Local name of a key pair                          |
+| coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
+
+### Example
+
+```yaml
+accounts:
+  - name: alice
+    coins: ["1000token", "100000000stake"]
+  - name: bob
+    coins: ["500token"]
+```
+
+## `validator`
+
+A blockchain has to have at least one validator-node. `validator` specifies the account that will be used to initialize the validator and parameters of the validator.
+
+| Key    | Required | Type   | Description                                                                       |
+| ------ | -------- | ------ | --------------------------------------------------------------------------------- |
+| name   | Y        | String | Name of a key pair. `name` must be in `accounts`                                  |
+| staked | Y        | String | Amount of coins to bond. Must be less or equal to the amount of coins account has |
+
+### Example
+
+```yaml
+accounts:
+  - name: alice
+    coins: ["1000token", "100000000stake"]
+validator:
+  name: user1
+  staked: "100000000stake"
+```
+
+## `init.home`
+
+A blockchain stores data and configuration in a data directory. This property specifies a path to the data directory.
+
+### Example
+
+```yaml
+init:
+  home: "~/.myblockchain"
+```
+
+## `init.config`
+
+Overwrites properties in `config/config.toml` in the data directory.
+
+## `init.app`
+
+Overwrites properties in `config/app.toml` in the data directory.
+
+## `init.keyring-backend`
+
+Specifies a [keyring backend](https://docs.cosmos.network/master/run-node/keyring.html).
+
+### Example
+
+```yaml
+init:
+  keyring-backend: "os"
+```
+
+## `genesis`
+
+Overwrites properties in `config.genesis.json` in the data directory.
+
+### Example
+
+```yaml
+genesis:
+  chain-id: "foobar"
+```
+
+## Learn more
+
+- [Starport](https://github.com/tendermint/starport)
+- [Cosmos SDK documentation](https://docs.cosmos.network)
+- [Cosmos Tutorials](https://tutorials.cosmos.network)
+- [Channel on Discord](https://discord.gg/W8trcGV)


### PR DESCRIPTION
Added more info about how to configure a chain with `config.yml` and about `--sdk-version` flag. Some of the properties of `config.yml` are omitted on purpose (like server ports), because I don't think they should be considered "public" yet.

close https://github.com/tendermint/starport/issues/644