### PR TITLE
docs: Fix Starport readme TOC

### DIFF
--- a/docs/99 Extra/1 Adding Support for CosmWasm.md
+++ b/docs/99 Extra/1 Adding Support for CosmWasm.md
@@ -1,6 +1,6 @@
-# Adding support for CosmWasm
+# Add support for CosmWasm
 
-The `wasm` module allows using WebAssembly code (Wasm) on a Cosmos SDK blockchain. With Starport, we can add the module very conveniently with
+The `wasm` module allows using WebAssembly code (Wasm) on a Cosmos SDK blockchain. With Starport, add the module very conveniently with
 
 ```bash
 starport module import wasm

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,47 +1,14 @@
-# The Starport Documentation
+# Starport Documentation
 
 **Quickstart:** Try [Starport in a web-based IDE](https://gitpod.io/#https://github.com/tendermint/starport/). It's the fastest way to get started. The latest version of Starport and its prerequisites are installed, just start hacking!
 
 ## Table of Contents 🔎
 
-1. Introduction
-
-  1. [Introduction](1%20Introduction/1%20Introduction.md)
-  2. [Install](1%20Introduction/2%20Install.md)
-  3. [Quickstart](1%20Introduction/3%20Quickstart.md)
-  4. [Configuration](1%20Introduction/4%20Configuration.md)
-  5. [Genesis File](1%20Introduction/5%20Genesis%20File.md)
-  6. [Starport IBC](1%20Introduction/6%20Starport%20IBC.md)
-
-2. Architecture
-
-  1. [Introduction](2%20Architecture/1%20Introduction.md)
-  2. [Directory Structure](2%20Architecture/2%20Directory%20Structure.md)
-  3. [Standard Modules](2%20Architecture/3%20Standard%20Modules.md)
-  4. [Writing Custom Modules](2%20Architecture/4%20Writing%20Custom%20Modules.md)
-
-3. Tutorials
-
-  1. [Introduction](3%20Starport/1%20Introduction.md)
-  2. [Poll](https://github.com/cosmos/sdk-tutorials/blob/master/voter/index.md)
-  3. [Blog](https://github.com/cosmos/sdk-tutorials/blob/master/blog/tutorial/01-index.md)
-  4. [Scavenge](https://github.com/cosmos/sdk-tutorials/blob/master/scavenge/tutorial/01-background.md)
-  5. [Nameservice](https://github.com/cosmos/sdk-tutorials/blob/master/nameservice/tutorial/00-intro.md)
-
-4. EVM Smart Contracts
-
-  1. [Introduction](4%20EVM%20smart%20contracts/1%20Introduction.md)
-  2. [ERC20](4%20EVM%20smart%20contracts/2%20ERC20.md)
-  3. [NFT](4%20EVM%20smart%20contracts/3%20NFT.md)
-
-5. Wasm Smart Contracts
-
-  1. [Introduction](5%20Wasm%20Smart%20Contracts/1%20Introduction.md)
-  2. [Adding support for CosmWasm](5%20Wasm%20Smart%20Contracts/2%20Adding%20Support%20for%20CosmWasm.md)
-  3. [Deploying your first contract](5%20Wasm%20Smart%20Contracts/3%20Deploying%20your%20first%20contract.md)
-
-6. Extra
-
-## Other Tutorials
-
-- [Smart contract tutorial](https://www.notion.so/Smart-contracts-with-CosmWasm-c6fbcd584b78437a843e738b922dc108): add smart contracts to your app with CosmWasm: build, upload, instantiate and run a smart contract
+1. [Introduction](1%20Introduction/1%20Introduction.md)
+2. [Start a Blockchain](2%20Run%20a%20Blockchain/1%20Start%20a%20Blockchain.md)
+3. [Scaffold a Blockchain](3%20Scaffold%20a%20Blockchain)
+4. [Configure a Blockchain](4%20Configure%20a%20Blockchain)
+5. [IBC and Relayer](5%20IBC%20and%20Relayer)
+6. [Protocol Buffer Files](6%20Protocol%20Buffer%20Files/1%20Overview.md)
+7. [Frontend](7%20Frontend/1%20Overview.md)
+8. [Extra](99%20Extra/1%20Adding%20Support%20for%20CosmWasm.md)


### PR DESCRIPTION
@fadeev I didn't realize our README was wonky (oops, my mistake) so here's a PR to fix the table of contents for the Starport docs

I manually crafted the top-level table of contents for this update. Teach me if there is an automated TOC option. 
I use the in-file Atom text editor Markdown package to generate an in-file toc, but can use some coaching for readme toc generation.

TOC links to go:
- the folder if there were multiple files
- the file if there was a single file
