### PR TITLE
refactor(nodetime): rm arm support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,10 +4,6 @@ builds:
       - -s -w -X github.com/tendermint/starport/starport/internal/version.Version={{.Tag}} -X github.com/tendermint/starport/starport/internal/version.Date={{.Date}}
     goarch:
       - amd64
-      - arm64
-    ignore:
-      - goos: darwin
-        goarch: arm64
 
 brews:
   - name: "starport"

--- a/scripts/data/gen-nodetime/package.json
+++ b/scripts/data/gen-nodetime/package.json
@@ -6,7 +6,7 @@
     "nodetime": "./nodetime"
   },
   "scripts": {
-    "build": "./node_modules/pkg/lib-es5/bin.js --debug -t node14-linux-x64,node14-macos-x64,node14-linux-arm64 -o nodetime ."
+    "build": "./node_modules/pkg/lib-es5/bin.js --debug -t node14-linux-x64,node14-macos-x64 -o nodetime ."
   },
   "dependencies": {
     "@confio/relayer": "^0.1.3",

--- a/scripts/gen-nodetime
+++ b/scripts/gen-nodetime
@@ -9,10 +9,8 @@ cd ./scripts/data/gen-nodetime
 npm i 
 npm run build
 
-tar -czvf nodetime-linux-arm64.tar.gz nodetime-linux-arm64
 tar -czvf nodetime-linux-x64.tar.gz nodetime-linux-x64
 tar -czvf nodetime-darwin-x64.tar.gz nodetime-macos-x64
 
-cp nodetime-linux-arm64.tar.gz ../../../starport/pkg/nodetime/
 cp nodetime-linux-x64.tar.gz ../../../starport/pkg/nodetime/ 
 cp nodetime-darwin-x64.tar.gz ../../../starport/pkg/nodetime/

--- a/starport/pkg/nodetime/binary_linux_arm64.go
+++ b/starport/pkg/nodetime/binary_linux_arm64.go
@@ -1,8 +1,0 @@
-// +build linux arm64
-
-package nodetime
-
-import _ "embed" // embed is required for binary embedding.
-
-//go:embed nodetime-linux-arm64.tar.gz
-var binaryCompressed []byte


### PR DESCRIPTION
we don't have a proper environment to build arm binaries for nodetime yet, until we
have one let's rm arm support for now.