### PR TITLE
fix: type scaffolding fails if there is no vue dir

### DIFF
--- a/starport/templates/typed/new_launchpad.go
+++ b/starport/templates/typed/new_launchpad.go
@@ -2,6 +2,7 @@ package typed
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gobuffalo/genny"
@@ -190,6 +191,10 @@ func (t *typedLaunchpad) frontendSrcStoreAppModify(opts *Options) genny.RunFn {
 	return func(r *genny.Runner) error {
 		path := "vue/src/views/Index.vue"
 		f, err := r.Disk.Find(path)
+		if os.IsNotExist(err) {
+			// Skip modification if the app doesn't contain front-end
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/starport/templates/typed/new_stargate.go
+++ b/starport/templates/typed/new_stargate.go
@@ -31,8 +31,6 @@ func NewStargate(opts *Options) (*genny.Generator, error) {
 	g.RunFn(t.typesQueryModify(opts))
 	g.RunFn(t.keeperQueryModify(opts))
 	g.RunFn(t.clientRestRestModify(opts))
-
-
 	g.RunFn(t.frontendSrcStoreAppModify(opts))
 	t.genesisModify(opts, g)
 	return g, box(cosmosver.Stargate, opts, g)

--- a/starport/templates/typed/new_stargate.go
+++ b/starport/templates/typed/new_stargate.go
@@ -2,6 +2,7 @@ package typed
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/gertd/go-pluralize"
@@ -30,6 +31,8 @@ func NewStargate(opts *Options) (*genny.Generator, error) {
 	g.RunFn(t.typesQueryModify(opts))
 	g.RunFn(t.keeperQueryModify(opts))
 	g.RunFn(t.clientRestRestModify(opts))
+
+
 	g.RunFn(t.frontendSrcStoreAppModify(opts))
 	t.genesisModify(opts, g)
 	return g, box(cosmosver.Stargate, opts, g)
@@ -357,6 +360,10 @@ func (t *typedStargate) frontendSrcStoreAppModify(opts *Options) genny.RunFn {
 	return func(r *genny.Runner) error {
 		path := "vue/src/views/Index.vue"
 		f, err := r.Disk.Find(path)
+		if os.IsNotExist(err) {
+			// Skip modification if the app doesn't contain front-end
+			return nil
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Skip the frontend modification if the required path is not found instead of returning an error