### PR TITLE
docs: readme in scaffold and config reference

### DIFF
--- a/docs/2 Architecture/5 Configuration.md
+++ b/docs/2 Architecture/5 Configuration.md
@@ -6,10 +6,11 @@ With Starport your blockchain can be configured with `config.yml`.
 
 A list of user accounts created during genesis of your application.
 
-| Key   | Required | Type            | Description                                       |
-| ----- | -------- | --------------- | ------------------------------------------------- |
-| name  | Y        | String          | Local name of a key pair                          |
-| coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
+| Key     | Required | Type            | Description                                       |
+| ------- | -------- | --------------- | ------------------------------------------------- |
+| name    | Y        | String          | Local name of a key pair                          |
+| coins   | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
+| address | N        | String          | Address of the account in bech32                  |
 
 ### Example
 
@@ -19,6 +20,49 @@ accounts:
     coins: ["1000token", "100000000stake"]
   - name: bob
     coins: ["500token"]
+    address: cosmos1adn9gxjmrc3hrsdx5zpc9sj2ra7kgqkmphf8yw
+```
+
+## `build`
+
+| Key    | Required | Type   | Description                                                     |
+| ------ | -------- | ------ | --------------------------------------------------------------- |
+| binary | N        | String | Name of the node binary that will be built and used by Starport |
+
+## Example
+
+```yaml
+build:
+  binary: "mychaind"
+```
+
+## `build.proto`
+
+| Key               | Required | Type            | Description                                                                                 |
+| ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------- |
+| path              | N        | String          | Path to protocol buffer files (default: `"proto"`)                                          |
+| third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files (default: `["third_party/proto", "proto_vendor"]`) |
+
+
+## `faucet`
+
+A faucet service that sends tokens to addresses. Web UI is available by default on http://localhost:4500.
+
+| Key       | Required | Type            | Description                                      |
+| --------- | -------- | --------------- | ------------------------------------------------ |
+| name      | Y        | String          | Name of a key pair. `name` must be in `accounts` |
+| coins     | Y        | List of Strings | Coins with denominations sent per request        |
+| coins_max | N        | List of Strings | Maximum amount of tokens sent per address        |
+| port      | N        | Integer         | Port number (default: `4500`)                    |
+
+### Example
+
+```yaml
+faucet:
+  name: faucet
+  coins: ["100token", "5foo"]
+  coins_max: ["2000token", "1000foo"]
+  port: 4500
 ```
 
 ## `validator`

--- a/docs/6 Extra/CI.md
+++ b/docs/6 Extra/CI.md
@@ -1,0 +1,16 @@
+# CI
+
+By default, a scaffolded blockchain includes a Github action that builds for amd64 and arm64 on Windows, Mac, and Linux.
+
+## Docker Images And Pi Images
+
+In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as secrets: https://github.com/{username}/{repository}/settings/secrets/actions
+
+Add these:
+
+```
+DOCKERHUB_USERNAME
+DOCKERHUB_TOKEN
+```
+
+You can get the token [here](https://hub.docker.com/settings/security).

--- a/docs/6 Extra/Web UI on Github Pages.md
+++ b/docs/6 Extra/Web UI on Github Pages.md
@@ -1,0 +1,11 @@
+### UI on Github Pages
+
+Click the link below, and scroll down until you see it get her pages. Then, select the branch gh-pages.
+
+Github Pages Setings: https://github.com/{username}/{repository}/settings/
+
+After you do that you can visit your chain's UI at:
+
+https://{username}.github.io/{repository}
+
+This is especially useful when you would like to rapidly iterate on a live user interface. Remember, each community member can have their own github pages instance, allowing your community to mix-and-match front ends.

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ starport serve
 
 ## Documentation
 
-To learn how to use Starport, check out the [Starport Documentation](/docs/README.md). To install Starport locally on GNU/Linux or macOS, follow [these steps](/docs/1%20Introduction/2%20Install.md).
+To learn how to use Starport, check out the [Starport Documentation](/docs/README.md). To learn more about how to customize your blockchain see `config.yml` [reference](/docs/2%20Architecture/5%20Configuration.md). To install Starport locally on GNU/Linux or macOS, follow [these steps](/docs/1%20Introduction/2%20Install.md).
 
 ## Questions
 

--- a/starport/templates/app/stargate/readme.md.plush
+++ b/starport/templates/app/stargate/readme.md.plush
@@ -1,6 +1,6 @@
 # <%= AppName %>
 
-**<%= AppName %>** is a blockchain application built using Cosmos SDK and Tendermint and generated with [Starport](https://github.com/tendermint/starport).
+**<%= AppName %>** is a blockchain built using Cosmos SDK and Tendermint and created with [Starport](https://github.com/tendermint/starport).
 
 ## Get started
 
@@ -8,53 +8,19 @@
 starport serve
 ```
 
-`serve` command installs dependencies, initializes and runs the application.
+`serve` command installs dependencies, builds, initializes and starts your blockchain in development.
 
 ## Configure
 
-Initialization parameters of your app are stored in `config.yml`.
+Your blockchain in development can be configured with `config.yml`. To learn more see the [reference](https://github.com/tendermint/starport#documentation).
 
-### `accounts`
+## Launch
 
-A list of user accounts created during genesis of your application.
-
-| Key   | Required | Type            | Description                                       |
-| ----- | -------- | --------------- | ------------------------------------------------- |
-| name  | Y        | String          | Local name of the key pair                        |
-| coins | Y        | List of Strings | Initial coins with denominations (e.g. "100coin") |
-
-### UI on Github Pages
-
-Click the link below, and scroll down until you see it get her pages. Then, select the branch gh-pages.
-
-[Github Pages Setings](https://github.com/(<%= OwnerName %>/<%= AppName %>/settings/)
-
-After you do that you can visit your chain's UI at:
-
-https://<%= OwnerName %>.github.io/<%= AppName %>
-
-This is especially useful when you would like to rapidly iterate on a live user interface. Remember, each community member can have their own github pages instance, allowing your community to mix-and-match front ends.
-
-
-### CI
-
-By default, this chain includes a github action that builds for amd64 and arm64 on Windows, Mac, and Linux.
-
-### Docker Images And Pi Images
-
-In order for Docker images and Raspberry Pi images to build successfully, please add your docker hub credentials as [secrets](https://github.com/<%= OwnerName %>/<%= AppName %>/settings/secrets/actions)
-
-Add these:
-
-DOCKERHUB_USERNAME
-DOCKERHUB_TOKEN
-
-You can get the token [here](https://hub.docker.com/settings/security)
-
+To launch your blockchain live on mutliple nodes use `starport network` commands. Learn more about [Starport Network](https://github.com/tendermint/spn).
 
 ## Learn more
 
 - [Starport](https://github.com/tendermint/starport)
 - [Cosmos SDK documentation](https://docs.cosmos.network)
-- [Cosmos Tutorials](https://tutorials.cosmos.network)
-- [Channel on Discord](https://discord.gg/W8trcGV)
+- [Cosmos SDK Tutorials](https://tutorials.cosmos.network)
+- [Discord](https://discord.gg/W8trcGV)


### PR DESCRIPTION
* Moved non-essential information from readme in `docs/Extras`
* Added faucet, build, etc. into the config reference (some properties, like server ports, are omitted, because we may reconsider their location in the future, let's consider them "private" for now)