### PR TITLE
chore(templates/ci): do not build arm binaries

### DIFF
--- a/starport/templates/app/stargate/.github/workflows/release.yml
+++ b/starport/templates/app/stargate/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: tendermint/starport/actions/cli@develop
         if: ${{ steps.vars.outputs.should_release == 'true' }}
         with:
-          args: chain build --release --release.prefix ${{ steps.vars.outputs.tarball_prefix }} -t linux:amd64 -t linux:arm64 -t darwin:amd64 -t darwin:arm64
+          args: chain build --release --release.prefix ${{ steps.vars.outputs.tarball_prefix }} -t linux:amd64 -t darwin:amd64
 
       - name: Delete the "latest" Release
         uses: dev-drprasad/delete-tag-and-release@v0.2.0


### PR DESCRIPTION
Because chains scaffold with Starport uses _tendermint/spm_ and this adds `wasm` entry to chain's `go.sum`, therefore chain cannot compile to arm64.