### PR TITLE
feat(codegen): add file path for code generation errs

### DIFF
--- a/starport/pkg/protoanalysis/parser.go
+++ b/starport/pkg/protoanalysis/parser.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/emicklei/proto"
+	"github.com/pkg/errors"
 	"github.com/tendermint/starport/starport/pkg/localfs"
 )
 
@@ -31,7 +32,7 @@ func parse(ctx context.Context, path, pattern string) ([]*pkg, error) {
 			return nil, ctx.Err()
 		}
 		if err := pr.parseFile(path); err != nil {
-			return nil, err
+			return nil, errors.Wrapf(err, "file: %s", path)
 		}
 	}
 


### PR DESCRIPTION
related to invalid .proto files.

instead of just returning with the parsing error, path info for the
related file also included. e.g.:

```
file: /home/ilker/Documents/code/src/github.com/tendermint/starport/local_test/mov/proto/mov/tx.proto: <input>:17:1: found "}" but expected [field =]
```

related to https://github.com/tendermint/starport/issues/1342.