### PR TITLE
docs: update install.md

### DIFF
--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -67,7 +67,7 @@ brew install tendermint/tap/starport
 
 ```
 git clone https://github.com/tendermint/starport --depth=1
-make -C starport install
+cd starport && make install
 ```
 
 ## Summary


### PR DESCRIPTION
This sounds silly, but on some systems `make -C starport install` fails with `make: *** No rule to make target build.  Stop.`. I've noticed this on one virtual server and Tobias had this problem on macOS. Maybe an old version of `make`, but `cd starport && make install` works reliably everywhere.