### PR TITLE
fix: use JSON marshalling to encode IBC packets and acknowledgements when scaffolding IBC modules and packets

### DIFF
--- a/starport/templates/ibc/packet.go
+++ b/starport/templates/ibc/packet.go
@@ -95,11 +95,11 @@ case *types.%[2]vPacketData_%[3]vPacket:
 		ack = channeltypes.NewErrorAcknowledgement(err.Error())
 	} else {
 		// Encode packet acknowledgment
-		packetAckBytes, err := packetAck.Marshal()
+		packetAckBytes, err := types.ModuleCdc.MarshalJSON(&packetAck)
 		if err != nil {
 			return nil, []byte{}, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 		}
-		ack = channeltypes.NewResultAcknowledgement(packetAckBytes)
+		ack = channeltypes.NewResultAcknowledgement(sdk.MustSortJSON(packetAckBytes))
 	}
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(

--- a/starport/templates/ibc/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
+++ b/starport/templates/ibc/packet/component/x/{{moduleName}}/keeper/{{packetName}}.go.plush
@@ -91,8 +91,8 @@ func (k Keeper) OnAcknowledgement<%= title(packetName) %>Packet(ctx sdk.Context,
 	case *channeltypes.Acknowledgement_Result:
         // Decode the packet acknowledgment
         var packetAck types.<%= title(packetName) %>PacketAck
-        err := packetAck.Unmarshal(dispatchedAck.Result)
-        if err != nil {
+
+        if err := types.ModuleCdc.UnmarshalJSON(dispatchedAck.Result, &packetAck); err != nil {
             // The counter-party module doesn't implement the correct acknowledgment format
             return errors.New("cannot unmarshal acknowledgment")
         }

--- a/starport/templates/module/create/ibc/x/{{moduleName}}/module_ibc.go.plush
+++ b/starport/templates/module/create/ibc/x/{{moduleName}}/module_ibc.go.plush
@@ -150,16 +150,10 @@ func (am AppModule) OnRecvPacket(
             return nil, []byte{}, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, errMsg)
     }
 
-    // Encode acknowledgement
-    ackBytes, err := ack.Marshal()
-    if err != nil {
-        return nil, []byte{}, sdkerrors.Wrap(sdkerrors.ErrInvalidType, err.Error())
-    }
-
 	// NOTE: acknowledgement will be written synchronously during IBC handler execution.
 	return &sdk.Result{
 		Events: ctx.EventManager().Events().ToABCIEvents(),
-	}, ackBytes, nil
+	}, ack.GetBytes(), nil
 }
 
 // OnAcknowledgementPacket implements the IBCModule interface
@@ -169,9 +163,10 @@ func (am AppModule) OnAcknowledgementPacket(
 	acknowledgement []byte,
 ) (*sdk.Result, error) {
 	var ack channeltypes.Acknowledgement
-	if err := ack.Unmarshal(acknowledgement); err != nil {
+    if err := types.ModuleCdc.UnmarshalJSON(acknowledgement, &ack); err != nil {
         return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet acknowledgement: %v", err)
     }
+
 	var modulePacketData types.<%= title(moduleName) %>PacketData
 	if err := modulePacketData.Unmarshal(modulePacket.GetData()); err != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "cannot unmarshal packet data: %s", err.Error())

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/codec.go.plush
@@ -19,5 +19,5 @@ func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
 
 var (
 	amino = codec.NewLegacyAmino()
-	ModuleCdc = codec.NewAminoCodec(amino)
+	ModuleCdc = codec.NewProtoCodec(cdctypes.NewInterfaceRegistry())
 )


### PR DESCRIPTION
Allows to use the tutorial with Starport with `ts-relayer`