### PR TITLE
fix(serve): change printed start error message

### DIFF
--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -178,7 +178,7 @@ func (c *Chain) Serve(ctx context.Context, options ...ServeOption) error {
 					fmt.Fprintf(c.stdLog(logStarport).out, "%s\n", infoColor("Waiting for a fix before retrying..."))
 				case errors.As(err, &startErr):
 					fmt.Fprintf(c.stdLog(logStarport).out, "%s %s\n", infoColor(`Blockchain failed to start.
-If the new code is no longer compatible with the saved state, you can reset the database by launching:`), "starport serve --force-reset")
+If the new code is no longer compatible with the saved state, you can reset the database by launching:`), "starport serve --reset-once")
 
 					return err
 				default:


### PR DESCRIPTION
Change `If the new code is no longer compatible with the saved state, you can reset the database by launching: starport serve --force-reset`

to:

`If the new code is no longer compatible with the saved state, you can reset the database by launching: starport serve --reset-once`

Because the user might not want to reset the state everytime if they just want to make the code compatible with the new dataformat