### PR TITLE
feat(cmd/relayer): wire lowlevel confio/relayer commands

### DIFF
--- a/starport/cmd/relayer.go
+++ b/starport/cmd/relayer.go
@@ -1,7 +1,6 @@
 package starportcmd
 
 import (
-	relayercmd "github.com/cosmos/relayer/cmd"
 	"github.com/spf13/cobra"
 )
 
@@ -11,11 +10,8 @@ func NewRelayer() *cobra.Command {
 		Short: "Connects blockchains via IBC protocol",
 	}
 
-	rlyCmd := relayercmd.NewRootCmd()
-	rlyCmd.Short = "Low-level commands from github.com/cosmos/relayer"
-
 	c.AddCommand(NewRelayerConfigure())
 	c.AddCommand(NewRelayerConnect())
-	c.AddCommand(rlyCmd)
+	c.AddCommand(NewRelayerLowLevel())
 	return c
 }

--- a/starport/cmd/relayer.go
+++ b/starport/cmd/relayer.go
@@ -1,17 +1,24 @@
 package starportcmd
 
 import (
+	relayercmd "github.com/cosmos/relayer/cmd"
 	"github.com/spf13/cobra"
 )
 
+// NewRelayer returns a new relayer command.
 func NewRelayer() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "relayer",
 		Short: "Connects blockchains via IBC protocol",
 	}
 
+	rlyCmd := relayercmd.NewRootCmd()
+	rlyCmd.Short = "Low-level commands from github.com/cosmos/relayer"
+
 	c.AddCommand(NewRelayerConfigure())
 	c.AddCommand(NewRelayerConnect())
 	c.AddCommand(NewRelayerLowLevel())
+	c.AddCommand(rlyCmd)
+
 	return c
 }

--- a/starport/cmd/relayer_lowlevel.go
+++ b/starport/cmd/relayer_lowlevel.go
@@ -1,0 +1,62 @@
+package starportcmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+	"github.com/tendermint/starport/starport/pkg/nodetime"
+)
+
+func NewRelayerLowLevel() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "lowlevel",
+		Short: "Low-level relayer commands from @confio/relayer",
+	}
+	c.AddCommand(NewRelayerLowLevelIBCSetup())
+	c.AddCommand(NewRelayerLowLevelIBCRelayer())
+	return c
+}
+
+func NewRelayerLowLevelIBCSetup() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "ibc-setup [--] [...]",
+		Short: "Collection of commands to quickly setup a relayer",
+		RunE:  relayerLowLevelHandle(nodetime.CommandIBCSetup),
+		Example: `starport relayer lowlevel ibc-setup -- -h
+starport relayer lowlevel ibc-setup -- init --src relayer_test_1 --dest relayer_test_2`,
+	}
+	return c
+}
+
+func NewRelayerLowLevelIBCRelayer() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "ibc-relayer [--] [...]",
+		Short:   "Typescript implementation of an IBC relayer",
+		RunE:    relayerLowLevelHandle(nodetime.CommandIBCRelayer),
+		Example: `starport relayer lowlevel ibc-relayer -- -h`,
+	}
+	return c
+}
+
+func relayerLowLevelHandle(c nodetime.CommandName) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		command, cleanup, err := nodetime.Command(c)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		command = append(command, args...)
+
+		return cmdrunner.New().Run(
+			cmd.Context(),
+			step.New(
+				step.Exec(command[0], command[1:]...),
+				step.Stdout(os.Stdout),
+				step.Stderr(os.Stderr),
+			),
+		)
+	}
+}

--- a/starport/pkg/cosmosgen/generate_javascript.go
+++ b/starport/pkg/cosmosgen/generate_javascript.go
@@ -37,8 +37,8 @@ type jsGenerator struct {
 	g *generator
 }
 
-func newJSGenerator(g *generator) jsGenerator {
-	return jsGenerator{
+func newJSGenerator(g *generator) *jsGenerator {
+	return &jsGenerator{
 		g: g,
 	}
 }

--- a/starport/pkg/nodetime/nodetime.go
+++ b/starport/pkg/nodetime/nodetime.go
@@ -23,6 +23,12 @@ const (
 
 	// CommandSTA is https://github.com/acacode/swagger-typescript-api.
 	CommandSTA CommandName = "sta"
+
+	// CommandIBCSetup is https://github.com/confio/ts-relayer/blob/main/spec/ibc-setup.md.
+	CommandIBCSetup = "ibc-setup"
+
+	// CommandIBCRelayer is https://github.com/confio/ts-relayer/blob/main/spec/ibc-relayer.md.
+	CommandIBCRelayer = "ibc-relayer"
 )
 
 // CommandName represents a high level command under nodetime.

--- a/starport/pkg/nodetime/ts-proto/tsproto.go
+++ b/starport/pkg/nodetime/ts-proto/tsproto.go
@@ -25,6 +25,8 @@ var (
 // will be protoc-gen-ts_proto.
 // see why: https://github.com/stephenh/ts-proto/blob/7f76c05/README.markdown#quickstart.
 func BinaryPath() (path string, cleanup func(), err error) {
+	cleanup = func() {}
+
 	once.Do(func() {
 		var command []string
 


### PR DESCRIPTION
which are:
* `starport relayer lowlevel ibc-setup`
* `starport relayer lowlevel ibc-relayer`

and remove the old `starport relayer rly` from the go-relayer.