### PR TITLE
fix: change "frontend" to "vue" in gitignore

### DIFF
--- a/starport/templates/app/stargate/.gitignore
+++ b/starport/templates/app/stargate/.gitignore
@@ -1,4 +1,3 @@
-frontend/node_modules
-frontend/dist
-frontend/.cache
+vue/node_modules
+vue/dist
 secret.yml


### PR DESCRIPTION
We used to have `frontend`, but now it's `vue`.