### PR TITLE
feat(cmd): build proto in build cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/gobuffalo/plushgen v0.1.2
 	github.com/goccy/go-yaml v1.8.0
 	github.com/google/go-cmp v0.5.2 // indirect
-	github.com/google/uuid v1.1.2
 	github.com/gookit/color v1.2.7
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -23,6 +23,10 @@ func (c *Chain) Build(ctx context.Context) error {
 		return err
 	}
 
+	if err := c.buildProto(ctx); err != nil {
+		return err
+	}
+
 	steps, err := c.buildSteps()
 	if err != nil {
 		return err


### PR DESCRIPTION
Seems like standalone `starport build` command wasn't building proto. This PR solves that.