### PR TITLE
fix: register Msg Service Desc in module codec

### DIFF
--- a/starport/templates/app/stargate/x/{{appName}}/types/codec.go.plush
+++ b/starport/templates/app/stargate/x/{{appName}}/types/codec.go.plush
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
     cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
     // this line is used by starport scaffolding # 1
+    "github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -12,6 +13,8 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
     // this line is used by starport scaffolding # 3
+
+    msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
 var (

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
@@ -4,6 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
     cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	// this line is used by starport scaffolding # 1
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
 )
 
 func RegisterCodec(cdc *codec.LegacyAmino) {
@@ -12,6 +13,8 @@ func RegisterCodec(cdc *codec.LegacyAmino) {
 
 func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 	// this line is used by starport scaffolding # 3
+
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
 var (


### PR DESCRIPTION
Add `RegisterMsgServiceDesc` in `RegisterInterfaces` of the module codec to register all type_urls from the messages into the registry