### PR TITLE
fix: no rebuild on second serve

### DIFF
--- a/starport/pkg/dirchange/dirchange.go
+++ b/starport/pkg/dirchange/dirchange.go
@@ -30,23 +30,24 @@ func SaveDirChecksum(workdir string, paths []string, checksumSavePath string, ch
 
 // HasDirChecksumChanged computes the md5 checksum of the provided paths (directories or files)
 // and compare it with the current saved checksum
-// If the checksum is different, the new checksum is saved
-// Return true if the checksum file doesn't exist yet and if checksumSavePath directory doesn't exist, it is created
+// Return true if the checksum file doesn't exist yet
 // paths are relative to workdir, if workdir is empty string paths are absolute
 func HasDirChecksumChanged(workdir string, paths []string, checksumSavePath string, checksumName string) (bool, error) {
-	checksum, err := checksumFromPaths(workdir, paths)
-	if err != nil {
-		return false, err
-	}
-
 	// create directory if needed
 	if err := os.MkdirAll(checksumSavePath, 0700); err != nil && !os.IsExist(err) {
 		return false, err
 	}
-
 	checksumFilePath := filepath.Join(checksumSavePath, checksumName)
 	if _, err := os.Stat(checksumFilePath); os.IsNotExist(err) {
-		return true, ioutil.WriteFile(checksumFilePath, checksum, 0644)
+		return true, nil
+	} else if err != nil {
+		return false, nil
+	}
+
+	// Compute checksum
+	checksum, err := checksumFromPaths(workdir, paths)
+	if err != nil {
+		return false, err
 	}
 
 	// Compare checksums
@@ -59,7 +60,7 @@ func HasDirChecksumChanged(workdir string, paths []string, checksumSavePath stri
 	}
 
 	// The checksum has changed
-	return true, ioutil.WriteFile(checksumFilePath, checksum, 0644)
+	return true, nil
 }
 
 // checksumFromPaths computes the md5 checksum from the provided paths

--- a/starport/pkg/dirchange/dirchange_test.go
+++ b/starport/pkg/dirchange/dirchange_test.go
@@ -126,27 +126,18 @@ func TestHasDirChecksumChanged(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, changed)
 
-	// Return true and create the checksum file if it doesn't exist
+	// Return true if it doesn't exist
 	newSaveDir, err := ioutil.TempDir(tempDir, TmpPattern)
 	require.NoError(t, err)
 	defer os.RemoveAll(newSaveDir)
 	changed, err = HasDirChecksumChanged("", paths, newSaveDir, ChecksumFile)
 	require.NoError(t, err)
 	require.True(t, changed)
-	require.FileExists(t, filepath.Join(newSaveDir, ChecksumFile))
-	fileContent, err = ioutil.ReadFile(filepath.Join(newSaveDir, ChecksumFile))
-	require.NoError(t, err)
-	require.Equal(t, newChecksum, fileContent)
 
-	// Return true and rewrite the checksum if it has been changed
+	// Return true if it has been changed
 	err = ioutil.WriteFile(filepath.Join(dir21, "bar"), randomBytes(20), 0644)
 	require.NoError(t, err)
 	changed, err = HasDirChecksumChanged("", paths, saveDir, ChecksumFile)
 	require.NoError(t, err)
 	require.True(t, changed)
-	fileContent, err = ioutil.ReadFile(filepath.Join(saveDir, ChecksumFile))
-	require.NoError(t, err)
-	newChecksum, err = checksumFromPaths("", paths)
-	require.NoError(t, err)
-	require.Equal(t, newChecksum, fileContent)
 }


### PR DESCRIPTION
Remove from`HasDirChecksumChanged` from `dirchange` the side effects, it doesn't save the checksum anymore.

Checksums of the source and config are only saved once the app is built and initialized