### PR TITLE
fix: starport network chain join hangs on some host

### DIFF
--- a/starport/pkg/chaincmd/runner/account.go
+++ b/starport/pkg/chaincmd/runner/account.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
@@ -64,8 +65,14 @@ func (r Runner) AddAccount(ctx context.Context, name, mnemonic string) (Account,
 			return Account{}, err
 		}
 	} else {
+
+
 		// note that, launchpad prints account output from stderr.
-		if err := r.run(ctx, runOptions{stdout: b, stderr: b}, r.cc.AddKeyCommand(name)); err != nil {
+		if err := r.run(ctx, runOptions{
+			stdout: b, // io.MultiWriter(b, os.Stdout),
+			stderr: os.Stderr, // io.MultiWriter(b, os.Stderr),
+			stdin: os.Stdin,
+		}, r.cc.AddKeyCommand(name)); err != nil {
 			return Account{}, err
 		}
 		if err := json.NewDecoder(b).Decode(&account); err != nil {

--- a/starport/pkg/chaincmd/runner/account.go
+++ b/starport/pkg/chaincmd/runner/account.go
@@ -96,7 +96,7 @@ func (r Runner) AddAccount(ctx context.Context, name, mnemonic string) (Account,
 	if err := r.run(ctx, runOptions{
 		stdout: io.MultiWriter(b, os.Stdout),
 		stderr: os.Stderr,
-		stdin: os.Stdin,
+		stdin:  os.Stdin,
 	}, opt...); err != nil {
 		return Account{}, err
 	}

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -58,7 +60,11 @@ func (r Runner) Gentx(ctx context.Context, validatorName, selfDelegation string,
 	b := &bytes.Buffer{}
 
 	// note: launchpad outputs from stderr.
-	if err := r.run(ctx, runOptions{stdout: b, stderr: b}, r.cc.GentxCommand(validatorName, selfDelegation, options...)); err != nil {
+	if err := r.run(ctx, runOptions{
+		stdout: io.MultiWriter(b, os.Stdout),
+		stderr: io.MultiWriter(b, os.Stderr),
+		stdin: os.Stdin,
+	}, r.cc.GentxCommand(validatorName, selfDelegation, options...)); err != nil {
 		return "", err
 	}
 

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -63,7 +63,7 @@ func (r Runner) Gentx(ctx context.Context, validatorName, selfDelegation string,
 	if err := r.run(ctx, runOptions{
 		stdout: io.MultiWriter(b, os.Stdout),
 		stderr: io.MultiWriter(b, os.Stderr),
-		stdin: os.Stdin,
+		stdin:  os.Stdin,
 	}, r.cc.GentxCommand(validatorName, selfDelegation, options...)); err != nil {
 		return "", err
 	}

--- a/starport/pkg/chaincmd/runner/runner.go
+++ b/starport/pkg/chaincmd/runner/runner.go
@@ -102,6 +102,9 @@ type runOptions struct {
 
 	// stdout and stderr used to collect a copy of command's outputs.
 	stdout, stderr io.Writer
+
+	// stdin defines input for the command
+	stdin io.Reader
 }
 
 // run executes a command.
@@ -117,6 +120,7 @@ func (r Runner) run(ctx context.Context, roptions runOptions, soptions ...step.O
 		stderr io.Writer = lineprefixer.NewWriter(r.stderr, func() string { return r.cliLogPrefix })
 	)
 
+	// Set standard outputs
 	if roptions.stdout != nil {
 		stdout = io.MultiWriter(stdout, roptions.stdout)
 	}
@@ -129,6 +133,11 @@ func (r Runner) run(ctx context.Context, roptions runOptions, soptions ...step.O
 	rnoptions := []cmdrunner.Option{
 		cmdrunner.DefaultStdout(stdout),
 		cmdrunner.DefaultStderr(stderr),
+	}
+
+	// Set standard input if defined
+	if roptions.stdin != nil {
+		rnoptions = append(rnoptions, cmdrunner.DefaultStdin(roptions.stdin))
 	}
 
 	err := cmdrunner.

--- a/starport/pkg/cmdrunner/cmdrunner.go
+++ b/starport/pkg/cmdrunner/cmdrunner.go
@@ -17,7 +17,7 @@ type Runner struct {
 	endSignal   os.Signal
 	stdout      io.Writer
 	stderr      io.Writer
-	stdin 		io.Reader
+	stdin       io.Reader
 	workdir     string
 	runParallel bool
 }
@@ -183,7 +183,6 @@ func (c *cmdSignalNoWriter) Signal(s os.Signal) { c.Cmd.Process.Signal(s) }
 
 func (c *cmdSignalNoWriter) Write(data []byte) (n int, err error) { return 0, nil }
 
-
 // newCommand returns a new command to execute
 func (r *Runner) newCommand(s *step.Step) Executor {
 	if s.Exec.Command == "" {
@@ -210,18 +209,15 @@ func (r *Runner) newCommand(s *step.Step) Executor {
 	c.Env = append(os.Environ(), s.Env...)
 	c.Env = append(c.Env, os.ExpandEnv(fmt.Sprintf("PATH=$PATH:%s", goenv.GetGOBIN())))
 
-	c.Stdin = os.Stdin
-	return &cmdSignalNoWriter{c}
-
-	//if r.stdin != nil {
-	//	c.Stdin = r.stdin
-	//	return &cmdSignalNoWriter{c}
-	//} else {
-	//	w, err := c.StdinPipe()
-	//	if err != nil {
-	//		// TODO do not panic
-	//		panic(err)
-	//	}
-	//	return &cmdSignal{c, w}
-	//}
+	if r.stdin != nil {
+		c.Stdin = r.stdin
+		return &cmdSignalNoWriter{c}
+	} else {
+		w, err := c.StdinPipe()
+		if err != nil {
+			// TODO do not panic
+			panic(err)
+		}
+		return &cmdSignal{c, w}
+	}
 }

--- a/starport/pkg/cmdrunner/cmdrunner.go
+++ b/starport/pkg/cmdrunner/cmdrunner.go
@@ -212,12 +212,12 @@ func (r *Runner) newCommand(s *step.Step) Executor {
 	if r.stdin != nil {
 		c.Stdin = r.stdin
 		return &cmdSignalNoWriter{c}
-	} else {
-		w, err := c.StdinPipe()
-		if err != nil {
-			// TODO do not panic
-			panic(err)
-		}
-		return &cmdSignal{c, w}
 	}
+
+	w, err := c.StdinPipe()
+	if err != nil {
+		// TODO do not panic
+		panic(err)
+	}
+	return &cmdSignal{c, w}
 }

--- a/starport/pkg/cmdrunner/cmdrunner.go
+++ b/starport/pkg/cmdrunner/cmdrunner.go
@@ -210,15 +210,18 @@ func (r *Runner) newCommand(s *step.Step) Executor {
 	c.Env = append(os.Environ(), s.Env...)
 	c.Env = append(c.Env, os.ExpandEnv(fmt.Sprintf("PATH=$PATH:%s", goenv.GetGOBIN())))
 
-	if r.stdin != nil {
-		c.Stdin = os.Stdin
-		return &cmdSignalNoWriter{c}
-	} else {
-		w, err := c.StdinPipe()
-		if err != nil {
-			// TODO do not panic
-			panic(err)
-		}
-		return &cmdSignal{c, w}
-	}
+	c.Stdin = os.Stdin
+	return &cmdSignalNoWriter{c}
+
+	//if r.stdin != nil {
+	//	c.Stdin = r.stdin
+	//	return &cmdSignalNoWriter{c}
+	//} else {
+	//	w, err := c.StdinPipe()
+	//	if err != nil {
+	//		// TODO do not panic
+	//		panic(err)
+	//	}
+	//	return &cmdSignal{c, w}
+	//}
 }


### PR DESCRIPTION
Adds the ability to provide a `stdin` to commands and prevents using `StdinPipe` if a custom `stdin` is used.

It seems there is also an issue with `lineprefixer.NewWriter` and you must manually passes `os.Stdout` to have correct outputs. Still investigating on this.