### PR TITLE
feat(cmd): check for a new version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@
 # Project variables.
 PROJECT_NAME = starport
 DATE := $(shell date '+%Y-%m-%dT%H:%M:%S')
-VERSION = development
 HEAD = $(shell git rev-parse HEAD)
-LD_FLAGS = -X github.com/tendermint/starport/starport/internal/version.Version='$(VERSION)' \
-	-X github.com/tendermint/starport/starport/internal/version.Head='$(HEAD)' \
+LD_FLAGS = -X github.com/tendermint/starport/starport/internal/version.Head='$(HEAD)' \
 	-X github.com/tendermint/starport/starport/internal/version.Date='$(DATE)'
 BUILD_FLAGS = -mod=readonly -ldflags='$(LD_FLAGS)'
 BUILD_FOLDER = ./dist

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/Microsoft/hcsshim v0.8.17 // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/briandowns/spinner v1.11.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/charmbracelet/glow v1.4.0
@@ -22,6 +23,7 @@ require (
 	github.com/gobuffalo/plush v3.8.3+incompatible
 	github.com/gobuffalo/plushgen v0.1.2
 	github.com/goccy/go-yaml v1.8.0
+	github.com/google/go-github/v37 v37.0.0
 	github.com/gookit/color v1.2.7
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/rpc v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/briandowns/spinner v1.11.1 h1:OixPqDEcX3juo5AjQZAnFPbeUA0jvkp2qzB5gOZJ/L0=
@@ -595,8 +596,13 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -3,6 +3,7 @@ package starportcmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -168,6 +169,10 @@ func deprecated() []*cobra.Command {
 }
 
 func checkNewVersion(ctx context.Context) {
+	if os.Getenv("GITPOD_WORKSPACE_ID") != "" {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, checkVersionTimeout)
 	defer cancel()
 

--- a/starport/cmd/starport/main.go
+++ b/starport/cmd/starport/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	ctx := clictx.From(context.Background())
 
-	err := starportcmd.New().ExecuteContext(ctx)
+	err := starportcmd.New(ctx).ExecuteContext(ctx)
 
 	if ctx.Err() == context.Canceled || err == context.Canceled {
 		fmt.Println("aborted")

--- a/starport/internal/tools/gen-cli-docs/main.go
+++ b/starport/internal/tools/gen-cli-docs/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -35,7 +36,7 @@ func main() {
 	outPath := flag.String("out", ".", ".md file path to place Starport CLI docs inside")
 	flag.Parse()
 
-	if err := generate(starportcmd.New(), *outPath); err != nil {
+	if err := generate(starportcmd.New(context.Background()), *outPath); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/starport/internal/version/version.go
+++ b/starport/internal/version/version.go
@@ -1,13 +1,21 @@
 package version
 
 import (
+	"context"
 	"fmt"
 	"runtime"
+	"strings"
+
+	"github.com/blang/semver"
+	"github.com/google/go-github/v37/github"
 )
+
+const versionDev = "development"
+const prefix = "v"
 
 var (
 	// Version is the semantic version of Starport.
-	Version = ""
+	Version = versionDev
 
 	// Date is the build date of Starport.
 	Date = ""
@@ -15,6 +23,40 @@ var (
 	// Head is the HEAD of the current branch.
 	Head = ""
 )
+
+// CheckNext checks whether there is a new version of Starport.
+func CheckNext(ctx context.Context) (isAvailable bool, version string, err error) {
+	if Version == versionDev {
+		return false, "", nil
+	}
+
+	latest, _, err := github.
+		NewClient(nil).
+		Repositories.
+		GetLatestRelease(ctx, "tendermint", "starport")
+
+	if err != nil {
+		return false, "", err
+	}
+
+	if latest.TagName == nil {
+		return false, "", err
+	}
+
+	currentVersion, err := semver.Parse(strings.TrimPrefix(Version, prefix))
+	if err != nil {
+		return false, "", err
+	}
+
+	latestVersion, err := semver.Parse(strings.TrimPrefix(*latest.TagName, prefix))
+	if err != nil {
+		return false, "", err
+	}
+
+	isAvailable = latestVersion.GT(currentVersion)
+
+	return isAvailable, *latest.TagName, nil
+}
 
 // Long generates a detailed version info.
 func Long() string {

--- a/starport/internal/version/version.go
+++ b/starport/internal/version/version.go
@@ -40,7 +40,7 @@ func CheckNext(ctx context.Context) (isAvailable bool, version string, err error
 	}
 
 	if latest.TagName == nil {
-		return false, "", err
+		return false, "", nil
 	}
 
 	currentVersion, err := semver.Parse(strings.TrimPrefix(Version, prefix))


### PR DESCRIPTION
and print instructions to upgrade.

this is how it looks like:

```
·
· 🛸 Starport "v0.16.2" is available!
·
· If you're looking to upgrade check out the instructions: https://docs.starport.network/intro/install.html#upgrading-your-starport-installation
·
··

Starport is a tool for creating sovereign blockchains built with Cosmos SDK, the world’s
most popular modular blockchain framework. Starport offers everything you need to scaffold,
test, build, and launch your blockchain.

To get started, create a blockchain:

starport scaffold chain github.com/cosmonaut/mars

Usage:
  starport [command]

Available Commands:
  scaffold    Scaffold a new blockchain, module, message, query, and more
  chain       Build, initialize and start a blockchain node or perform other actions on the blockchain
  generate    Generate clients, API docs from source code
  network     Launch a blockchain network in production
  relayer     Connects blockchains via IBC protocol
  tools       Tools for advanced users
  docs        Show Starport docs
  version     Print the current build information
  help        Help about any command

Flags:
  -h, --help   help for starport

Use "starport [command] --help" for more information about a command.
```