### PR TITLE
fix: Rpi ci

### DIFF
--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -9,4 +9,4 @@ RUN useradd --create-home starport && \
 
 
 # later, update to tendermint/starport
-COPY --from=tendermintdevelopment/starport /starport/build/starport /usr/bin/starport
+COPY --from=tendermintdevelopment/starport /go/bin/starport /usr/bin/starport


### PR DESCRIPTION
Closes #677

I changed some edging some things in the image build process, and it left the binary in a different place and now that is fixed.