### PR TITLE
fix: use nightly.starport.network

### DIFF
--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -27,7 +27,7 @@ const (
 	spnFaucetAddressFlag = "spn-faucet-address"
 
 	// spnNodeAddressAlpha   = "https://rpc.alpha.starport.network:443"
-	// spnAPIAddressAlpha    = "https://rest.alpha.starport.network"
+	// spnAPIAddressAlpha    = "https://api.alpha.starport.network"
 	// spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
 
 	spnNodeAddressNightly   = "https://rpc.nightly.starport.network:443"

--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -31,7 +31,7 @@ const (
 	spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
 
 	spnNodeAddressNightly = "https://rpc.nightly.starport.network:443"
-	spnAPIAddressNightly = "https://rest.nightly.starport.network"
+	spnAPIAddressNightly = "https://api.nightly.starport.network"
 	spnFaucetAddressNightly = "https://faucet.nightly.starport.network"
 )
 

--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	nightly			bool
+	nightly bool
 
 	spnNodeAddress   string
 	spnAPIAddress    string
@@ -24,11 +24,11 @@ var (
 )
 
 const (
-	nightlyFlag = "nightly"
+	flagNightlyFlag = "nightly"
 
-	spnNodeAddressFlag   = "spn-node-address"
-	spnAPIAddressFlag    = "spn-api-address"
-	spnFaucetAddressFlag = "spn-faucet-address"
+	flagSPNNodeAddressFlag   = "spn-node-address"
+	flagSPNAPIAddressFlag    = "spn-api-address"
+	flagSPNFaucetAddressFlag = "spn-faucet-address"
 
 	spnNodeAddressAlpha   = "https://rpc.alpha.starport.network:443"
 	spnAPIAddressAlpha    = "https://rest.alpha.starport.network"
@@ -49,10 +49,10 @@ func NewNetwork() *cobra.Command {
 	}
 
 	// configure flags.
-	c.PersistentFlags().BoolVar(&nightly, nightlyFlag, false, "Use nightly SPN network")
-	c.PersistentFlags().StringVar(&spnNodeAddress, spnNodeAddressFlag, spnNodeAddressAlpha, "SPN node address")
-	c.PersistentFlags().StringVar(&spnAPIAddress, spnAPIAddressFlag, spnAPIAddressAlpha, "SPN api address")
-	c.PersistentFlags().StringVar(&spnFaucetAddress, spnFaucetAddressFlag, spnFaucetAddressAlpha, "SPN Faucet address")
+	c.PersistentFlags().BoolVar(&nightly, flagNightlyFlag, false, "Use nightly SPN network")
+	c.PersistentFlags().StringVar(&spnNodeAddress, flagSPNNodeAddressFlag, spnNodeAddressAlpha, "SPN node address")
+	c.PersistentFlags().StringVar(&spnAPIAddress, flagSPNAPIAddressFlag, spnAPIAddressAlpha, "SPN api address")
+	c.PersistentFlags().StringVar(&spnFaucetAddress, flagSPNFaucetAddressFlag, spnFaucetAddressAlpha, "SPN Faucet address")
 
 	// add sub commands.
 	c.AddCommand(NewNetworkAccount())

--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -22,16 +22,16 @@ var (
 )
 
 const (
-	spnNodeAddressFlag = "spn-node-address"
-	spnAPIAddressFlag = "spn-api-address"
+	spnNodeAddressFlag   = "spn-node-address"
+	spnAPIAddressFlag    = "spn-api-address"
 	spnFaucetAddressFlag = "spn-faucet-address"
 
-	spnNodeAddressAlpha = "https://rpc.alpha.starport.network:443"
-	spnAPIAddressAlpha = "https://rest.alpha.starport.network"
-	spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
+	// spnNodeAddressAlpha   = "https://rpc.alpha.starport.network:443"
+	// spnAPIAddressAlpha    = "https://rest.alpha.starport.network"
+	// spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
 
-	spnNodeAddressNightly = "https://rpc.nightly.starport.network:443"
-	spnAPIAddressNightly = "https://api.nightly.starport.network"
+	spnNodeAddressNightly   = "https://rpc.nightly.starport.network:443"
+	spnAPIAddressNightly    = "https://api.nightly.starport.network"
 	spnFaucetAddressNightly = "https://faucet.nightly.starport.network"
 )
 

--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -21,6 +21,20 @@ var (
 	spnFaucetAddress string
 )
 
+const (
+	spnNodeAddressFlag = "spn-node-address"
+	spnAPIAddressFlag = "spn-api-address"
+	spnFaucetAddressFlag = "spn-faucet-address"
+
+	spnNodeAddressAlpha = "https://rpc.alpha.starport.network:443"
+	spnAPIAddressAlpha = "https://rest.alpha.starport.network"
+	spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
+
+	spnNodeAddressNightly = "https://rpc.nightly.starport.network:443"
+	spnAPIAddressNightly = "https://rest.nightly.starport.network"
+	spnFaucetAddressNightly = "https://faucet.nightly.starport.network"
+)
+
 // NewNetwork creates a new network command that holds some other sub commands
 // related to creating a new network collaboratively.
 func NewNetwork() *cobra.Command {
@@ -31,9 +45,9 @@ func NewNetwork() *cobra.Command {
 	}
 
 	// configure flags.
-	c.PersistentFlags().StringVar(&spnNodeAddress, "spn-node-address", "https://rpc.alpha.starport.network:443", "SPN node address")
-	c.PersistentFlags().StringVar(&spnAPIAddress, "spn-api-address", "https://rest.alpha.starport.network", "SPN api address")
-	c.PersistentFlags().StringVar(&spnFaucetAddress, "spn-faucet-address", "https://faucet.alpha.starport.network", "SPN Faucet address")
+	c.PersistentFlags().StringVar(&spnNodeAddress, spnNodeAddressFlag, spnNodeAddressNightly, "SPN node address")
+	c.PersistentFlags().StringVar(&spnAPIAddress, spnAPIAddressFlag, spnAPIAddressNightly, "SPN api address")
+	c.PersistentFlags().StringVar(&spnFaucetAddress, spnFaucetAddressFlag, spnFaucetAddressNightly, "SPN Faucet address")
 
 	// add sub commands.
 	c.AddCommand(NewNetworkAccount())

--- a/starport/interface/cli/starport/cmd/network.go
+++ b/starport/interface/cli/starport/cmd/network.go
@@ -16,19 +16,23 @@ import (
 )
 
 var (
+	nightly			bool
+
 	spnNodeAddress   string
 	spnAPIAddress    string
 	spnFaucetAddress string
 )
 
 const (
+	nightlyFlag = "nightly"
+
 	spnNodeAddressFlag   = "spn-node-address"
 	spnAPIAddressFlag    = "spn-api-address"
 	spnFaucetAddressFlag = "spn-faucet-address"
 
-	// spnNodeAddressAlpha   = "https://rpc.alpha.starport.network:443"
-	// spnAPIAddressAlpha    = "https://api.alpha.starport.network"
-	// spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
+	spnNodeAddressAlpha   = "https://rpc.alpha.starport.network:443"
+	spnAPIAddressAlpha    = "https://rest.alpha.starport.network"
+	spnFaucetAddressAlpha = "https://faucet.alpha.starport.network"
 
 	spnNodeAddressNightly   = "https://rpc.nightly.starport.network:443"
 	spnAPIAddressNightly    = "https://api.nightly.starport.network"
@@ -45,9 +49,10 @@ func NewNetwork() *cobra.Command {
 	}
 
 	// configure flags.
-	c.PersistentFlags().StringVar(&spnNodeAddress, spnNodeAddressFlag, spnNodeAddressNightly, "SPN node address")
-	c.PersistentFlags().StringVar(&spnAPIAddress, spnAPIAddressFlag, spnAPIAddressNightly, "SPN api address")
-	c.PersistentFlags().StringVar(&spnFaucetAddress, spnFaucetAddressFlag, spnFaucetAddressNightly, "SPN Faucet address")
+	c.PersistentFlags().BoolVar(&nightly, nightlyFlag, false, "Use nightly SPN network")
+	c.PersistentFlags().StringVar(&spnNodeAddress, spnNodeAddressFlag, spnNodeAddressAlpha, "SPN node address")
+	c.PersistentFlags().StringVar(&spnAPIAddress, spnAPIAddressFlag, spnAPIAddressAlpha, "SPN api address")
+	c.PersistentFlags().StringVar(&spnFaucetAddress, spnFaucetAddressFlag, spnFaucetAddressAlpha, "SPN Faucet address")
 
 	// add sub commands.
 	c.AddCommand(NewNetworkAccount())
@@ -67,6 +72,14 @@ func newNetworkBuilder(options ...networkbuilder.Option) (*networkbuilder.Builde
 	if os.Getenv("GITPOD_WORKSPACE_ID") != "" {
 		spnoptions = append(spnoptions, spn.Keyring(keyring.BackendTest))
 	}
+
+	// check if using nightly spn
+	if nightly {
+		spnNodeAddress = spnNodeAddressNightly
+		spnAPIAddress = spnAPIAddressNightly
+		spnFaucetAddress = spnFaucetAddressNightly
+	}
+
 	// init spnclient only once on start in order to spnclient to
 	// reuse unlocked keyring in the following steps.
 	if spnclient == nil {


### PR DESCRIPTION
Use `nightly.starport.network` to support `launch` module renaming on `spn`