### PR TITLE
docs: install, mention setting go env vars

### DIFF
--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -9,7 +9,12 @@ You can run Starport in a web-based Gitpod IDE or you can install Starport on yo
 
 ## Prerequisite
 
-Starport is written in the Go programming language. To use Starport on a local system, [Go](https://golang.org/doc/install) (**version 1.16** or higher) must be installed. Please, make sure that Go environment variables on your systems [are set properly](https://golang.org/doc/gopath_code#GOPATH).
+Starport is written in the Go programming language. To use Starport on a local system:
+
+ - Install [Go](https://golang.org/doc/install) (**version 1.16** or higher)
+ - Ensure the Go environment variables are [set properly(https://golang.org/doc/gopath_code#GOPATH) on your system
+ 
+**Tip:** If you get the message `appd: command not found` then your Go environment variables might not be set correctly.
 
 ## Upgrading Your Starport Installation
 

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -9,7 +9,7 @@ You can run Starport in a web-based Gitpod IDE or you can install Starport on yo
 
 ## Prerequisite
 
-Starport is written in the Go programming language. To use Starport on a local installation, [Go](https://golang.org/doc/install) (**version 1.16** or higher) must be installed.
+Starport is written in the Go programming language. To use Starport on a local system, [Go](https://golang.org/doc/install) (**version 1.16** or higher) must be installed. Please, make sure that Go environment variables on your systems [are set properly](https://golang.org/doc/gopath_code#GOPATH).
 
 ## Upgrading Your Starport Installation
 


### PR DESCRIPTION
A good chunk of questions we get on Discord is about `appd: command not found`. Let's mention this more explicitly in the install doc.