### PR TITLE
docs: how to install go

### DIFF
--- a/docs/intro/docker.md
+++ b/docs/intro/docker.md
@@ -1,5 +1,5 @@
 ---
-order: 3
+order: 4
 description: Run Starport CLI using a Docker container.
 ---
 
@@ -17,7 +17,7 @@ Experimentation and file system impact is limited to the Docker instance. The ho
 
 Docker must be installed. See [Get Started with Docker](https://www.docker.com/get-started).
 
-## Starport Commands in Docker 
+## Starport Commands in Docker
 
 After you scaffold and start a chain in your Docker container, all Starport commands are available. Just type the commands after `docker run -ti starport/cli`. For example:
 
@@ -48,7 +48,6 @@ Be patient, this command takes a minute or two to run because it does everything
     Using `-w` and `-v` together provides file persistence on the host machine. The application source code on the Docker container is mirrored to the file system of the host machine.
 
     **Note:** The directory name for the `-w` and `-v` flags can be a name other then `/app`, but the same directory must be specified for both flags. If you omit `-w` and `-v`, the changes are made in the container only and are lost when that container is shut down.
-
 
 ## Starting a Blockchain
 

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -7,7 +7,7 @@ description: Install the Go programming language
 
 In this tutorial, you will install the Go programming language (golang) on your local computer. Follow the instructions for your operating system:
 
-## Mac OS X
+## macOS
 
 * Download the latest MacOS installer package from <https://golang.org/dl/>.
 * Open the downloaded package and follow the prompts through to completion.

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -69,10 +69,37 @@ source ~/.bash_profile
 go version
 ```
 
-## Windows
+## Windows Subsystem for Linux (WSL)
 
-* Download the latest windows distribution package from <https://golang.org/dl/>.
-* Open the MSI file you downloaded and follow the prompts to install Go.
+* Download the latest Linux distribution package from <https://golang.org/dl/>.
+* Extract the archive you downloaded and move into the `/usr/local` directory by running:
+
+```sh
+sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
+```
+
+* To add Go to your `.bash_profile` file:
+
+    1. Open `.bash_profile` profile using:
+
+        ```sh
+        nano ~/.bash_profile
+        ```
+
+    2. Add the following lines in your `.bash_profile` profile:
+
+        ```sh
+        export GOROOT=/usr/local/go
+        export GOPATH=$HOME/go
+        export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+        ```
+
+* To make sure the above changes are applied, run the following command:
+
+```sh
+~/.bash_profile
+```
+
 * Verify the installation of go using:
 
 ```sh

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -26,7 +26,7 @@ In this tutorial, you will install the Go programming language (Golang) on your 
         source ~/.profile
         ```
 
-* Verify the installation of go by checking its version:
+* Verify that you have installed Go by running the following command to check the version:
 
     ```sh
     go version
@@ -34,14 +34,20 @@ In this tutorial, you will install the Go programming language (Golang) on your 
 
 ## Linux
 
-* Download the latest Linux distribution package from <https://golang.org/dl/>.
+* Download the latest Linux distribution package from [Go downloads](https://golang.org/dl/).
 * Extract the archive you downloaded into `/usr/local` using the following command:
+
+```sh
+sudo tar -C /usr/local -xzf gox.xx.x.linux-amd64.tar.gz
+```
+
+For example, to install version 1.16.6:
 
 ```sh
 sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 ```
 
-**Note - Make sure to install the latest version available at that time.**
+**Note:** Make sure to install the latest supported version.
 
 * To add Go to your `.profile` file:
 
@@ -51,13 +57,13 @@ sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
         export PATH=$PATH:$(go env GOPATH)/bin:/usr/local/go/bin
         ```
 
-* To make sure the above changes are applied, run the following command:
+* To make sure these changes are applied to `~/.profile`, run the following command:
 
 ```sh
 source ~/.profile
 ```
 
-* Verify the installation of go using:
+* Verify that you have installed Go by running the following command to check the version:
 
 ```sh
 go version
@@ -82,13 +88,13 @@ sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
         export PATH=$PATH:$(go env GOPATH)/bin
         ```
 
-* To make sure the above changes are applied, run the following command:
+* To make sure these changes are applied to `~/.profile`, run the following command:
 
 ```sh
 source ~/.profile
 ```
 
-* Verify the installation of go using:
+* Verify that you have installed Go by running the following command to check the version:
 
 ```sh
 go version

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -20,7 +20,7 @@ In this tutorial, you will install the Go programming language (Golang) on your 
         export PATH=$PATH:$(go env GOPATH)/bin
         ```
 
-    3. To make sure these changes execute, run the following command:
+    3. To make sure these changes are applied, run the following command:
 
         ```sh
         source ~/.profile
@@ -43,10 +43,9 @@ sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 
 **Note - Make sure to install the latest version available at that time.**
 
-* To add Go to your `.bash_profile` file:
+* To add Go to your `.profile` file:
 
-    1. Open `~/.profile` file with your favorite command-line text editor.
-    2. Add the following lines in your `.bash_profile` file:
+    1. Open `~/.profile` file with your favorite command-line text editor and add the following line.
 
         ```sh
         export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
@@ -75,14 +74,12 @@ sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
 
 **Note - Make sure to install the latest version available at that time.**
 
-* To add Go to your `.bash_profile` file:
+* To add Go to your `.profile` file:
 
-    1. Open `~/.profile` file with your favorite command-line text editor.
-    2. Add the following lines in your `.bash_profile` profile:
+    1. Open `~/.profile` file with your favorite command-line text editor and add the following line.
 
         ```sh
-        export GOPATH=$HOME/go
-        export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+        export PATH=$GOPATH/bin:$PATH
         ```
 
 * To make sure the above changes are applied, run the following command:

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -5,7 +5,7 @@ description: Install the Go programming language
 
 # Install Go
 
-In this tutorial, you will install the Go programming language (golang) on your local computer. Follow the instructions for your operating system:
+In this tutorial, you will install the Go programming language (Golang) on your local computer. Follow the instructions for your operating system:
 
 ## macOS
 
@@ -17,8 +17,7 @@ In this tutorial, you will install the Go programming language (golang) on your 
     2. Add the following lines:
 
         ```sh
-        export GOPATH=$HOME/go
-        export PATH=$PATH:$GOPATH/bin
+        export PATH=$PATH:$(go env GOPATH)/bin
         ```
 
     3. To make sure these changes execute, run the following command:
@@ -42,18 +41,14 @@ In this tutorial, you will install the Go programming language (golang) on your 
 sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 ```
 
+**Note - Make sure to install the latest version available at that time.**
+
 * To add Go to your `.bash_profile` file:
 
-    1. Open `.bash_profile` file using:
-
-        ```sh
-        nano ~/.bash_profile
-        ```
-
+    1. Open `~/.bash_profile` file with your favorite command-line text editor.
     2. Add the following lines in your `.bash_profile` file:
 
         ```sh
-        export GOPATH=$HOME/go
         export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
         ```
 
@@ -78,18 +73,14 @@ go version
 sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
 ```
 
+**Note - Make sure to install the latest version available at that time.**
+
 * To add Go to your `.bash_profile` file:
 
-    1. Open `.bash_profile` profile using:
-
-        ```sh
-        nano ~/.bash_profile
-        ```
-
+    1. Open `~/.bash_profile` file with your favorite command-line text editor.
     2. Add the following lines in your `.bash_profile` profile:
 
         ```sh
-        export GOROOT=/usr/local/go
         export GOPATH=$HOME/go
         export PATH=$GOPATH/bin:$GOROOT/bin:$PATH
         ```

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -1,6 +1,6 @@
 ---
 order: 2
-description: Run Starport CLI using a Docker container.
+description: Install the Go programming language
 ---
 
 # Install Go

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -13,7 +13,7 @@ In this tutorial, you will install the Go programming language (Golang) on your 
 * Open the downloaded package and follow the prompts through to completion.
 * By default, the package installs the Go distribution to `/usr/local/go`, however it is always best to define the path explicitly:
 
-    1. Open or create a `~/.bash_profile` file with your favorite command-line text editor.
+    1. Open or create a `~/.profile` file with your favorite command-line text editor.
     2. Add the following lines:
 
         ```sh
@@ -23,7 +23,7 @@ In this tutorial, you will install the Go programming language (Golang) on your 
     3. To make sure these changes execute, run the following command:
 
         ```sh
-        source ~/.bash_profile
+        source ~/.profile
         ```
 
 * Verify the installation of go by checking its version:
@@ -45,7 +45,7 @@ sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 
 * To add Go to your `.bash_profile` file:
 
-    1. Open `~/.bash_profile` file with your favorite command-line text editor.
+    1. Open `~/.profile` file with your favorite command-line text editor.
     2. Add the following lines in your `.bash_profile` file:
 
         ```sh
@@ -55,7 +55,7 @@ sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
 * To make sure the above changes are applied, run the following command:
 
 ```sh
-source ~/.bash_profile
+source ~/.profile
 ```
 
 * Verify the installation of go using:
@@ -77,7 +77,7 @@ sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
 
 * To add Go to your `.bash_profile` file:
 
-    1. Open `~/.bash_profile` file with your favorite command-line text editor.
+    1. Open `~/.profile` file with your favorite command-line text editor.
     2. Add the following lines in your `.bash_profile` profile:
 
         ```sh
@@ -88,7 +88,7 @@ sudo tar -xvf go1.16.6.linux-amd64.tar.gz && sudo mv go /usr/local
 * To make sure the above changes are applied, run the following command:
 
 ```sh
-~/.bash_profile
+~/.profile
 ```
 
 * Verify the installation of go using:

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -1,0 +1,80 @@
+---
+order: 2
+description: Run Starport CLI using a Docker container.
+---
+
+# Install Go
+
+In this tutorial, you will install golang on your local computer. Follow the instructions for your operating system:
+
+## Mac OS X
+
+* Download the latest MacOS installer package from <https://golang.org/dl/>.
+* Open the downloaded package and follow the prompts through to completion.
+* By default, the package installs the Go distribution to `/usr/local/go`, however it is always best to define the path explicitly:
+
+    1. Open or create a `~/.bash_profile` file with your favorite command-line text editor.
+    2. Add the following lines:
+
+        ```sh
+        export GOPATH=$HOME/go
+        export PATH=$PATH:$GOPATH/bin
+        ```
+
+    3. To make sure these changes execute, run the following command:
+
+        ```sh
+        source ~/.bash_profile
+        ```
+
+* Verify the installation of go by checking its version:
+
+    ```sh
+    go version
+    ```
+
+## Linux
+
+* Download the latest linux distribution package from <https://golang.org/dl/>.
+* Extract the archive you downloaded into `/usr/local` using the following command:
+
+```sh
+sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
+```
+
+* To add Go to your `.bash_profile` file:
+
+    1. Open `.bash_profile` file using:
+
+        ```sh
+        nano ~/.bash_profile
+        ```
+
+    2. Add the following lines in your `.bash_profile` file:
+
+        ```sh
+        export GOPATH=$HOME/go
+        export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
+        ```
+
+* To make sure the above changes execute, run the following command:
+
+```sh
+source ~/.bash_profile
+```
+
+* Verify the installation of go using:
+
+```sh
+go version
+```
+
+## Windows
+
+* Download the latest windows distribution package from <https://golang.org/dl/>.
+* Open the MSI file you downloaded and follow the prompts to install Go.
+* Verify the installation of go using:
+
+```sh
+go version
+```

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -35,7 +35,7 @@ In this tutorial, you will install the Go programming language (golang) on your 
 
 ## Linux
 
-* Download the latest linux distribution package from <https://golang.org/dl/>.
+* Download the latest Linux distribution package from <https://golang.org/dl/>.
 * Extract the archive you downloaded into `/usr/local` using the following command:
 
 ```sh

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -5,7 +5,7 @@ description: Install the Go programming language
 
 # Install Go
 
-In this tutorial, you will install golang on your local computer. Follow the instructions for your operating system:
+In this tutorial, you will install the Go programming language (golang) on your local computer. Follow the instructions for your operating system:
 
 ## Mac OS X
 

--- a/docs/intro/go.md
+++ b/docs/intro/go.md
@@ -57,7 +57,7 @@ sudo tar -C /usr/local -xzf go1.16.6.linux-amd64.tar.gz
         export PATH=$PATH:$GOPATH/bin:/usr/local/go/bin
         ```
 
-* To make sure the above changes execute, run the following command:
+* To make sure the above changes are applied, run the following command:
 
 ```sh
 source ~/.bash_profile

--- a/docs/intro/install.md
+++ b/docs/intro/install.md
@@ -1,5 +1,5 @@
 ---
-order: 2
+order: 3
 description: Steps to install Starport on your local computer.
 ---
 


### PR DESCRIPTION
This document adds the installation process of go across the different operating systems.

**Note** The Starport content is moving from the https://github.com/cosmos/sdk-tutorials/ repo to the https://github.com/tendermint/starport/ repo to consolidate in our best place.

[Starport docs structure](https://www.notion.so/allinbits/Starport-Content-Outline-draft-41ad2d55b6244da4a9710d990df5c882) are in Notion