### PR TITLE
fix: messages scaffolding, type implementation mistake

### DIFF
--- a/starport/templates/typed/stargate/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -82,7 +82,7 @@ func (msg *MsgUpdate<%= title(TypeName) %>) ValidateBasic() error {
    return nil
 }
 
-var _ sdk.Msg = &MsgCreate<%= title(TypeName) %>{}
+var _ sdk.Msg = &MsgDelete<%= title(TypeName) %>{}
 
 func NewMsgDelete<%= title(TypeName) %>(creator string, id uint64) *MsgDelete<%= title(TypeName) %> {
   return &MsgDelete<%= title(TypeName) %>{

--- a/starport/templates/typed/stargate_legacy/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate_legacy/x/{{moduleName}}/types/messages_{{typeName}}.go.plush
@@ -82,7 +82,7 @@ func (msg *MsgUpdate<%= title(TypeName) %>) ValidateBasic() error {
    return nil
 }
 
-var _ sdk.Msg = &MsgCreate<%= title(TypeName) %>{}
+var _ sdk.Msg = &MsgDelete<%= title(TypeName) %>{}
 
 func NewMsgDelete<%= title(TypeName) %>(creator string, id uint64) *MsgDelete<%= title(TypeName) %> {
   return &MsgDelete<%= title(TypeName) %>{


### PR DESCRIPTION
When using "starport type" the generated messages_type.go do not match the expected results.

The expected generated results should be
```
var _ sdk.Msg = &MsgDeleteType{}

func NewMsgDeleteType...
```

instead, the actual generated file contains 

```
var _ sdk.Msg = &MsgCreateType{}

func NewMsgDeleteType...
```