### PR TITLE
fix: add json output to launchpad send command on faucet

### DIFF
--- a/starport/pkg/chaincmd/chaincmd.go
+++ b/starport/pkg/chaincmd/chaincmd.go
@@ -437,6 +437,10 @@ func (c ChainCmd) BankSendCommand(fromAddress, toAddress, amount string) step.Op
 	command = c.attachKeyringBackend(command)
 	command = c.attachNode(command)
 
+	if c.sdkVersion.Major().Is(cosmosver.Launchpad) {
+		command = append(command, optionOutput, constJSON)
+	}
+
 	return c.cliCommand(command)
 }
 


### PR DESCRIPTION
This PR fixes tx send command on launchpad versions