### PR TITLE
fix: cannot create two messages in the same module

### DIFF
--- a/integration/cmd_message_test.go
+++ b/integration/cmd_message_test.go
@@ -29,6 +29,14 @@ func TestGenerateAnAppWithMessage(t *testing.T) {
 		ExecShouldError(),
 	))
 
+	env.Must(env.Exec("create a second message",
+		step.NewSteps(step.New(
+			step.Exec("starport", "message", "bar", "bar"),
+			step.Workdir(path),
+		)),
+		ExecShouldError(),
+	))
+
 	env.Must(env.Exec("create a module",
 		step.NewSteps(step.New(
 			step.Exec("starport", "module", "create", "foo", "--require-registration"),

--- a/starport/templates/message/stargate.go
+++ b/starport/templates/message/stargate.go
@@ -33,7 +33,7 @@ func handlerModify(replacer placeholder.Replacer, opts *Options) genny.RunFn {
 
 		// Set once the MsgServer definition if it is not defined yet
 		replacementMsgServer := `msgServer := keeper.NewMsgServerImpl(k)`
-		content := replacer.Replace(f.String(), PlaceholderHandlerMsgServer, replacementMsgServer)
+		content := replacer.ReplaceOnce(f.String(), PlaceholderHandlerMsgServer, replacementMsgServer)
 
 		templateHandlers := `%[1]v
 		case *types.Msg%[2]v:


### PR DESCRIPTION
A import in `/types/codec.go/` was replaced with `Replace` instead of `ReplaceOnce` and `MsgServer` in `handler.go` as well. This made it impossible to scaffold two messages in the same module

Use `ReplaceOnce` instead of `Replace`