### PR TITLE
fix: remove extra space from Welcome.vue 

### DIFF
--- a/starport/ui/src/views/Welcome.vue
+++ b/starport/ui/src/views/Welcome.vue
@@ -72,8 +72,7 @@
             target="_blank"
             class="-sp-c-txt-highlight"
             >Cosmos SDK</a
-          >
-          , a modular framework for building blockchains. Every feature in the
+          >, a modular framework for building blockchains. Every feature in the
           Cosmos SDK is packaged as a separate module that can interact with
           other modules. We've installed the
           <span>auth</span>, <span>bank</span>, and <span>staking</span> modules


### PR DESCRIPTION
I built my first blockchain and noticed we had an extra space before the comma