### PR TITLE
fix: Bump template to v0.1.46

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -8,3 +8,5 @@ RUN wget https://golang.org/dl/go1.16.linux-amd64.tar.gz && \
 ENV GONAME go1.15
 
 RUN brew install gh
+
+RUN npm install -g npm@7.10.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,12 +14,12 @@ tasks:
     init: |
       ##
       ## install Starport
-      go install /workspace/starport/...
-      npm install -g npm@7.10.0
-      
+      go install /workspace/starport/...      
+
     command: |
       ##
       # configure env vars.
+      npm install -g npm@7.10.0
       echo "
       export VUE_APP_CUSTOM_URL=$(gp url)
       export CHISEL_ADDR=$(gp url 7575)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,7 +29,7 @@ tasks:
       echo "
       export VUE_APP_API_COSMOS=${API_ADDRESS}
       export VUE_APP_API_TENDERMINT=${RPC_ADDRESS}
-      export VUE_APP_WS_TENDERMINT=${RPC_ADDRESS/https/wss}
+      export VUE_APP_WS_TENDERMINT=${RPC_ADDRESS/https/wss}/websocket
       " >> ~/.bashrc && source ~/.bashrc
 
       ## 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,7 +15,8 @@ tasks:
       ##
       ## install Starport
       go install /workspace/starport/...
-
+      npm install -g npm@7.10.0
+      
     command: |
       ##
       # configure env vars.

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,8 +18,7 @@ tasks:
 
     command: |
       ##
-      # configure env vars.
-      npm install -g npm@7.10.0
+      # configure env vars.      
       echo "
       export VUE_APP_CUSTOM_URL=$(gp url)
       export CHISEL_ADDR=$(gp url 7575)

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/spn v0.0.0-20210406123257-decaff8dcaf9
 	github.com/tendermint/tendermint v0.34.8
-	github.com/tendermint/vue v0.1.44
+	github.com/tendermint/vue v0.1.45
 	golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 // indirect
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/spn v0.0.0-20210406123257-decaff8dcaf9
 	github.com/tendermint/tendermint v0.34.8
-	github.com/tendermint/vue v0.1.45
+	github.com/tendermint/vue v0.1.46
 	golang.org/x/crypto v0.0.0-20210317152858-513c2a44f670 // indirect
 	golang.org/x/mod v0.4.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -898,14 +898,8 @@ github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs
 github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFNWtrCWSf8=
 github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
-github.com/tendermint/vue v0.0.0-20210407103210-b92631502f18 h1:oVZyTXXr6bqdORxIjwHhzxs7+FIef3fOBWY9xsju5/s=
-github.com/tendermint/vue v0.0.0-20210407103210-b92631502f18/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
-github.com/tendermint/vue v0.0.0-20210409081157-e0d6d2d78acf h1:6+4WRRECLm+10uONkQD/ZcrYKHX3voK/3VlolV95NEc=
-github.com/tendermint/vue v0.0.0-20210409081157-e0d6d2d78acf/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
-github.com/tendermint/vue v0.0.0-20210409090150-9b8e55e5cd36 h1:UbnNeUCoWLUfQkCsf+sMojK2vqsGQGGwuwedHvkyHjA=
-github.com/tendermint/vue v0.0.0-20210409090150-9b8e55e5cd36/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
-github.com/tendermint/vue v0.1.44 h1:hxuSWQGP8Mb8z35A4q1n1za+bK83Gpk1cEZqT3Ian74=
-github.com/tendermint/vue v0.1.44/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
+github.com/tendermint/vue v0.1.45 h1:HuWET1dKt20gkUsNaY1HFG1VIrluPUPbBFU4dKCPFDQ=
+github.com/tendermint/vue v0.1.45/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=

--- a/go.sum
+++ b/go.sum
@@ -898,8 +898,8 @@ github.com/tendermint/tm-db v0.6.2/go.mod h1:GYtQ67SUvATOcoY8/+x6ylk8Qo02BQyLrAs
 github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFNWtrCWSf8=
 github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
-github.com/tendermint/vue v0.1.45 h1:HuWET1dKt20gkUsNaY1HFG1VIrluPUPbBFU4dKCPFDQ=
-github.com/tendermint/vue v0.1.45/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
+github.com/tendermint/vue v0.1.46 h1:GaXzH8eGfChhSeviQECC4ngkFDJuN4qQxnNnhw5GDso=
+github.com/tendermint/vue v0.1.46/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=

--- a/scripts/test-vue
+++ b/scripts/test-vue
@@ -1,5 +1,4 @@
 #!/bin/bash
-npm install -g npm@7.10.0
 cd /workspace && starport app github.com/chain/vuetest
 cd /workspace && git clone https://github.com/tendermint/vue
 cd /workspace/vue && git checkout $1

--- a/scripts/test-vue
+++ b/scripts/test-vue
@@ -1,4 +1,5 @@
 #!/bin/bash
+npm install -g npm@7.10.0
 cd /workspace && starport app github.com/chain/vuetest
 cd /workspace && git clone https://github.com/tendermint/vue
 cd /workspace/vue && git checkout $1

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -504,10 +504,6 @@ func (c *Chain) watchAppFrontend(ctx context.Context) error {
 				step.Env(
 					fmt.Sprintf("HOST=%s", host),
 					fmt.Sprintf("PORT=%s", port),
-					fmt.Sprintf("VUE_APP_API_COSMOS=%s", xurl.HTTP(conf.Host.API)),
-					fmt.Sprintf("VUE_APP_API_TENDERMINT=%s", xurl.HTTP(conf.Host.RPC)),
-					fmt.Sprintf("VUE_APP_WS_TENDERMINT=%s/websocket", xurl.WS(conf.Host.RPC)),
-					fmt.Sprintf("VUE_APP_STARPORT_URL=%s", xurl.HTTP(conf.Host.DevUI)),
 				),
 				step.PostExec(postExec),
 			),


### PR DESCRIPTION
Bumps template to v0.1.46 which includes @starport/* v0.1.46

Fixes https://github.com/tendermint/starport/issues/1031

Also fixes error in WS env var and build errors when using test-vue script