### PR TITLE
fix: solve the race condition for the clispinner

### DIFF
--- a/starport/pkg/clispinner/clispinner.go
+++ b/starport/pkg/clispinner/clispinner.go
@@ -23,19 +23,22 @@ func New() *Spinner {
 	s := &Spinner{
 		sp: sp,
 	}
-	s.SetText("Initializing...")
-	return s
+	return s.SetText("Initializing...")
 }
 
 // SetText sets the text for spinner.
 func (s *Spinner) SetText(text string) *Spinner {
+	s.sp.Lock()
 	s.sp.Suffix = " " + text
+	s.sp.Unlock()
 	return s
 }
 
 // SetPrefix sets the prefix for spinner.
 func (s *Spinner) SetPrefix(text string) *Spinner {
+	s.sp.Lock()
 	s.sp.Prefix = text + " "
+	s.sp.Unlock()
 	return s
 }
 
@@ -60,9 +63,9 @@ func (s *Spinner) Start() *Spinner {
 // Stop stops spinning.
 func (s *Spinner) Stop() *Spinner {
 	s.sp.Stop()
-	s.SetColor(spinnerColor)
-	s.SetPrefix("")
-	s.SetCharset(charset)
+	s.sp.Prefix = ""
+	s.sp.Color(spinnerColor)
+	s.sp.UpdateCharSet(charset)
 	s.sp.Stop()
 	return s
 }


### PR DESCRIPTION
Closes #1265

### What does this PR does?

Fix the data race condition for the CLISpinner. 

#### Considerations

The current spinner has some data race conditions, and using the locks provided by the package can stuck the main goroutine and stop the application. The issue can be reproduced by calling a `lock` after calling the `stop` method.

### How to test?

Scaffolding a new application with the Golang `-race` parameters active
