### PR TITLE
fix(templates): remove replacement string for keeper test setup code

### DIFF
--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -22,7 +22,6 @@ func NewIBC(opts *CreateOptions) (*genny.Generator, error) {
 	g.RunFn(genesisProtoModify(opts))
 	g.RunFn(keysModify(opts))
 	g.RunFn(keeperModify(opts))
-	g.RunFn(keeperTestSetupModify(opts))
 	g.RunFn(appModify(opts))
 
 	if err := g.Box(ibcTemplate); err != nil {
@@ -221,19 +220,6 @@ scopedKeeper:  scopedKeeper,`
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
-	}
-}
-
-func keeperTestSetupModify(opts *CreateOptions) genny.RunFn {
-	return func(r *genny.Runner) error {
-		path := fmt.Sprintf("x/%s/keeper/keeper_test.go", opts.ModuleName)
-		f, err := r.Disk.Find(path)
-		if err != nil {
-			return err
-		}
-		content := strings.Replace(f.String(), module.PlaceholderIBCTestKeeperSetup,
-			"nil, nil, nil,", 1)
-		return r.File(genny.NewFileS(path, content))
 	}
 }
 

--- a/starport/templates/module/create/ibc/x/{{moduleName}}/keeper/keeper_test.go.plush
+++ b/starport/templates/module/create/ibc/x/{{moduleName}}/keeper/keeper_test.go.plush
@@ -26,7 +26,10 @@ func setupKeeper(t testing.TB) (*Keeper, sdk.Context) {
 	require.NoError(t, stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
-	keeper := NewKeeper(codec.NewProtoCodec(registry), storeKey, memStoreKey)
+	keeper := NewKeeper(
+        codec.NewProtoCodec(registry), storeKey, memStoreKey,
+        nil, nil, nil,
+    )
 
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, log.NewNopLogger())
 	return keeper, ctx

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -62,5 +62,4 @@ const (
 	PlaceholderIBCAppScopedKeeperDefinition  = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/definition"
 	PlaceholderIBCAppKeeperArgument          = "// this line is used by starport scaffolding # ibc/app/keeper/argument"
 	PlaceholderIBCAppRouter                  = "// this line is used by starport scaffolding # ibc/app/router"
-	PlaceholderIBCTestKeeperSetup            = "// this line is used by starport scaffolding # ibc/keeper/testsetup"
 )


### PR DESCRIPTION
instead add new template for keeper_test that will have code that is required for ibc testing