### PR TITLE
fix(codeowners): make global owners to get added to all prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS: https://help.github.com/articles/about-codeowners/
 
-# Primary repo maintainers
-*       @fadeev @ilgooz @lubtd @dshulyak
-
 # Docs
 *.md    @barriebyron
+
+# Primary repo maintainers
+*       @fadeev @ilgooz @lubtd @dshulyak


### PR DESCRIPTION
let's see if this will fix it. before, other codeowners were not being automatically added as reviewers to PRs that updates .md files.