### PR TITLE
fix(templates/ci): upgrade go version

### DIFF
--- a/starport/templates/app/stargate/.github/workflows/build.yml.plush
+++ b/starport/templates/app/stargate/.github/workflows/build.yml.plush
@@ -21,7 +21,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.16
         env:
           GOOS: ${{ matrix.targetos }}
           GOARCH: ${{ matrix.arch }}


### PR DESCRIPTION
This brings go to 1.16 in the scaffolded github action, so that it does not fail when asked to embed docs. 