### PR TITLE
improvement(cmd): rename --no-default-module to --no-module

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -961,7 +961,7 @@ starport scaffold chain [github.com/org/repo] [flags]
 ```
       --address-prefix string   Address prefix (default "cosmos")
   -h, --help                    help for chain
-      --no-default-module       Prevent scaffolding a default module in the app
+      --no-default              Prevent scaffolding a default module in the app
 ```
 
 **SEE ALSO**

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -961,7 +961,7 @@ starport scaffold chain [github.com/org/repo] [flags]
 ```
       --address-prefix string   Address prefix (default "cosmos")
   -h, --help                    help for chain
-      --no-default              Prevent scaffolding a default module in the app
+      --no-module              Prevent scaffolding a default module in the app
 ```
 
 **SEE ALSO**
@@ -1081,4 +1081,3 @@ starport version [flags]
 **SEE ALSO**
 
 * [starport](#starport)	 - A developer tool for building Cosmos SDK blockchains
-

--- a/integration/cmd_app_test.go
+++ b/integration/cmd_app_test.go
@@ -38,7 +38,7 @@ func TestGenerateAnAppWithNoDefaultModule(t *testing.T) {
 				"scaffold",
 				"chain",
 				fmt.Sprintf("github.com/test/%s", appName),
-				"--no-default-module",
+				"--no-module",
 			),
 			step.Workdir(root),
 		)),

--- a/starport/cmd/scaffold_chain.go
+++ b/starport/cmd/scaffold_chain.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	flagAddressPrefix   = "address-prefix"
-	flagNoDefaultModule = "no-default-module"
+	flagNoDefaultModule = "no-module"
 )
 
 // NewScaffoldChain creates new command to scaffold a Comos-SDK based blockchain.


### PR DESCRIPTION
Signed-off-by: Sonia Singla <soniasingla.1812@gmail.com>

Rename --no-default-module to --no-module.

Fixes #1345 