### PR TITLE
fix: starport rpi dev env

### DIFF
--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -7,6 +7,15 @@ RUN useradd --create-home starport && \
         usermod --append --groups wheel starport && \
         passwd -e root
 
+USER starport
+
+# Setup $PATH & GOPATH for more seamlessness
+RUN mkdir /home/starport/go && \
+        echo "PATH=$PATH:/home/starport/go/bin" >> /home/starport/.bash_profile && \
+        echo "GOPATH=/home/starport/go"  >> /home/starport/.bash_profile
+
+USER root
+
 
 # later, update to tendermint/starport
 COPY --from=tendermintdevelopment/starport /go/bin/starport /usr/bin/starport

--- a/.pi/build.sh
+++ b/.pi/build.sh
@@ -10,7 +10,7 @@
 # * we are not offering as many choices to users and are designing around automation.
 # Later we can make this work for more devices and platforms with nearly the same technique.
 # Reasonable build targets include: https://archlinuxarm.org/platforms/armv8
-# For example, the Odroid-N2 is the same software-wise as our Router!
+# For example, the Odroid-C2 is the same software-wise as our Router!
 
 # Fail on error
 set -exo pipefail
@@ -46,31 +46,32 @@ sudo bash -c "echo starport > ./.tmp/result-rootfs/etc/hostname"
 # ===================================================================================
 
 
-# Unmount anything on the loop device (uncomment if building on metal)
+# Unmount anything on the loop device (uncomment if building on metal and "working in a loop")
 # sudo umount /dev/loop0p2 || true
 # sudo umount /dev/loop0p1 || true
 
-# Detach from the loop device (uncomment if building on metal)
+# Detach from the loop device (uncomment if building on metal and "working in a loop")
 # sudo losetup -d /dev/loop0 || true
 
-# Create a folder for images (uncomment if building on metal)
+# Create a folder for images (uncomment if building on metal and "working in a loop")
 # rm -rf images || true
 mkdir images
 
 # Make the image file
 fallocate -l 4G "images/starport.img"
 
+
 # loop-mount the image file so it becomes a disk
-export LOOPDISK=$(sudo losetup --find --show images/starport.img)
+export LOOP=$(sudo losetup --find --show images/starport.img)
 
 # partition the loop-mounted disk
-sudo parted --script $LOOPDISK mklabel msdos
-sudo parted --script $(echo $LOOPDISK)p1 mkpart primary fat32 0% 200M
-sudo parted --script $(echo $LOOPDISK)p2 mkpart primary ext4 200M 100%
+sudo parted --script $LOOP mklabel msdos
+sudo parted --script $LOOP mkpart primary fat32 0% 200M
+sudo parted --script $LOOP mkpart primary ext4 200M 100%
 
 # format the newly partitioned loop-mounted disk
-sudo mkfs.vfat -F32 $(echo $LOOPDISK)p1
-sudo mkfs.ext4 -F $(echo $LOOPDISK)p2
+sudo mkfs.vfat -F32 $(echo $LOOP)p1
+sudo mkfs.ext4 -F $(echo $LOOP)p2
 
 # Use the toolbox to copy the rootfs into the filesystem we formatted above.
 # * mount the disk's /boot and / partitions
@@ -79,12 +80,12 @@ sudo mkfs.ext4 -F $(echo $LOOPDISK)p2
 # soon will not use toolbox
 
 sudo mkdir -p mnt/boot mnt/rootfs
-sudo mount $(echo $LOOPDISK)p1 mnt/boot
-sudo mount $(echo $LOOPDISK)p2 mnt/rootfs
+sudo mount $(echo $LOOP)p1 mnt/boot
+sudo mount $(echo $LOOP)p2 mnt/rootfs
 sudo rsync -a ./.tmp/result-rootfs/boot/* mnt/boot
 sudo rsync -a ./.tmp/result-rootfs/* mnt/rootfs --exclude boot
 sudo mkdir mnt/rootfs/boot
-sudo umount mnt/boot mnt/rootfs || true
+sudo umount mnt/boot mnt/rootfs
 
 # Drop the loop mount (uncomment if building outside of Github Actions)
 # sudo losetup -d /dev/loop0


### PR DESCRIPTION
This fixes the build of the raspberry pi development environment.

Made the loopback device into a variable so that if there is a loopback device in use, there will not be any problems building. 

closes #726 