### PR TITLE
fix: update some part with the new command name format

### DIFF
--- a/.gitpod/readme.md
+++ b/.gitpod/readme.md
@@ -9,7 +9,7 @@ In this browser-based development environment, the terminal window is in the low
 To create a blockchain and start a node in development:
 
 ```
-starport scaffold app github.com/user/hello
+starport scaffold chain github.com/user/hello
 
 cd hello
 

--- a/.gitpod/readme.md
+++ b/.gitpod/readme.md
@@ -9,11 +9,11 @@ In this browser-based development environment, the terminal window is in the low
 To create a blockchain and start a node in development:
 
 ```
-starport app github.com/user/hello
+starport scaffold app github.com/user/hello
 
 cd hello
 
-starport serve
+starport chain serve
 ```
 
 ## Next steps

--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,11 @@ Starport is the easiest way to build a blockchain. It is a developer-friendly in
 Open Starport [in your browser](https://gitpod.io/#https://github.com/tendermint/starport/tree/master), or [install it](https://docs.starport.network/intro/install). Create and start a blockchain:
 
 ```
-starport app github.com/alice/chain
+starport scaffold app github.com/alice/chain
 
 cd chain
 
-starport serve
+starport chain serve
 ```
 
 ## Documentation

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Starport is the easiest way to build a blockchain. It is a developer-friendly in
 Open Starport [in your browser](https://gitpod.io/#https://github.com/tendermint/starport/tree/master), or [install it](https://docs.starport.network/intro/install). Create and start a blockchain:
 
 ```
-starport scaffold app github.com/alice/chain
+starport scaffold chain github.com/alice/chain
 
 cd chain
 

--- a/starport/cmd/scaffold_chain.go
+++ b/starport/cmd/scaffold_chain.go
@@ -57,7 +57,7 @@ func scaffoldChainHandler(cmd *cobra.Command, args []string) error {
 👉 Get started with the following commands:
 
  %% cd %[1]v
- %% starport serve
+ %% starport chain serve
 
 Documentation: https://docs.starport.network
 `

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -179,7 +179,7 @@ func (c *Chain) Serve(ctx context.Context, options ...ServeOption) error {
 					// We suggest the user to eventually reset the app state
 					if parsedErr == "" {
 						fmt.Fprintf(c.stdLog().out, "%s %s\n", infoColor(`Blockchain failed to start.
-If the new code is no longer compatible with the saved state, you can reset the database by launching:`), "starport serve --reset-once")
+If the new code is no longer compatible with the saved state, you can reset the database by launching:`), "starport chain serve --reset-once")
 
 						return fmt.Errorf("cannot run %s", startErr.AppName)
 					}

--- a/starport/templates/app/stargate/readme.md.plush
+++ b/starport/templates/app/stargate/readme.md.plush
@@ -4,7 +4,7 @@
 ## Get started
 
 ```
-starport serve
+starport chain serve
 ```
 
 `serve` command installs dependencies, builds, initializes, and starts your blockchain in development.


### PR DESCRIPTION
Update `starport app` -> `starport scaffold app`
`starport serve` -> `starport chain serve`

In some area where the command is mentioned