### PR TITLE
feat(cmd): add faucet command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 // indirect
+	golang.org/x/sys v0.0.0-20210122093101-04d7465088b8 // indirect
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154 // indirect
 	google.golang.org/grpc v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -936,8 +936,8 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210122093101-04d7465088b8 h1:de2yTH1xuxjmGB7i6Z5o2z3RCHVa0XlpSZzjd8Fe6bE=
+golang.org/x/sys v0.0.0-20210122093101-04d7465088b8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/starport/interface/cli/starport/cmd/cmd.go
+++ b/starport/interface/cli/starport/cmd/cmd.go
@@ -35,6 +35,7 @@ func New() *cobra.Command {
 	c.AddCommand(NewApp())
 	c.AddCommand(NewType())
 	c.AddCommand(NewServe())
+	c.AddCommand(NewFaucet())
 	c.AddCommand(NewBuild())
 	c.AddCommand(NewModule())
 	c.AddCommand(NewRelayer())

--- a/starport/interface/cli/starport/cmd/faucet.go
+++ b/starport/interface/cli/starport/cmd/faucet.go
@@ -1,0 +1,60 @@
+package starportcmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/chaincmd"
+	"github.com/tendermint/starport/starport/pkg/cosmoscoin"
+	"github.com/tendermint/starport/starport/services/chain"
+)
+
+// NewFaucet creates a new faucet command to send coins to accounts.
+func NewFaucet() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "faucet [address] [coin<,...>]",
+		Short: "Send coins to an account",
+		Args:  cobra.ExactArgs(2),
+		RunE:  faucetHandler,
+	}
+	c.Flags().AddFlagSet(flagSetHomes())
+	c.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
+	c.Flags().BoolP("verbose", "v", false, "Verbose output")
+	return c
+}
+
+func faucetHandler(cmd *cobra.Command, args []string) error {
+	var (
+		toAddress = args[0]
+		coins     = args[1]
+	)
+
+	chainOption := []chain.Option{
+		chain.LogLevel(logLevel(cmd)),
+		chain.KeyringBackend(chaincmd.KeyringBackendTest),
+	}
+
+	c, err := newChainWithHomeFlags(cmd, appPath, chainOption...)
+	if err != nil {
+		return err
+	}
+
+	faucet, err := c.Faucet(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	for _, coin := range strings.Split(coins, ",") {
+		amount, denom, err := cosmoscoin.Parse(coin)
+		if err != nil {
+			return fmt.Errorf("%s: %s", err, coin)
+		}
+		if err := faucet.Transfer(cmd.Context(), toAddress, amount, denom); err != nil {
+			return err
+		}
+	}
+
+	fmt.Println("📨 Coins sent.")
+	return nil
+}

--- a/starport/pkg/chaincmd/runner/account.go
+++ b/starport/pkg/chaincmd/runner/account.go
@@ -87,7 +87,8 @@ func (r Runner) ShowAccount(ctx context.Context, name string) (Account, error) {
 	b := &bytes.Buffer{}
 
 	if err := r.run(ctx, runOptions{stdout: b}, r.cc.ShowKeyAddressCommand(name)); err != nil {
-		if strings.Contains(err.Error(), "item could not be found") {
+		if strings.Contains(err.Error(), "item could not be found") ||
+			strings.Contains(err.Error(), "not a valid name or address") {
 			return Account{}, ErrAccountDoesNotExist
 		}
 		return Account{}, err

--- a/starport/services/chain/faucet.go
+++ b/starport/services/chain/faucet.go
@@ -1,0 +1,72 @@
+package chain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
+	"github.com/tendermint/starport/starport/pkg/cosmoscoin"
+	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
+)
+
+var (
+	// ErrFaucetIsNotEnabled is returned when faucet is not enabled in the config.yml.
+	ErrFaucetIsNotEnabled = errors.New("faucet is not enabled in the config.yml")
+
+	// ErrFaucetAccountDoesNotExist returned when specified faucet account in the config.yml does not exist.
+	ErrFaucetAccountDoesNotExist = errors.New("specified account (faucet.name) does not exist")
+)
+
+// Faucet returns the faucet for the chain or an error if the faucet
+// configuration is wrong or not configured (not enabled) at all.
+func (c *Chain) Faucet(ctx context.Context) (cosmosfaucet.Faucet, error) {
+	conf, err := c.Config()
+	if err != nil {
+		return cosmosfaucet.Faucet{}, err
+	}
+
+	// validate if the faucet initialization in the config.yml is correct.
+	if conf.Faucet.Name == nil {
+		return cosmosfaucet.Faucet{}, ErrFaucetIsNotEnabled
+	}
+
+	if _, err := c.cmd.ShowAccount(ctx, *conf.Faucet.Name); err != nil {
+		if err == chaincmdrunner.ErrAccountDoesNotExist {
+			return cosmosfaucet.Faucet{}, ErrFaucetAccountDoesNotExist
+		}
+		return cosmosfaucet.Faucet{}, err
+	}
+
+	// construct faucet options.
+	faucetOptions := []cosmosfaucet.Option{
+		cosmosfaucet.Account(*conf.Faucet.Name, ""),
+	}
+
+	// parse coins to pass to the faucet as coins.
+	for _, coin := range conf.Faucet.Coins {
+		amount, denom, err := cosmoscoin.Parse(coin)
+		if err != nil {
+			return cosmosfaucet.Faucet{}, fmt.Errorf("%s: %s", err, coin)
+		}
+
+		var amountMax uint64
+
+		// find out the max amount for this coin.
+		for _, coinMax := range conf.Faucet.CoinsMax {
+			amount, denomMax, err := cosmoscoin.Parse(coinMax)
+			if err != nil {
+				return cosmosfaucet.Faucet{}, fmt.Errorf("%s: %s", err, coin)
+			}
+			if denomMax == denom {
+				amountMax = amount
+				break
+			}
+		}
+
+		faucetOptions = append(faucetOptions, cosmosfaucet.Coin(amount, amountMax, denom))
+	}
+
+	// init the faucet with options and return.
+	return cosmosfaucet.New(ctx, c.cmd, faucetOptions...)
+}

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -19,10 +19,8 @@ import (
 	"github.com/pkg/errors"
 	conf "github.com/tendermint/starport/starport/chainconf"
 	secretconf "github.com/tendermint/starport/starport/chainconf/secret"
-	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
-	"github.com/tendermint/starport/starport/pkg/cosmoscoin"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
 	"github.com/tendermint/starport/starport/pkg/fswatcher"
 	"github.com/tendermint/starport/starport/pkg/xexec"
@@ -279,20 +277,21 @@ func (c *Chain) start(ctx context.Context, conf conf.Config) error {
 	}()
 
 	// start the faucet if enabled.
-	var isFaucedEnabled bool
+	var (
+		faucet, err     = c.Faucet(ctx)
+		isFaucetEnabled = err != ErrFaucetIsNotEnabled
+	)
 
-	if conf.Faucet.Name != nil {
-		if _, err := c.cmd.ShowAccount(ctx, *conf.Faucet.Name); err != nil {
-			if err == chaincmdrunner.ErrAccountDoesNotExist {
-				return &CannotBuildAppError{errors.Wrap(err, "faucet account doesn't exist")}
-			}
+	if isFaucetEnabled {
+		if err == ErrFaucetAccountDoesNotExist {
+			return &CannotBuildAppError{errors.Wrap(err, "faucet account doesn't exist")}
+		}
+		if err != nil {
 			return err
 		}
 
-		isFaucedEnabled = true
-
 		g.Go(func() (err error) {
-			if err := c.runFaucetServer(ctx); err != nil {
+			if err := c.runFaucetServer(ctx, faucet); err != nil {
 				return &CannotBuildAppError{err}
 			}
 			return nil
@@ -306,7 +305,7 @@ func (c *Chain) start(ctx context.Context, conf conf.Config) error {
 	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a Cosmos '%[1]v' app with Tendermint at %s.\n", c.app.Name, xurl.HTTP(conf.Servers.RPCAddr))
 	fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a server at %s (LCD)\n", xurl.HTTP(conf.Servers.APIAddr))
 
-	if isFaucedEnabled {
+	if isFaucetEnabled {
 		fmt.Fprintf(c.stdLog(logStarport).out, "🌍 Running a faucet at http://localhost:%d\n", conf.Faucet.Port)
 	}
 
@@ -390,47 +389,14 @@ func (c *Chain) runDevServer(ctx context.Context) error {
 	})
 }
 
-func (c *Chain) runFaucetServer(ctx context.Context) error {
-	config, err := c.Config()
-	if err != nil {
-		return err
-	}
-
-	faucetOptions := []cosmosfaucet.Option{
-		cosmosfaucet.Account(*config.Faucet.Name, ""),
-	}
-
-	// parse coins to pass to the faucet as coins.
-	for _, coin := range config.Faucet.Coins {
-		amount, denom, err := cosmoscoin.Parse(coin)
-		if err != nil {
-			return fmt.Errorf("%s: %s", err, coin)
-		}
-
-		var amountMax uint64
-
-		// find out the max amount for this coin.
-		for _, coinMax := range config.Faucet.CoinsMax {
-			amount, denomMax, err := cosmoscoin.Parse(coinMax)
-			if err != nil {
-				return fmt.Errorf("%s: %s", err, coin)
-			}
-			if denomMax == denom {
-				amountMax = amount
-				break
-			}
-		}
-
-		faucetOptions = append(faucetOptions, cosmosfaucet.Coin(amount, amountMax, denom))
-	}
-
-	faucet, err := cosmosfaucet.New(ctx, c.cmd, faucetOptions...)
+func (c *Chain) runFaucetServer(ctx context.Context, faucet cosmosfaucet.Faucet) error {
+	conf, err := c.Config()
 	if err != nil {
 		return err
 	}
 
 	return xhttp.Serve(ctx, &http.Server{
-		Addr:    fmt.Sprintf("0.0.0.0:%d", config.Faucet.Port),
+		Addr:    fmt.Sprintf("0.0.0.0:%d", conf.Faucet.Port),
 		Handler: faucet,
 	})
 }


### PR DESCRIPTION
to transfer coins from the configured faucet in the app's `config.yml` to the target account.

In order `starport faucet` to work, chain needs to be served first via `starport serve`.

Sample usage:
```
$ starport faucet -p ./mars [to-account-address] 100token,10stake
```