### PR TITLE
fix: give a more descriptive error when the app fails to start with a known error

### DIFF
--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -16,12 +16,12 @@ import (
 
 // Start starts the blockchain.
 func (r Runner) Start(ctx context.Context, args ...string) error {
-	return r.run(ctx, runOptions{wrapStdErr: true, wrappedStdErrMaxLen: 50000}, r.cc.StartCommand(args...))
+	return r.run(ctx, runOptions{wrappedStdErrMaxLen: 50000}, r.cc.StartCommand(args...))
 }
 
 // LaunchpadStartRestServer start launchpad rest server.
 func (r Runner) LaunchpadStartRestServer(ctx context.Context, apiAddress, rpcAddress string) error {
-	return r.run(ctx, runOptions{}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
+	return r.run(ctx, runOptions{wrappedStdErrMaxLen: 50000}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
 }
 
 // Init inits the blockchain.

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -16,12 +16,12 @@ import (
 
 // Start starts the blockchain.
 func (r Runner) Start(ctx context.Context, args ...string) error {
-	return r.run(ctx, runOptions{longRunning: true}, r.cc.StartCommand(args...))
+	return r.run(ctx, runOptions{wrapStdErr: false}, r.cc.StartCommand(args...))
 }
 
 // LaunchpadStartRestServer start launchpad rest server.
 func (r Runner) LaunchpadStartRestServer(ctx context.Context, apiAddress, rpcAddress string) error {
-	return r.run(ctx, runOptions{longRunning: true}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
+	return r.run(ctx, runOptions{wrapStdErr: true}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
 }
 
 // Init inits the blockchain.

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -16,12 +16,12 @@ import (
 
 // Start starts the blockchain.
 func (r Runner) Start(ctx context.Context, args ...string) error {
-	return r.run(ctx, runOptions{wrapStdErr: false}, r.cc.StartCommand(args...))
+	return r.run(ctx, runOptions{wrapStdErr: true, wrappedStdErrMaxLen: 50000}, r.cc.StartCommand(args...))
 }
 
 // LaunchpadStartRestServer start launchpad rest server.
 func (r Runner) LaunchpadStartRestServer(ctx context.Context, apiAddress, rpcAddress string) error {
-	return r.run(ctx, runOptions{wrapStdErr: true}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
+	return r.run(ctx, runOptions{}, r.cc.LaunchpadRestServerCommand(apiAddress, rpcAddress))
 }
 
 // Init inits the blockchain.

--- a/starport/pkg/chaincmd/runner/runner.go
+++ b/starport/pkg/chaincmd/runner/runner.go
@@ -90,10 +90,8 @@ func (r Runner) Copy(options ...Option) Runner {
 }
 
 type runOptions struct {
-	// wrapStdErr wraps the error logs of the app into the returned error
-	wrapStdErr bool
-
 	// wrappedStdErrMaxLen determines the maximum length of the wrapped error logs
+	// this option is used for long running command to prevent the buffer containing stderr getting too big
 	// 0 can be used for no maximum length
 	wrappedStdErrMaxLen int
 
@@ -121,9 +119,7 @@ func (r Runner) run(ctx context.Context, roptions runOptions, soptions ...step.O
 		stderr = io.MultiWriter(stderr, roptions.stderr)
 	}
 
-	if roptions.wrapStdErr {
-		stderr = io.MultiWriter(stderr, errb)
-	}
+	stderr = io.MultiWriter(stderr, errb)
 
 	rnoptions := []cmdrunner.Option{
 		cmdrunner.DefaultStdout(stdout),
@@ -134,8 +130,5 @@ func (r Runner) run(ctx context.Context, roptions runOptions, soptions ...step.O
 		New(rnoptions...).
 		Run(ctx, step.New(soptions...))
 
-	if roptions.wrapStdErr {
-		return errors.Wrap(err, errb.GetBuffer().String())
-	}
-	return err
+	return errors.Wrap(err, errb.GetBuffer().String())
 }

--- a/starport/pkg/chaincmd/runner/runner.go
+++ b/starport/pkg/chaincmd/runner/runner.go
@@ -90,8 +90,8 @@ func (r Runner) Copy(options ...Option) Runner {
 }
 
 type runOptions struct {
-	// longRunning indicates that command expected to run for a long period of time.
-	longRunning bool
+	// wrapStdErr wraps the error logs of the app into the returned error
+	wrapStdErr bool
 
 	// stdout and stderr used to collect a copy of command's outputs.
 	stdout, stderr io.Writer
@@ -114,7 +114,7 @@ func (r Runner) run(ctx context.Context, roptions runOptions, soptions ...step.O
 		stderr = io.MultiWriter(stderr, roptions.stderr)
 	}
 
-	if !roptions.longRunning {
+	if !roptions.wrapStdErr {
 		stderr = io.MultiWriter(stderr, errb)
 	}
 

--- a/starport/pkg/truncatedbuffer/truncatedbuffer.go
+++ b/starport/pkg/truncatedbuffer/truncatedbuffer.go
@@ -43,7 +43,6 @@ func (b *TruncatedBuffer) Write(p []byte) (n int, err error) {
 
 	if b.cap > 0 && surplus > 0 {
 		b.buf.Truncate(b.cap)
-		n -= surplus
 	}
 
 	return n, nil

--- a/starport/pkg/truncatedbuffer/truncatedbuffer.go
+++ b/starport/pkg/truncatedbuffer/truncatedbuffer.go
@@ -1,0 +1,50 @@
+package truncatedbuffer
+
+import (
+	"bytes"
+)
+
+// TruncatedBuffer contains a bytes buffer that has a limited capacity
+// The buffer is truncated on Write if the length reaches the maximum capacity
+// Only the first bytes are preserved
+type TruncatedBuffer struct {
+	buf *bytes.Buffer
+	cap int
+}
+
+// NewTruncatedBuffer returns a new TruncatedBuffer
+// If the provided cap is 0, the truncated buffer has no limit for truncating
+func NewTruncatedBuffer(cap int) *TruncatedBuffer {
+	return &TruncatedBuffer{
+		buf: &bytes.Buffer{},
+		cap: cap,
+	}
+}
+
+// GetCap returns the buffer
+func (b TruncatedBuffer) GetBuffer() *bytes.Buffer {
+	return b.buf
+}
+
+// GetCap returns the maximum capacity of the buffer
+func (b TruncatedBuffer) GetCap() int {
+	return b.cap
+}
+
+// Write implements io.Writer
+func (b *TruncatedBuffer) Write(p []byte) (n int, err error) {
+	n, err = b.buf.Write(p)
+	if err != nil {
+		return n, err
+	}
+
+	// Check surplus bytes
+	surplus := b.buf.Len() - b.cap
+
+	if b.cap > 0 && surplus > 0 {
+		b.buf.Truncate(b.cap)
+		n = n - (surplus)
+	}
+
+	return n, nil
+}

--- a/starport/pkg/truncatedbuffer/truncatedbuffer.go
+++ b/starport/pkg/truncatedbuffer/truncatedbuffer.go
@@ -43,7 +43,7 @@ func (b *TruncatedBuffer) Write(p []byte) (n int, err error) {
 
 	if b.cap > 0 && surplus > 0 {
 		b.buf.Truncate(b.cap)
-		n = n - (surplus)
+		n -= surplus
 	}
 
 	return n, nil

--- a/starport/pkg/truncatedbuffer/truncatedbuffer_test.go
+++ b/starport/pkg/truncatedbuffer/truncatedbuffer_test.go
@@ -25,7 +25,7 @@ func TestWriter(t *testing.T) {
 
 	n, err = b.Write(ranBytes1000)
 	require.NoError(t, err)
-	require.Equal(t, 90, n)
+	require.Equal(t, 1000, n)
 	require.Equal(t, append(ranBytes10, ranBytes1000[:90]...), b.GetBuffer().Bytes())
 
 	// TruncatedBuffer has no max capacity

--- a/starport/pkg/truncatedbuffer/truncatedbuffer_test.go
+++ b/starport/pkg/truncatedbuffer/truncatedbuffer_test.go
@@ -1,0 +1,37 @@
+package truncatedbuffer
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriter(t *testing.T) {
+	ranBytes10 := make([]byte, 10)
+	rand.Read(ranBytes10)
+	ranBytes1000 := make([]byte, 1000)
+	rand.Read(ranBytes1000)
+
+	// TruncatedBuffer has a max capacity
+	b := NewTruncatedBuffer(100)
+
+	require.Equal(t, 100, b.GetCap())
+
+	n, err := b.Write(ranBytes10)
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+	require.Equal(t, ranBytes10, b.GetBuffer().Bytes())
+
+	n, err = b.Write(ranBytes1000)
+	require.NoError(t, err)
+	require.Equal(t, 90, n)
+	require.Equal(t, append(ranBytes10, ranBytes1000[:90]...), b.GetBuffer().Bytes())
+
+	// TruncatedBuffer has no max capacity
+	b = NewTruncatedBuffer(0)
+	n, err = b.Write(ranBytes1000)
+	require.NoError(t, err)
+	require.Equal(t, 1000, n)
+	require.Equal(t, ranBytes1000, b.GetBuffer().Bytes())
+}

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -198,7 +198,7 @@ func (c *Chain) Serve(ctx context.Context, options ...ServeOption) error {
 						fmt.Fprintf(c.stdLog(logStarport).out, "%s %s\n", infoColor(`Blockchain failed to start.
 If the new code is no longer compatible with the saved state, you can reset the database by launching:`), "starport serve --reset-once")
 
-						return fmt.Errorf("cannot run %s", err.AppName)
+						return fmt.Errorf("cannot run %s", startErr.AppName)
 					}
 
 					// return the clear parsed error

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -187,7 +187,6 @@ func (c *Chain) Serve(ctx context.Context, options ...ServeOption) error {
 					fmt.Fprintf(c.stdLog(logStarport).out, "%s\n", infoColor("Waiting for a fix before retrying..."))
 
 				case errors.As(err, &startErr):
-					err := err.(*CannotStartAppError)
 
 					// Parse returned error logs
 					parsedErr := err.ParseStartError()

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -189,7 +189,7 @@ func (c *Chain) Serve(ctx context.Context, options ...ServeOption) error {
 				case errors.As(err, &startErr):
 
 					// Parse returned error logs
-					parsedErr := err.ParseStartError()
+					parsedErr := startErr.ParseStartError()
 
 					// If empty, we cannot recognized the error
 					// Therefore, the error may be caused by a new logic that is not compatible with the old app state


### PR DESCRIPTION
The error logs from Cosmos SDK apps are too extensive, we cannot print them directly

When the app fails to start on `starport serve`:
- Parse the error log output
- Check for specific pattern
- If the error is recognized, print the error details
- If not, the error may be caused by an incompatible previous saved state