### PR TITLE
feat(network): verify chain and custom genesis URL

### DIFF
--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -87,16 +87,16 @@ func (b *Blockchain) init(
 		chainOption = append(chainOption, chain.KeyringBackend(keyringBackend))
 	}
 
-	c, err := chain.New(ctx, b.appPath, chainOption...)
+	chain, err := chain.New(ctx, b.appPath, chainOption...)
 	if err != nil {
 		return err
 	}
 
-	if v := c.SDKVersion(); v != cosmosver.Stargate {
+	if v := chain.SDKVersion(); v != cosmosver.Stargate {
 		return errors.New("starport doesn't support Cosmos SDK Launchpad blockchains")
 	}
 
-	chainHome, err := c.Home()
+	chainHome, err := chain.Home()
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func (b *Blockchain) init(
 	}
 
 	// cleanup home dir of app if exists.
-	paths, err := c.StoragePaths()
+	paths, err := chain.StoragePaths()
 	if err != nil {
 		return err
 	}
@@ -118,16 +118,16 @@ func (b *Blockchain) init(
 		}
 	}
 
-	if err := c.Build(ctx); err != nil {
+	if err := chain.Build(ctx); err != nil {
 		return err
 	}
-	if err := c.Init(ctx); err != nil {
+	if err := chain.Init(ctx); err != nil {
 		return err
 	}
 	b.builder.ev.Send(events.New(events.StatusDone, "Blockchain initialized"))
 
 	// backup initial genesis so it can be used during `start`.
-	genesisPath, err := c.GenesisPath()
+	genesisPath, err := chain.GenesisPath()
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func (b *Blockchain) init(
 		return err
 	}
 
-	b.chain = c
+	b.chain = chain
 	return nil
 }
 

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -174,6 +174,16 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 		option(o)
 	}
 
+	chain, err := b.spnclient.ShowChain(ctx, account.Name, chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	// verify chain information
+	if err := b.VerifyChain(ctx, chain); err != nil {
+		return nil, err
+	}
+
 	// determine final source configuration.
 	var (
 		url  = o.url
@@ -183,10 +193,6 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	)
 
 	if o.isChainIDSource {
-		chain, err := b.spnclient.ShowChain(ctx, account.Name, chainID)
-		if err != nil {
-			return nil, err
-		}
 		url = chain.URL
 		hash = chain.Hash
 	}

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -174,16 +174,6 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 		option(o)
 	}
 
-	chain, err := b.spnclient.ShowChain(ctx, account.Name, chainID)
-	if err != nil {
-		return nil, err
-	}
-
-	// verify chain information
-	if err := b.VerifyChain(ctx, chain); err != nil {
-		return nil, err
-	}
-
 	// determine final source configuration.
 	var (
 		url  = o.url
@@ -193,6 +183,16 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 	)
 
 	if o.isChainIDSource {
+		chain, err := b.spnclient.ShowChain(ctx, account.Name, chainID)
+		if err != nil {
+			return nil, err
+		}
+
+		// verify chain information
+		if err := b.VerifyChain(ctx, chain); err != nil {
+			return nil, err
+		}
+
 		url = chain.URL
 		hash = chain.Hash
 	}

--- a/starport/services/networkbuilder/verification.go
+++ b/starport/services/networkbuilder/verification.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/tendermint/starport/starport/pkg/spn"
 	"io"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,6 +18,30 @@ type VerificationError struct {
 
 func (e VerificationError) Error() string {
 	return e.Err.Error()
+}
+
+// VerifyChain verifies if information of the chain are correct
+// Current and only check for now is the eventual custom genesis content
+func (b *Builder) VerifyChain(ctx context.Context, chain spn.Chain) error {
+	if chain.GenesisURL != "" {
+		// Verify custom genesis
+		_, hash, err := genesisAndHashFromURL(ctx, chain.GenesisURL)
+		if err != nil {
+			return err
+		}
+		if hash != chain.GenesisHash {
+			return VerificationError{
+				fmt.Errorf(
+					"hash of custom genesis for chain %v is incorrect, expected: %v, actual: %v",
+					chain.ChainID,
+					chain.GenesisHash,
+					hash,
+				),
+			}
+		}
+	}
+
+	return nil
 }
 
 type GentxInfo struct {

--- a/starport/services/networkbuilder/verification.go
+++ b/starport/services/networkbuilder/verification.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/tendermint/starport/starport/pkg/spn"
 	"io"
+
+	"github.com/tendermint/starport/starport/pkg/spn"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/starport/starport/pkg/jsondoc"


### PR DESCRIPTION
Check the genesis URL of a chain before joining it. A method `verifyChain` is called inside `Init`. Though we may refactor this method in the future, the idea is to have a generalistic method `verifyChain` to verify the static information of the chain. This method should be called before any operation with chains of Starport Network.

For test purpose, the chain `toast2` of `nightly` has a incorrect hash for the genesis