### PR TITLE
fix: starport network join not compatible with old scaffolded chain

### DIFF
--- a/starport/pkg/chaincmd/chaincmd.go
+++ b/starport/pkg/chaincmd/chaincmd.go
@@ -241,7 +241,6 @@ func (c ChainCmd) AddGenesisAccountCommand(address string, coins string) step.Op
 		address,
 		coins,
 	}
-	command = c.attachKeyringBackend(command)
 
 	return c.daemonCommand(command)
 }
@@ -365,6 +364,8 @@ func (c ChainCmd) GentxCommand(
 	if c.sdkVersion.Major().Is(cosmosver.Stargate) {
 		command = c.attachChainID(command)
 	}
+
+	command = c.attachKeyringBackend(command)
 
 	return c.daemonCommand(command)
 }

--- a/starport/pkg/chaincmd/chaincmd.go
+++ b/starport/pkg/chaincmd/chaincmd.go
@@ -366,8 +366,6 @@ func (c ChainCmd) GentxCommand(
 		command = c.attachChainID(command)
 	}
 
-	command = c.attachKeyringBackend(command)
-
 	return c.daemonCommand(command)
 }
 


### PR DESCRIPTION
Remove the `keyring-backend` value provided in the `add-genesis-account` command to be compatible with old scaffolded chain interface.

This option is only used when you want to add a genesis account from a key name. This is a feature that is for now not used by the CLI (and I don't it will) therefore we can simply remove the option.