### PR TITLE
fix: error when using a custom index for map that includes more than two word

### DIFF
--- a/integration/cmd_map_test.go
+++ b/integration/cmd_map_test.go
@@ -59,7 +59,7 @@ func TestCreateMapWithStargate(t *testing.T) {
 
 	env.Must(env.Exec("create a map with custom indexes",
 		step.NewSteps(step.New(
-			step.Exec("starport", "s", "map", "map_with_index", "email", "--index", "foo:string,bar:int,foobar:uint,barfoo:bool"),
+			step.Exec("starport", "s", "map", "map_with_index", "email", "--index", "foo:string,bar:int,foobar:uint,barFoo:bool"),
 			step.Workdir(path),
 		)),
 	))

--- a/starport/templates/typed/indexed/stargate.go
+++ b/starport/templates/typed/indexed/stargate.go
@@ -94,11 +94,11 @@ import "%s/%s.proto";`
 		)
 		content := replacer.Replace(f.String(), typed.Placeholder, replacementImport)
 
-		var lowercaseIndexes []string
+		var lowerCamelIndexes []string
 		for _, index := range opts.Indexes {
-			lowercaseIndexes = append(lowercaseIndexes, fmt.Sprintf("{%s}", index.Name.Lowercase))
+			lowerCamelIndexes = append(lowerCamelIndexes, fmt.Sprintf("{%s}", index.Name.LowerCamel))
 		}
-		indexPath := strings.Join(lowercaseIndexes, "/")
+		indexPath := strings.Join(lowerCamelIndexes, "/")
 
 		// Add the service
 		templateService := `%[1]v


### PR DESCRIPTION
The rpc query path used a wrong naming convention for the index name by setting all characters to lowercase.
For example running `starport s map foo --index fooBar` fails

We set it to lower camel case so it can correctly retrieve the field in the type.

We also add a test to include this case.