### PR TITLE
fix: rpi GOPATH and GOBIN 

### DIFF
--- a/.pi/Dockerfile
+++ b/.pi/Dockerfile
@@ -6,6 +6,15 @@ RUN useradd --create-home starport && \
         echo "starport:starport" | chpasswd && \
         usermod --append --groups wheel starport && \
         passwd -e root
+        
+USER starport
+
+# Setup $PATH & GOPATH for more seamlessness
+RUN mkdir /home/starport/go && \
+        echo "PATH=$PATH:/home/starport/go/bin" >> /home/starport/.bash_profile && \
+        echo "GOPATH=/home/starport/go"  >> /home/starport/.bash_profile
+
+USER root
 
 
 # later, update to tendermint/starport


### PR DESCRIPTION
closes #727 

This will allow users to boot the device and immediately use all Starport features. 