### PR TITLE
feat: gh pages automation

### DIFF
--- a/starport/templates/app/launchpad/.github/workflows/pages.yml
+++ b/starport/templates/app/launchpad/.github/workflows/pages.yml
@@ -1,0 +1,25 @@
+name: Build and Deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          cd vue
+          npm install
+          npm run build
+          
+          
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: vue/dist # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/starport/templates/app/launchpad/readme.md.plush
+++ b/starport/templates/app/launchpad/readme.md.plush
@@ -23,13 +23,25 @@ A list of user accounts created during genesis of your application.
 | name  | Y        | String          | Local name of the key pair                        |
 | coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
 
+### UI on Github Pages
+
+Click the link below, and scroll down until you see it get her pages. Then, select the branch gh-pages.
+
+[Github Pages Setings](https://github.com/(<%= OwnerName %>/<%= AppName %>/settings/)
+
+After you do that you can visit your chain's UI at:
+
+https://<%= OwnerName %>.github.io/<%= AppName %>
+
+This is especially useful when you would like to rapidly iterate on a live user interface. Remember, each community member can have their own github pages instance, allowing your community to mix-and-match front ends.
+
 ### CI
 
 By default, this chain includes a github action that builds for amd64 and arm64 on Windows, Mac, and Linux.
 
 ### Docker Images And Pi Images
 
-In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as [secrets](https://github.com/(<%= OwnerName %>/<%= AppName %>/settings/secrets/actions)
+In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as [secrets](https://github.com/<%= OwnerName %>/<%= AppName %>/settings/secrets/actions)
 
 Add these:
 

--- a/starport/templates/app/stargate/.github/workflows/pages.yml
+++ b/starport/templates/app/stargate/.github/workflows/pages.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          cd vue
+          npm install
+          npm run build
+          
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: vue/dist # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/starport/templates/app/stargate/readme.md.plush
+++ b/starport/templates/app/stargate/readme.md.plush
@@ -23,6 +23,18 @@ A list of user accounts created during genesis of your application.
 | name  | Y        | String          | Local name of the key pair                        |
 | coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
 
+### UI on Github Pages
+
+Click the link below, and scroll down until you see it get her pages. Then, select the branch gh-pages.
+
+[Github Pages Setings](https://github.com/(<%= OwnerName %>/<%= AppName %>/settings/)
+
+After you do that you can visit your chain's UI at:
+
+https://<%= OwnerName %>.github.io/<%= AppName %>
+
+This is especially useful when you would like to rapidly iterate on a live user interface. Remember, each community member can have their own github pages instance, allowing your community to mix-and-match front ends.
+
 
 ### CI
 
@@ -30,7 +42,7 @@ By default, this chain includes a github action that builds for amd64 and arm64 
 
 ### Docker Images And Pi Images
 
-In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as [secrets](https://github.com/(<%= OwnerName %>/<%= AppName %>/settings/secrets/actions)
+In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as [secrets](https://github.com/<%= OwnerName %>/<%= AppName %>/settings/secrets/actions)
 
 Add these:
 


### PR DESCRIPTION
This ad get hub pages automation to both the Stargate and launchpad templates.

It's fully auto, the user does not need to click a thing.

Also adds an addendum to readme.md in generated chains telling users how to turn on github pages