### PR TITLE
fix(cmd/generate): vuex and openapi cmds should work

### DIFF
--- a/starport/cmd/generate_vuex.go
+++ b/starport/cmd/generate_vuex.go
@@ -15,8 +15,6 @@ func NewGenerateVuex() *cobra.Command {
 		RunE:  generateVuexHandler,
 	}
 
-	c.Flags().Bool(flagRebuildProtoOnce, false, "Enables proto code generation for 3rd party modules.")
-
 	return c
 }
 
@@ -24,15 +22,7 @@ func generateVuexHandler(cmd *cobra.Command, args []string) error {
 	s := clispinner.New().SetText("Generating...")
 	defer s.Stop()
 
-	isRebuildProtoOnce, _ := cmd.Flags().GetBool(flagRebuildProtoOnce)
-
-	chainOption := []chain.Option{}
-
-	if isRebuildProtoOnce {
-		chainOption = append(chainOption, chain.EnableThirdPartyModuleCodegen())
-	}
-
-	c, err := newChainWithHomeFlags(cmd, appPath, chainOption...)
+	c, err := newChainWithHomeFlags(cmd, appPath, chain.EnableThirdPartyModuleCodegen())
 	if err != nil {
 		return err
 	}

--- a/starport/services/chain/generate.go
+++ b/starport/services/chain/generate.go
@@ -47,7 +47,22 @@ func GenerateOpenAPI() GenerateTarget {
 }
 
 func (c *Chain) generateAll(ctx context.Context) error {
-	return c.Generate(ctx, GenerateGo(), GenerateVuex(), GenerateOpenAPI())
+	conf, err := c.Config()
+	if err != nil {
+		return err
+	}
+
+	var additionalTargets []GenerateTarget
+
+	if conf.Client.Vuex.Path != "" {
+		additionalTargets = append(additionalTargets, GenerateVuex())
+	}
+
+	if conf.Client.OpenAPI.Path != "" {
+		additionalTargets = append(additionalTargets, GenerateVuex())
+	}
+
+	return c.Generate(ctx, GenerateGo(), additionalTargets...)
 }
 
 // Generate makes code generation from proto files for given target and additionalTargets.

--- a/starport/services/chain/generate.go
+++ b/starport/services/chain/generate.go
@@ -59,7 +59,7 @@ func (c *Chain) generateAll(ctx context.Context) error {
 	}
 
 	if conf.Client.OpenAPI.Path != "" {
-		additionalTargets = append(additionalTargets, GenerateVuex())
+		additionalTargets = append(additionalTargets, GenerateOpenAPI())
 	}
 
 	return c.Generate(ctx, GenerateGo(), additionalTargets...)


### PR DESCRIPTION
whether if 'client' section presents or not in the 'config.yml'.