### PR TITLE
fix: type generation error with <v0.14.0 apps

### DIFF
--- a/starport/templates/typed/genesis.go
+++ b/starport/templates/typed/genesis.go
@@ -54,8 +54,10 @@ func (t *typedStargate) genesisTypesModify(opts *Options) genny.RunFn {
 			return err
 		}
 
+		content := PatchGenesisTypeImport(f.String())
+
 		templateTypesImport := `"fmt"`
-		content := strings.Replace(f.String(), PlaceholderGenesisTypesImport, templateTypesImport, 1)
+		content = strings.Replace(content, PlaceholderGenesisTypesImport, templateTypesImport, 1)
 
 		templateTypesDefault := `%[1]v
 %[2]vList: []*%[2]v{},`
@@ -129,4 +131,20 @@ for _, elem := range %[2]vList {
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
 	}
+}
+
+// PatchGenesisTypeImport patches types/genesis.go content from the issue:
+// https://github.com/tendermint/starport/issues/992
+func PatchGenesisTypeImport(content string) string {
+	patternToCheck := fmt.Sprintf(`import (
+%[1]v`, PlaceholderGenesisTypesImport)
+	replacement := fmt.Sprintf(`import (
+%[1]v
+)`, PlaceholderGenesisTypesImport)
+
+	if !strings.Contains(content, patternToCheck) {
+		content = strings.Replace(content, PlaceholderGenesisTypesImport, replacement, 1)
+	}
+
+	return content
 }

--- a/starport/templates/typed/genesis.go
+++ b/starport/templates/typed/genesis.go
@@ -136,8 +136,7 @@ for _, elem := range %[2]vList {
 // PatchGenesisTypeImport patches types/genesis.go content from the issue:
 // https://github.com/tendermint/starport/issues/992
 func PatchGenesisTypeImport(content string) string {
-	patternToCheck := fmt.Sprintf(`import (
-%[1]v`, PlaceholderGenesisTypesImport)
+	patternToCheck := "import ("
 	replacement := fmt.Sprintf(`import (
 %[1]v
 )`, PlaceholderGenesisTypesImport)

--- a/starport/templates/typed/indexed/new_stargate.go
+++ b/starport/templates/typed/indexed/new_stargate.go
@@ -192,8 +192,10 @@ func genesisTypesModify(opts *typed.Options) genny.RunFn {
 			return err
 		}
 
+		content := typed.PatchGenesisTypeImport(f.String())
+
 		templateTypesImport := `"fmt"`
-		content := strings.Replace(f.String(), typed.PlaceholderGenesisTypesImport, templateTypesImport, 1)
+		content = strings.Replace(content, typed.PlaceholderGenesisTypesImport, templateTypesImport, 1)
 
 		templateTypesDefault := `%[1]v
 %[2]vList: []*%[2]v{},`


### PR DESCRIPTION
Introduce a function that patches `types/genesis.go` to make it compatible with current scaffolding logic.

Since other template inconsistencies could arise in the future, it could make sense to introduce a package `patch` in `template` that centralize all of them.

The difference between the current "modify" logic and the notion of patch is:
- modify functions only modify the code from the placeholders inside it
- patches can also modify other parts not only related to placeholders

For testing, the following app is scaffolded with 0.14.0:
https://github.com/lubtd/earth