### PR TITLE
feat(scaffolder): run fmt on scaffolder commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20210113000019-eaf3bda374d2 // indirect
+	golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -928,8 +928,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210113000019-eaf3bda374d2 h1:F9vNgpIiamoF+Q1/c78bikg/NScXEtbZSNEpnRelOzs=
-golang.org/x/sys v0.0.0-20210113000019-eaf3bda374d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78 h1:nVuTkr9L6Bq62qpUqKo/RnZCFfzDBL0bYo6w9OJUqZY=
+golang.org/x/sys v0.0.0-20210113181707-4bcb84eeeb78/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/starport/services/scaffolder/init.go
+++ b/starport/services/scaffolder/init.go
@@ -39,12 +39,23 @@ func (s *Scaffolder) Init(name string) (path string, err error) {
 		return "", err
 	}
 	absRoot := filepath.Join(pwd, pathInfo.Root)
+
+	// create the project
 	if err := s.generate(pathInfo, absRoot); err != nil {
 		return "", err
 	}
+
+	// generate protobuf types
 	if err := s.protoc(absRoot, s.options.sdkVersion); err != nil {
 		return "", err
 	}
+
+	// format the source
+	if err := fmtProject(absRoot); err != nil {
+		return "", err
+	}
+
+	// initialize git repository and perform the first commit
 	if err := initGit(pathInfo.Root); err != nil {
 		return "", err
 	}

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -70,7 +70,10 @@ func (s *Scaffolder) CreateModule(moduleName string) error {
 	if err != nil {
 		return err
 	}
-	return s.protoc(pwd, version)
+	if err := s.protoc(pwd, version); err != nil {
+		return err
+	}
+	return fmtProject(pwd)
 }
 
 // ImportModule imports specified module with name to the scaffolded app.
@@ -109,7 +112,14 @@ func (s *Scaffolder) ImportModule(name string) error {
 	}
 	run := genny.WetRunner(context.Background())
 	run.With(g)
-	return run.Run()
+	if err := run.Run(); err != nil {
+		return err
+	}
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	return fmtProject(pwd)
 }
 
 func ModuleExists(appPath string, moduleName string) (bool, error) {

--- a/starport/services/scaffolder/scaffolder.go
+++ b/starport/services/scaffolder/scaffolder.go
@@ -3,6 +3,10 @@
 package scaffolder
 
 import (
+	"context"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+	"os"
 	"strings"
 
 	"github.com/tendermint/starport/starport/pkg/cosmosver"
@@ -35,4 +39,21 @@ func (s *Scaffolder) version() (cosmosver.MajorVersion, error) {
 
 func owner(modulePath string) string {
 	return strings.Split(modulePath, "/")[1]
+}
+
+func fmtProject(path string) error {
+	return cmdrunner.
+		New(
+			cmdrunner.DefaultStderr(os.Stderr),
+			cmdrunner.DefaultWorkdir(path),
+		).
+		Run(context.Background(),
+			step.New(
+				step.Exec(
+					"go",
+					"fmt",
+					"./...",
+				),
+			),
+		)
 }

--- a/starport/services/scaffolder/scaffolder.go
+++ b/starport/services/scaffolder/scaffolder.go
@@ -4,10 +4,11 @@ package scaffolder
 
 import (
 	"context"
-	"github.com/tendermint/starport/starport/pkg/cmdrunner"
-	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"os"
 	"strings"
+
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 
 	"github.com/tendermint/starport/starport/pkg/cosmosver"
 )

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -127,7 +127,10 @@ func (s *Scaffolder) AddType(moduleName string, stype string, fields ...string) 
 	if err != nil {
 		return err
 	}
-	return s.protoc(pwd, version)
+	if err := s.protoc(pwd, version); err != nil {
+		return err
+	}
+	return fmtProject(pwd)
 }
 
 func isTypeCreated(appPath, moduleName, typeName string) (isCreated bool, err error) {


### PR DESCRIPTION
The scaffolded generate code sometimes badly indented and on `starport app` we have a badly intended code that is automatically committed.
We run `go fmt` on the project so that the source is always well formatted.