### PR TITLE
Updated link to ecosystem projects

### DIFF
--- a/docs/1 Introduction/1 Introduction.md
+++ b/docs/1 Introduction/1 Introduction.md
@@ -29,7 +29,7 @@ The following projects are using the technology:
 - [CosmWasm](https://cosmwasm.com/) (smart contracts using WASM)
 - [Ethermint](https://ethermint.zone/) (Ethereum virtual machine)
 
-[See the full list here](https://cosmonauts.world/).
+[See the full list here](https://cosmos.network/ecosystem/apps).
 
 ## Modules
 


### PR DESCRIPTION
Cosmonauts World is deprecated now, in favor of the new ecosystem page on the Cosmos website.