### PR TITLE
fix: prevent duplicated component name

### DIFF
--- a/starport/services/scaffolder/component.go
+++ b/starport/services/scaffolder/component.go
@@ -1,0 +1,91 @@
+package scaffolder
+
+import (
+	"go/token"
+	"os"
+	"path/filepath"
+)
+
+// isComponentCreated checks if the component has been already created with Starport in the project
+func isComponentCreated(appPath, moduleName, compName string) (bool, error) {
+	// Check for type, packet or message creation
+	created, err := isTypeCreated(appPath, moduleName, compName)
+	if err != nil {
+		return false, err
+	}
+	if created {
+		return created, nil
+	}
+	created, err = isPacketCreated(appPath, moduleName, compName)
+	if err != nil {
+		return false, err
+	}
+	if created {
+		return created, nil
+	}
+	return isMsgCreated(appPath, moduleName, compName)
+}
+
+// isMsgServerDefined checks if the module uses the MsgServer convention for transactions
+// this is checked by verifying the existence of the tx.proto file
+func isMsgServerDefined(appPath, moduleName string) (bool, error) {
+	txProto, err := filepath.Abs(filepath.Join(appPath, "proto", moduleName, "tx.proto"))
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := os.Stat(txProto); os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func isGoReservedWord(name string) bool {
+	// Check keyword or literal
+	if token.Lookup(name).IsKeyword() {
+		return true
+	}
+
+	// Check with builtin identifier
+	switch name {
+	case
+		"panic",
+		"recover",
+		"append",
+		"bool",
+		"byte",
+		"cap",
+		"close",
+		"complex",
+		"complex64",
+		"complex128",
+		"uint16",
+		"copy",
+		"false",
+		"float32",
+		"float64",
+		"imag",
+		"int",
+		"int8",
+		"int16",
+		"uint32",
+		"int32",
+		"int64",
+		"iota",
+		"len",
+		"make",
+		"new",
+		"nil",
+		"uint64",
+		"print",
+		"println",
+		"real",
+		"string",
+		"true",
+		"uint",
+		"uint8",
+		"uintptr":
+		return true
+	}
+	return false
+}

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -39,7 +39,7 @@ func (s *Scaffolder) AddMessage(moduleName string, msgName string, msgDesc strin
 
 	// Ensure the name is valid, otherwise it would generate an incorrect code
 	if isForbiddenComponentName(msgName) {
-		return fmt.Errorf("%s can't be used as a packet name", msgName)
+		return fmt.Errorf("%s can't be used as a message name", msgName)
 	}
 
 	// Check component name is not already used
@@ -124,7 +124,7 @@ func isMsgCreated(appPath, moduleName, msgName string) (isCreated bool, err erro
 
 	_, err = os.Stat(absPath)
 	if os.IsNotExist(err) {
-		// Packet doesn't exist
+		// Message doesn't exist
 		return false, nil
 	}
 

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -42,13 +42,13 @@ func (s *Scaffolder) AddMessage(moduleName string, msgName string, msgDesc strin
 		return fmt.Errorf("%s can't be used as a type name", msgName)
 	}
 
-	// Check msg is not already created
-	ok, err = isMsgCreated(s.path, moduleName, msgName)
+	// Check component name is not already used
+	ok, err = isComponentCreated(s.path, moduleName, msgName)
 	if err != nil {
 		return err
 	}
 	if ok {
-		return fmt.Errorf("%s message is already added", msgName)
+		return fmt.Errorf("%s component is already added", msgName)
 	}
 
 	// Parse provided fields

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -52,11 +52,11 @@ func (s *Scaffolder) AddMessage(moduleName string, msgName string, msgDesc strin
 	}
 
 	// Parse provided fields
-	parsedMsgFields, err := parseFields(fields)
+	parsedMsgFields, err := parseFields(fields, isForbiddenMessageField)
 	if err != nil {
 		return err
 	}
-	parsedResFields, err := parseFields(resField)
+	parsedResFields, err := parseFields(resField, isGoReservedWord)
 	if err != nil {
 		return err
 	}
@@ -109,6 +109,7 @@ func (s *Scaffolder) AddMessage(moduleName string, msgName string, msgDesc strin
 	return fmtProject(pwd)
 }
 
+// isMsgCreated checks if the message is already scaffolded
 func isMsgCreated(appPath, moduleName, msgName string) (isCreated bool, err error) {
 	absPath, err := filepath.Abs(filepath.Join(
 		appPath,
@@ -128,4 +129,13 @@ func isMsgCreated(appPath, moduleName, msgName string) (isCreated bool, err erro
 	}
 
 	return true, err
+}
+
+// isForbiddenTypeField returns true if the name is forbidden as a message name
+func isForbiddenMessageField(name string) bool {
+	if name == "creator" {
+		return true
+	}
+
+	return isGoReservedWord(name)
 }

--- a/starport/services/scaffolder/packet.go
+++ b/starport/services/scaffolder/packet.go
@@ -54,13 +54,13 @@ func (s *Scaffolder) AddPacket(moduleName string, packetName string, packetField
 		return fmt.Errorf("the module %s doesn't implement IBC module interface", moduleName)
 	}
 
-	// Check packet doesn't exist
-	ok, err = isPacketCreated(s.path, moduleName, packetName)
+	// Check component name is not already used
+	ok, err = isComponentCreated(s.path, moduleName, packetName)
 	if err != nil {
 		return err
 	}
 	if ok {
-		return fmt.Errorf("the packet %s already exist", packetName)
+		return fmt.Errorf("the component %s already exist", packetName)
 	}
 
 	// Parse packet fields

--- a/starport/services/scaffolder/packet.go
+++ b/starport/services/scaffolder/packet.go
@@ -64,13 +64,13 @@ func (s *Scaffolder) AddPacket(moduleName string, packetName string, packetField
 	}
 
 	// Parse packet fields
-	parsedPacketFields, err := parseFields(packetFields)
+	parsedPacketFields, err := parseFields(packetFields, isForbiddenPacketField)
 	if err != nil {
 		return err
 	}
 
 	// Parse acknowledgment fields
-	parsedAcksFields, err := parseFields(ackFields)
+	parsedAcksFields, err := parseFields(ackFields, isGoReservedWord)
 	if err != nil {
 		return err
 	}
@@ -139,4 +139,17 @@ func isPacketCreated(appPath, moduleName, packetName string) (isCreated bool, er
 	}
 
 	return true, err
+}
+
+// isForbiddenPacketField returns true if the name is forbidden as a packet name
+func isForbiddenPacketField(name string) bool {
+	switch name {
+	case
+		"sender",
+		"port",
+		"channelID":
+		return true
+	}
+
+	return isGoReservedWord(name)
 }

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -59,13 +59,13 @@ func (s *Scaffolder) AddType(addTypeOptions AddTypeOption, moduleName string, st
 		return fmt.Errorf("%s can't be used as a type name", stype)
 	}
 
-	// Check type is not already created
-	ok, err = isTypeCreated(s.path, moduleName, stype)
+	// Check component name is not already used
+	ok, err = isComponentCreated(s.path, moduleName, stype)
 	if err != nil {
 		return err
 	}
 	if ok {
-		return fmt.Errorf("%s type is already added", stype)
+		return fmt.Errorf("%s component is already added", stype)
 	}
 
 	// Parse provided field
@@ -208,20 +208,6 @@ func isTypeCreated(appPath, moduleName, typeName string) (isCreated bool, err er
 	return
 }
 
-// isMsgServerDefined checks if the module uses the MsgServer convention for transactions
-// this is checked by verifying the existence of the tx.proto file
-func isMsgServerDefined(appPath, moduleName string) (bool, error) {
-	txProto, err := filepath.Abs(filepath.Join(appPath, "proto", moduleName, "tx.proto"))
-	if err != nil {
-		return false, err
-	}
-
-	if _, err := os.Stat(txProto); os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, err
-}
-
 // isForbiddenTypeField returns true if the name is forbidden as a field name
 func isForbiddenTypeField(name string) bool {
 	switch name {
@@ -233,54 +219,4 @@ func isForbiddenTypeField(name string) bool {
 	}
 
 	return isGoReservedWord(name)
-}
-
-func isGoReservedWord(name string) bool {
-	// Check keyword or literal
-	if token.Lookup(name).IsKeyword() {
-		return true
-	}
-
-	// Check with builtin identifier
-	switch name {
-	case
-		"panic",
-		"recover",
-		"append",
-		"bool",
-		"byte",
-		"cap",
-		"close",
-		"complex",
-		"complex64",
-		"complex128",
-		"uint16",
-		"copy",
-		"false",
-		"float32",
-		"float64",
-		"imag",
-		"int",
-		"int8",
-		"int16",
-		"uint32",
-		"int32",
-		"int64",
-		"iota",
-		"len",
-		"make",
-		"new",
-		"nil",
-		"uint64",
-		"print",
-		"println",
-		"real",
-		"string",
-		"true",
-		"uint",
-		"uint8",
-		"uintptr":
-		return true
-	}
-	return false
 }

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -69,7 +69,7 @@ func (s *Scaffolder) AddType(addTypeOptions AddTypeOption, moduleName string, st
 	}
 
 	// Parse provided field
-	tFields, err := parseFields(fields)
+	tFields, err := parseFields(fields, isForbiddenTypeField)
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (s *Scaffolder) AddType(addTypeOptions AddTypeOption, moduleName string, st
 }
 
 // parseFields parses the provided fields, analyses the types and checks there is no duplicated field
-func parseFields(fields []string) ([]typed.Field, error) {
+func parseFields(fields []string, isForbiddenField func(string) bool) ([]typed.Field, error) {
 	// Used to check duplicated field
 	existingFields := make(map[string]bool)
 
@@ -141,7 +141,7 @@ func parseFields(fields []string) ([]typed.Field, error) {
 		name := fs[0]
 
 		// Ensure the field name is not a Go reserved name, it would generate an incorrect code
-		if isGoReservedWord(name) {
+		if isForbiddenField(name) {
 			return tFields, fmt.Errorf("%s can't be used as a field name", name)
 		}
 
@@ -220,6 +220,19 @@ func isMsgServerDefined(appPath, moduleName string) (bool, error) {
 		return false, nil
 	}
 	return true, err
+}
+
+// isForbiddenTypeField returns true if the name is forbidden as a field name
+func isForbiddenTypeField(name string) bool {
+	switch name {
+	case
+		"id",
+		"index",
+		"creator":
+		return true
+	}
+
+	return isGoReservedWord(name)
 }
 
 func isGoReservedWord(name string) bool {


### PR DESCRIPTION
We were only verifying for the same kind of component if the name already exists. Now we prevent having a `type` and a `message` with the same name (which used to work and generated a code that doesn't compile)