### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
 # INSTALL DEPENDENCIES
+RUN pacman -S archlinux-keyring
 RUN pacman -Syyu --noconfirm go npm make git which && \
 	mkdir /go
 
@@ -27,10 +28,10 @@ CMD ["/go/bin/starport"]
 # FROM gcr.io/distroless/base
 # COPY --from=builder /starport/build/starport /
 
-# EXPOSE 12345
-# EXPOSE 8080
-# EXPOSE 1317
-# EXPOSE 26656
-# EXPOSE 26657
+EXPOSE 12345
+EXPOSE 8080
+EXPOSE 1317
+EXPOSE 26656
+EXPOSE 26657
 
 # CMD ["/starport"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ FROM lopsided/archlinux
 ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
-# INSTALL DEPENDENCIES
-RUN rm /etc/pacman.d/gnupg && \
+# Ensure that there are no issues with pacman keys.  
+RUN rm -rf /etc/pacman.d/gnupg && \
 	pacman-key --init && \
 	pacman-key --populate archlinux
 	
 RUN pacman -Syy --noconfirm archlinux-keyring
 
+# INSTALL DEPENDENCIES
 RUN pacman -Syyu --noconfirm go npm make git which && \
 	mkdir /go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
 # INSTALL DEPENDENCIES
-RUN pacman -S --noconfirm archlinux-keyring
+RUN pacman -Syy --noconfirm archlinux-keyring
+
 RUN pacman -Syyu --noconfirm go npm make git which && \
 	mkdir /go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
 # INSTALL DEPENDENCIES
-RUN pacman -S archlinux-keyring
+RUN pacman -S --noconfirm archlinux-keyring
 RUN pacman -Syyu --noconfirm go npm make git which && \
 	mkdir /go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH=$PATH:/go/bin
 # Ensure that there are no issues with pacman keys.  
 RUN rm -rf /etc/pacman.d/gnupg && \
 	pacman-key --init && \
-	pacman-key --populate archlinux
+	pacman-key --populate archlinux || pacman-key --populate archlinuxarm
 	
 RUN pacman -Syy --noconfirm archlinux-keyring
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
 # INSTALL DEPENDENCIES
+RUN rm /etc/pacman.d/gnupg && \
+	pacman-key --init && \
+	pacman-key --populate archlinux
+	
 RUN pacman -Syy --noconfirm archlinux-keyring
 
 RUN pacman -Syyu --noconfirm go npm make git which && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,9 @@ ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 
 # Ensure that there are no issues with pacman keys.  
-RUN rm -rf /etc/pacman.d/gnupg && \
-	pacman-key --init && \
-	pacman-key --populate archlinux || pacman-key --populate archlinuxarm
+RUN pacman-key --refresh-keys
 	
-RUN pacman -Syy --noconfirm archlinux-keyring
+# RUN pacman -Syy --noconfirm archlinux-keyring
 
 # INSTALL DEPENDENCIES
 RUN pacman -Syyu --noconfirm go npm make git which && \


### PR DESCRIPTION
Added a new step to the Dockerfile that updates the keyring before updating the system. 

This may be a serious disadvantage of using Arch in a Docker image and I may look to use Alpine in docker in the future.

Another solution is to stop caching the Docker image build, and that may be preferable. 

Dockerfiles should be alpine.  This is not cool. 