### PR TITLE
docs: Added client.openapi, removed 12345

### DIFF
--- a/docs/configure/reference.md
+++ b/docs/configure/reference.md
@@ -15,12 +15,12 @@ Only a default set of parameters is provided. If more nuanced configuration is r
 
 A list of user accounts created during genesis of the blockc
 
-Key      | Required | Type            | Description
--------- | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------
-name     | Y        | String          | Local name of a key pair. An account name must be listed to gain access to the account tokens after the blockchain is launched.
-coins    | Y        | List of Strings | Initial coins with denominations. For example, "1000token"
-address  | N        | String          | Account address in Bech32 address format
-mnemonic | N        | String          | Mnemonic used to generate an account. This field is ignored if `address` is specified
+| Key      | Required | Type            | Description                                                                                                                     |
+| -------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| name     | Y        | String          | Local name of a key pair. An account name must be listed to gain access to the account tokens after the blockchain is launched. |
+| coins    | Y        | List of Strings | Initial coins with denominations. For example, "1000token"                                                                      |
+| address  | N        | String          | Account address in Bech32 address format                                                                                        |
+| mnemonic | N        | String          | Mnemonic used to generate an account. This field is ignored if `address` is specified                                           |
 
 **accounts example**
 
@@ -35,9 +35,9 @@ accounts:
 
 ## `build`
 
-Key    | Required | Type   | Description
------- | -------- | ------ | --------------------------------------------------------------
-binary | N        | String | Name of the node binary that is built, typically ends with `d`
+| Key    | Required | Type   | Description                                                    |
+| ------ | -------- | ------ | -------------------------------------------------------------- |
+| binary | N        | String | Name of the node binary that is built, typically ends with `d` |
 
 **build example**
 
@@ -48,33 +48,45 @@ build:
 
 ## `build.proto`
 
-Key               | Required | Type            | Description
------------------ | -------- | --------------- | ------------------------------------------------------------------------------------------
-path              | N        | String          | Path to protocol buffer files. Default: `"proto"`
-third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]`
+| Key               | Required | Type            | Description                                                                                |
+| ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
+| path              | N        | String          | Path to protocol buffer files. Default: `"proto"`                                          |
+| third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]` |
 
 ## `client`
 
 Configures and enables client code generation. To prevent Starport from regenerating the client, remove the `client` property.
 
-```
+### `client.vuex`
+
+```yaml
 client:
   vuex:
     path: "vue/src/store"
 ```
 
-Generates TypeScript/Vuex client for the blockchain in `path` on `serve` and `build` commands.
+`client.vuex` generates TypeScript/Vuex client for the blockchain in `path` on `serve` and `build` commands.
+
+### `client.openapi`
+
+```yaml
+client:
+  openapi:
+    path: "docs/static/openapi.yml"
+```
+
+`client.openapi` generates OpenAPI YAML file in `path`. By default this file is embedded into the node's binary.
 
 ## `faucet`
 
 The faucet service sends tokens to addresses. The default address for the web user interface is <http://localhost:4500>.
 
-Key       | Required | Type            | Description
---------- | -------- | --------------- | -----------------------------------------------------------
-name      | Y        | String          | Name of a key pair. `name` must be in `accounts`
-coins     | Y        | List of Strings | One or more coins with denominations sent per request
-coins_max | N        | List of Strings | One or more maximum amounts of tokens sent for each address
-host      | N        | String          | Host and port number. Default: `:4500`
+| Key       | Required | Type            | Description                                                 |
+| --------- | -------- | --------------- | ----------------------------------------------------------- |
+| name      | Y        | String          | Name of a key pair. `name` must be in `accounts`            |
+| coins     | Y        | List of Strings | One or more coins with denominations sent per request       |
+| coins_max | N        | List of Strings | One or more maximum amounts of tokens sent for each address |
+| host      | N        | String          | Host and port number. Default: `:4500`                      |
 
 **faucet example**
 
@@ -90,10 +102,10 @@ faucet:
 
 A blockchain requires one or more validators.
 
-Key    | Required | Type   | Description
------- | -------- | ------ | -----------------------------------------------------------------------------------------------
-name   | Y        | String | The account that is used to initialize the validator. The `name` key pair must be in `accounts`
-staked | Y        | String | Amount of coins to bond. Must be less than or equal to the amount of coins in the account
+| Key    | Required | Type   | Description                                                                                     |
+| ------ | -------- | ------ | ----------------------------------------------------------------------------------------------- |
+| name   | Y        | String | The account that is used to initialize the validator. The `name` key pair must be in `accounts` |
+| staked | Y        | String | Amount of coins to bond. Must be less than or equal to the amount of coins in the account       |
 
 **validator example**
 
@@ -142,15 +154,13 @@ Configuration of host names and ports for processes started by Starport:
 
 **host example**
 
-```
+```yaml
 host:
   rpc: ":26659"
   p2p: ":26658"
   prof: ":6061"
   grpc: ":9091"
   api: ":1318"
-  frontend: ":8081"
-  dev-ui: ":12346"
 ```
 
 ## `genesis`


### PR DESCRIPTION
* Added `client.openapi`
* Removed 12345 from `host`

@barriebyron do you think you can set up your editor to format tables like in this PR? It's a bit easier to read when in text editor, in my opinion. This is the default way VS Code formats tables in Markdown.