### PR TITLE
chore(ci): run integration tests on self-hosted runner

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
later we'll be enabling parallel tests for testing things faster.