### PR TITLE
fix(pkg/ctxreader): Fix the data race after the context timeout

### DIFF
--- a/starport/pkg/ctxreader/ctxreader.go
+++ b/starport/pkg/ctxreader/ctxreader.go
@@ -6,10 +6,16 @@ import (
 	"io"
 )
 
-type cancelableReader struct {
-	io.Reader
-	ctx context.Context
-}
+type (
+	cancelableReader struct {
+		io.Reader
+		ctx context.Context
+	}
+	ioReadResult struct {
+		n   int
+		err error
+	}
+)
 
 // New returns a new reader that emits a context error through its r.Read() method
 // when ctx canceled.
@@ -18,18 +24,21 @@ func New(ctx context.Context, r io.Reader) io.Reader {
 }
 
 func (r *cancelableReader) Read(data []byte) (n int, err error) {
-	isRead := make(chan struct{})
+	chData := make([]byte, len(data))
+	chResult := make(chan ioReadResult, 1)
 
 	go func() {
-		n, err = r.Reader.Read(data)
-		close(isRead)
+		n, err := r.Reader.Read(chData)
+		chResult <- ioReadResult{n, err}
+		close(chResult)
 	}()
 
 	select {
 	case <-r.ctx.Done():
 		return 0, r.ctx.Err()
 
-	case <-isRead:
-		return
+	case ret := <-chResult:
+		copy(data, chData)
+		return ret.n, ret.err
 	}
 }

--- a/starport/pkg/ctxreader/ctxreader.go
+++ b/starport/pkg/ctxreader/ctxreader.go
@@ -20,8 +20,8 @@ func New(ctx context.Context, r io.Reader) io.Reader {
 	return &cancelableReader{Reader: r, ctx: ctx}
 }
 
-// Read reads up to len(p) bytes into p. It returns the number of bytes
-// read (0 <= n <= len(p)) and any error encountered.
+// Read implements io.Reader and it stops blocking when reading is completed
+// or context is cancelled.
 func (r *cancelableReader) Read(data []byte) (n int, err error) {
 	r.m.Lock()
 	defer r.m.Unlock()


### PR DESCRIPTION
closes #1303

### What does this MR does?

All cancelable readers reach the timeout deadline make a data race condition to close the `Read` method.

### Changes

- Fix the data race condition using channels;
- Return the Reader error;

### How to test?

Run the unit test: ` go test -v -race github.com/tendermint/starport/starport/pkg/ctxreader/...`
