### PR TITLE
docs: remove aragon chain

### DIFF
--- a/docs/1 Introduction/1 Introduction.md
+++ b/docs/1 Introduction/1 Introduction.md
@@ -25,7 +25,6 @@ The following projects are using the technology:
 - [Crypto.com Chain](https://github.com/crypto-com/chain-main) (Payments, DeFi, and utility token)
 - [IRIS](https://github.com/irisnet) (IBC Hub and developer oriented)
 - [Kava](https://github.com/Kava-Labs/kava) (DeFi and Stable Coins)
-- [Aragon](https://docs.chain.aragon.org/) (DAO catalyst)
 - [CosmWasm](https://cosmwasm.com/) (smart contracts using WASM)
 - [Ethermint](https://ethermint.zone/) (Ethereum virtual machine)
 


### PR DESCRIPTION
aragon is no longer launching their own cosmos chain. removing from docs.