### PR TITLE
refactor(cmd): add 'chain' command and

### DIFF
--- a/integration/env_test.go
+++ b/integration/env_test.go
@@ -176,6 +176,7 @@ func (e env) Scaffold(appName string) (appPath string) {
 // unless calling with Must(), Serve() will not exit test runtime on failure.
 func (e env) Serve(msg, path, home, configPath string, options ...execOption) (ok bool) {
 	serveCommand := []string{
+		"chain",
 		"serve",
 		"-v",
 	}

--- a/starport/cmd/chain.go
+++ b/starport/cmd/chain.go
@@ -7,7 +7,7 @@ import "github.com/spf13/cobra"
 func NewChain() *cobra.Command {
 	c := &cobra.Command{
 		Use:     "chain [command]",
-		Short:   "Compile, serve blockchains and so on",
+		Short:   "Build, initialize, and start a blockchain",
 		Aliases: []string{"c"},
 		Args:    cobra.ExactArgs(1),
 	}

--- a/starport/cmd/chain.go
+++ b/starport/cmd/chain.go
@@ -1,0 +1,20 @@
+package starportcmd
+
+import "github.com/spf13/cobra"
+
+// NewChain returns a command that groups sub commands related to compiling, serving
+// blockchains and so on.
+func NewChain() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "chain [command]",
+		Short:   "Compile, serve blockchains and so on",
+		Aliases: []string{"c"},
+		Args:    cobra.ExactArgs(1),
+	}
+
+	c.AddCommand(NewChainServe())
+	c.AddCommand(NewChainBuild())
+	c.AddCommand(NewChainFaucet())
+
+	return c
+}

--- a/starport/cmd/chain_build.go
+++ b/starport/cmd/chain_build.go
@@ -15,8 +15,8 @@ const (
 	flagReleasePrefix    = "release.prefix"
 )
 
-// NewBuild returns a new build command to build a blockchain app.
-func NewBuild() *cobra.Command {
+// NewChainBuild returns a new build command to build a blockchain app.
+func NewChainBuild() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "build",
 		Short: "Build a node binary",
@@ -32,7 +32,7 @@ Sample usages:
 	- starport build
 	- starport build --release -t linux:amd64 -t darwin:amd64 -t darwin:arm64`,
 		Args: cobra.ExactArgs(0),
-		RunE: buildHandler,
+		RunE: chainBuildHandler,
 	}
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().StringVarP(&appPath, "path", "p", ".", "path of the app")
@@ -44,7 +44,7 @@ Sample usages:
 	return c
 }
 
-func buildHandler(cmd *cobra.Command, args []string) error {
+func chainBuildHandler(cmd *cobra.Command, args []string) error {
 	isRebuildProtoOnce, err := cmd.Flags().GetBool(flagRebuildProtoOnce)
 	if err != nil {
 		return err

--- a/starport/cmd/chain_faucet.go
+++ b/starport/cmd/chain_faucet.go
@@ -10,13 +10,13 @@ import (
 	"github.com/tendermint/starport/starport/services/chain"
 )
 
-// NewFaucet creates a new faucet command to send coins to accounts.
-func NewFaucet() *cobra.Command {
+// NewChainFaucet creates a new faucet command to send coins to accounts.
+func NewChainFaucet() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "faucet [address] [coin<,...>]",
 		Short: "Send coins to an account",
 		Args:  cobra.ExactArgs(2),
-		RunE:  faucetHandler,
+		RunE:  chainFaucetHandler,
 	}
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().StringVarP(&appPath, "path", "p", "", "path of the app")
@@ -24,7 +24,7 @@ func NewFaucet() *cobra.Command {
 	return c
 }
 
-func faucetHandler(cmd *cobra.Command, args []string) error {
+func chainFaucetHandler(cmd *cobra.Command, args []string) error {
 	var (
 		toAddress = args[0]
 		coins     = args[1]

--- a/starport/cmd/chain_serve.go
+++ b/starport/cmd/chain_serve.go
@@ -12,14 +12,14 @@ const flagConfig = "config"
 
 var appPath string
 
-// NewServe creates a new serve command to serve a blockchain.
-func NewServe() *cobra.Command {
+// NewChainServe creates a new serve command to serve a blockchain.
+func NewChainServe() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "serve",
 		Short: "Start a blockchain node in development",
 		Long:  "Start a blockchain node with automatic reloading",
 		Args:  cobra.ExactArgs(0),
-		RunE:  serveHandler,
+		RunE:  chainServeHandler,
 	}
 	c.Flags().AddFlagSet(flagSetHome())
 	c.Flags().StringVarP(&appPath, "path", "p", "", "Path of the app")
@@ -32,7 +32,7 @@ func NewServe() *cobra.Command {
 	return c
 }
 
-func serveHandler(cmd *cobra.Command, args []string) error {
+func chainServeHandler(cmd *cobra.Command, args []string) error {
 	isRebuildProtoOnce, err := cmd.Flags().GetBool(flagRebuildProtoOnce)
 	if err != nil {
 		return err

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -36,12 +36,10 @@ func New() *cobra.Command {
 			return goenv.ConfigurePath()
 		},
 	}
+	c.AddCommand(NewChain())
 	c.AddCommand(NewDocs())
 	c.AddCommand(NewApp())
 	c.AddCommand(NewType())
-	c.AddCommand(NewServe())
-	c.AddCommand(NewFaucet())
-	c.AddCommand(NewBuild())
 	c.AddCommand(NewModule())
 	c.AddCommand(NewRelayer())
 	c.AddCommand(NewVersion())

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -141,5 +141,17 @@ func deprecated() []*cobra.Command {
 			Use:        "app",
 			Deprecated: "use `starport scaffold chain` instead.",
 		},
+		{
+			Use:        "build",
+			Deprecated: "use `starport chain build` instead.",
+		},
+		{
+			Use:        "serve",
+			Deprecated: "use `starport chain serve` instead.",
+		},
+		{
+			Use:        "faucet",
+			Deprecated: "use `starport chain faucet` instead.",
+		},
 	}
 }


### PR DESCRIPTION
move 'serve', 'build' and 'faucet' commands to under 'chain'.

related to #1244.