### PR TITLE
fix: link on welcome screen to go to docs not the repo

### DIFF
--- a/starport/ui/src/views/Welcome.vue
+++ b/starport/ui/src/views/Welcome.vue
@@ -68,7 +68,7 @@
         <p>
           Your blockchain is built with
           <a
-            href="https://github.com/cosmos/cosmos-sdk"
+            href="https://docs.cosmos.network/"
             target="_blank"
             class="-sp-c-txt-highlight"
             >Cosmos SDK</a


### PR DESCRIPTION
close https://github.com/tendermint/starport/issues/788
changed link to go to the docs href="https://docs.cosmos.network/