### PR TITLE
feat: basic unit tests for non-indexed type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ apps/
 .idea
 .vscode
 docs/.vuepress/dist
+build/

--- a/starport/templates/app/stargate/go.mod.plush
+++ b/starport/templates/app/stargate/go.mod.plush
@@ -10,10 +10,12 @@ require (
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tendermint v0.34.8
 	github.com/tendermint/tm-db v0.6.4
-	google.golang.org/genproto v0.0.0-20210114201628-6edceaf6022f
-	google.golang.org/grpc v1.35.0
+	google.golang.org/genproto v0.0.0-20210426193834-eac7f76ac494
+	google.golang.org/grpc v1.37.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 replace google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/starport/templates/module/create/ibc/x/{{moduleName}}/types/expected_keeper_ibc.go.plush
+++ b/starport/templates/module/create/ibc/x/{{moduleName}}/types/expected_keeper_ibc.go.plush
@@ -19,3 +19,10 @@ type ChannelKeeper interface {
 type PortKeeper interface {
 	BindPort(ctx sdk.Context, portID string) *capabilitytypes.Capability
 }
+
+// ScopedKeeper defines the expected INC scoped keeper
+type ScopedKeeper interface {
+	GetCapability(ctx sdk.Context, name string) (*capabilitytypes.Capability, bool)
+	AuthenticateCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) bool
+	ClaimCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) error
+}

--- a/starport/templates/module/create/ibc/x/{{moduleName}}/types/expected_keeper_ibc.go.plush
+++ b/starport/templates/module/create/ibc/x/{{moduleName}}/types/expected_keeper_ibc.go.plush
@@ -20,7 +20,7 @@ type PortKeeper interface {
 	BindPort(ctx sdk.Context, portID string) *capabilitytypes.Capability
 }
 
-// ScopedKeeper defines the expected INC scoped keeper
+// ScopedKeeper defines the expected IBC scoped keeper
 type ScopedKeeper interface {
 	GetCapability(ctx sdk.Context, name string) (*capabilitytypes.Capability, bool)
 	AuthenticateCapability(ctx sdk.Context, cap *capabilitytypes.Capability, name string) bool

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
@@ -26,7 +26,9 @@ func setupKeeper(t testing.TB) (*Keeper, sdk.Context) {
 	require.NoError(t, stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
-	keeper := NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey) // this line is used by starport scaffolding # ibc/keeper/testsetup
+	keeper := NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey, 
+	// this line is used by starport scaffolding # ibc/keeper/testsetup
+	)
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
 	return keeper, ctx

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
@@ -8,39 +8,26 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmdb "github.com/tendermint/tm-db"
 	"<%= modulePath %>/x/<%= moduleName %>/types"
 )
 
-func TestKeeper(t *testing.T) {
-	suite.Run(t, new(KeeperSuite))
-}
-
-type KeeperSuite struct {
-	suite.Suite
-
-	Keeper     *Keeper
-	SDKContext sdk.Context
-
-	stateStore storetypes.CommitMultiStore
-}
-
-func (s *KeeperSuite) SetupTest() {
+func setupKeeper(t testing.TB) (*Keeper, sdk.Context) {
 	storeKey := sdk.NewKVStoreKey(types.StoreKey)
 	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
 
 	db := tmdb.NewMemDB()
-	s.stateStore = store.NewCommitMultiStore(db)
-	s.stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
-	s.stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
-	s.Require().NoError(s.stateStore.LoadLatestVersion())
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
-	s.Keeper = NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey, 
-	// this line is used by starport scaffolding # ibc/keeper/testsetup
-	)
-	s.SDKContext = sdk.NewContext(s.stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	keeper := NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey) // this line is used by starport scaffolding # ibc/keeper/testsetup
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
+	return keeper, ctx
 }

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
@@ -1,0 +1,44 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+	"<%= modulePath %>/x/<%= moduleName %>/types"
+)
+
+func TestKeeper(t *testing.T) {
+	suite.Run(t, new(KeeperSuite))
+}
+
+type KeeperSuite struct {
+	suite.Suite
+
+	Keeper     *Keeper
+	SDKContext sdk.Context
+
+	stateStore storetypes.CommitMultiStore
+}
+
+func (s *KeeperSuite) SetupTest() {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	s.stateStore = store.NewCommitMultiStore(db)
+	s.stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	s.stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	s.Require().NoError(s.stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	s.Keeper = NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey)
+	s.SDKContext = sdk.NewContext(s.stateStore, tmproto.Header{}, false, log.NewNopLogger())
+}

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper_test.go.plush
@@ -39,6 +39,8 @@ func (s *KeeperSuite) SetupTest() {
 	s.Require().NoError(s.stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
-	s.Keeper = NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey)
+	s.Keeper = NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey, 
+	// this line is used by starport scaffolding # ibc/keeper/testsetup
+	)
 	s.SDKContext = sdk.NewContext(s.stateStore, tmproto.Header{}, false, log.NewNopLogger())
 }

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -62,4 +62,5 @@ const (
 	PlaceholderIBCAppScopedKeeperDefinition  = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/definition"
 	PlaceholderIBCAppKeeperArgument          = "// this line is used by starport scaffolding # ibc/app/keeper/argument"
 	PlaceholderIBCAppRouter                  = "// this line is used by starport scaffolding # ibc/app/router"
+	PlaceholderIBCTestKeeperSetup            = "// this line is used by starport scaffolding # ibc/keeper/testsetup"
 )

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -1,0 +1,45 @@
+package keeper
+
+import "<%= ModulePath %>/x/<%= ModuleName %>/types"
+
+func (s *KeeperSuite) createN<%= title(TypeName) %>(n int) []types.<%= title(TypeName) %> {
+	items := make([]types.<%= title(TypeName) %>, n)
+	for i := range items {
+		items[i].Creator = "any"
+		items[i].Id = s.Keeper.Append<%= title(TypeName) %>(s.SDKContext, items[i])
+	}
+	return items
+}
+
+func (s *KeeperSuite) Test<%= title(TypeName) %>Get() {
+	items := s.createN<%= title(TypeName) %>(10)
+	for _, item := range items {
+		s.Equal(item, s.Keeper.Get<%= title(TypeName) %>(s.SDKContext, item.Id))
+	}
+}
+
+func (s *KeeperSuite) Test<%= title(TypeName) %>Exist() {
+	items := s.createN<%= title(TypeName) %>(10)
+	for _, item := range items {
+		s.True(s.Keeper.Has<%= title(TypeName) %>(s.SDKContext, item.Id))
+	}
+}
+
+func (s *KeeperSuite) Test<%= title(TypeName) %>Remove() {
+	items := s.createN<%= title(TypeName) %>(10)
+	for _, item := range items {
+		s.Keeper.Remove<%= title(TypeName) %>(s.SDKContext, item.Id)
+		s.False(s.Keeper.Has<%= title(TypeName) %>(s.SDKContext, item.Id))
+	}
+}
+
+func (s *KeeperSuite) Test<%= title(TypeName) %>GetAll() {
+	items := s.createN<%= title(TypeName) %>(10)
+	s.Equal(items, s.Keeper.GetAll<%= title(TypeName) %>(s.SDKContext))
+}
+
+func (s *KeeperSuite) Test<%= title(TypeName) %>Count() {
+	items := s.createN<%= title(TypeName) %>(10)
+	count := uint64(len(items))
+	s.Equal(count, s.Keeper.Get<%= title(TypeName) %>Count(s.SDKContext))
+}

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -1,45 +1,56 @@
 package keeper
 
-import "<%= ModulePath %>/x/<%= ModuleName %>/types"
+import (
+	"testing"
 
-func (s *KeeperSuite) createN<%= title(TypeName) %>(n int) []types.<%= title(TypeName) %> {
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+    "<%= ModulePath %>/x/<%= ModuleName %>/types"
+)
+
+func createN<%= title(TypeName) %>(keeper *Keeper, ctx sdk.Context, n int) []types.<%= title(TypeName) %> {
 	items := make([]types.<%= title(TypeName) %>, n)
 	for i := range items {
 		items[i].Creator = "any"
-		items[i].Id = s.Keeper.Append<%= title(TypeName) %>(s.SDKContext, items[i])
+		items[i].Id = keeper.Append<%= title(TypeName) %>(ctx, items[i])
 	}
 	return items
 }
 
-func (s *KeeperSuite) Test<%= title(TypeName) %>Get() {
-	items := s.createN<%= title(TypeName) %>(10)
+func Test<%= title(TypeName) %>Get(t *testing.T) {
+	keeper, ctx := setupKeeper(t)
+	items := createN<%= title(TypeName) %>(keeper, ctx, 10)
 	for _, item := range items {
-		s.Equal(item, s.Keeper.Get<%= title(TypeName) %>(s.SDKContext, item.Id))
+		assert.Equal(t, item, keeper.Get<%= title(TypeName) %>(ctx, item.Id))
 	}
 }
 
-func (s *KeeperSuite) Test<%= title(TypeName) %>Exist() {
-	items := s.createN<%= title(TypeName) %>(10)
+func Test<%= title(TypeName) %>Exist(t *testing.T) {
+	keeper, ctx := setupKeeper(t)
+	items := createN<%= title(TypeName) %>(keeper, ctx, 10)
 	for _, item := range items {
-		s.True(s.Keeper.Has<%= title(TypeName) %>(s.SDKContext, item.Id))
+		assert.True(t, keeper.Has<%= title(TypeName) %>(ctx, item.Id))
 	}
 }
 
-func (s *KeeperSuite) Test<%= title(TypeName) %>Remove() {
-	items := s.createN<%= title(TypeName) %>(10)
+func Test<%= title(TypeName) %>Remove(t *testing.T) {
+	keeper, ctx := setupKeeper(t)
+	items := createN<%= title(TypeName) %>(keeper, ctx, 10)
 	for _, item := range items {
-		s.Keeper.Remove<%= title(TypeName) %>(s.SDKContext, item.Id)
-		s.False(s.Keeper.Has<%= title(TypeName) %>(s.SDKContext, item.Id))
+		keeper.Remove<%= title(TypeName) %>(ctx, item.Id)
+		assert.False(t, keeper.Has<%= title(TypeName) %>(ctx, item.Id))
 	}
 }
 
-func (s *KeeperSuite) Test<%= title(TypeName) %>GetAll() {
-	items := s.createN<%= title(TypeName) %>(10)
-	s.Equal(items, s.Keeper.GetAll<%= title(TypeName) %>(s.SDKContext))
+func Test<%= title(TypeName) %>GetAll(t *testing.T) {
+	keeper, ctx := setupKeeper(t)
+	items := createN<%= title(TypeName) %>(keeper, ctx, 10)
+	assert.Equal(t, items, keeper.GetAll<%= title(TypeName) %>(ctx))
 }
 
-func (s *KeeperSuite) Test<%= title(TypeName) %>Count() {
-	items := s.createN<%= title(TypeName) %>(10)
+func Test<%= title(TypeName) %>Count(t *testing.T) {
+	keeper, ctx := setupKeeper(t)
+	items := createN<%= title(TypeName) %>(keeper, ctx, 10)
 	count := uint64(len(items))
-	s.Equal(count, s.Keeper.Get<%= title(TypeName) %>Count(s.SDKContext))
+	assert.Equal(t, count, keeper.Get<%= title(TypeName) %>Count(ctx))
 }


### PR DESCRIPTION
This PR has only setup code for the keeper that is initialized when a module is created. And tests for non-indexed type. The plan is to reuse `KeeperSuite` for `QuerierSuite` and `MsgServerSuite`.

I don't see any reasons to use table tests so far, maybe only as an example of how they can be written. Maybe I will change my opinion when I will extend this stuff.

I didn't add any new tests, since the change already covered by integration tests, that execute `go test ./...`.

related: https://github.com/tendermint/starport/issues/715