### PR TITLE
fix(services/chain): don't init accounts from config for SPN chains

### DIFF
--- a/starport/cmd/chain_init.go
+++ b/starport/cmd/chain_init.go
@@ -37,7 +37,7 @@ func chainInitHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := c.Init(cmd.Context()); err != nil {
+	if err := c.Init(cmd.Context(), true); err != nil {
 		return err
 	}
 

--- a/starport/services/chain/init.go
+++ b/starport/services/chain/init.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Init initializes the chain and applies all optional configurations.
-func (c *Chain) Init(ctx context.Context) error {
+func (c *Chain) Init(ctx context.Context, initAccounts bool) error {
 	conf, err := c.Config()
 	if err != nil {
 		return &CannotBuildAppError{err}
@@ -28,7 +28,10 @@ func (c *Chain) Init(ctx context.Context) error {
 		return err
 	}
 
-	return c.InitAccounts(ctx, conf)
+	if initAccounts {
+		return c.InitAccounts(ctx, conf)
+	}
+	return nil
 }
 
 // InitChain initializes the chain.

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -343,7 +343,7 @@ func (c *Chain) serve(ctx context.Context, forceReset bool) error {
 	if !isInit || (appModified && !exportGenesisExists) {
 		fmt.Fprintln(c.stdLog().out, "💿 Initializing the app...")
 
-		if err := c.Init(ctx); err != nil {
+		if err := c.Init(ctx, true); err != nil {
 			return err
 		}
 	} else if appModified {

--- a/starport/services/config.go
+++ b/starport/services/config.go
@@ -18,7 +18,7 @@ func InitConfig() error {
 		return err
 	}
 
-	if err := os.MkdirAll(confPath, 0700); err != nil && !os.IsExist(err) {
+	return os.MkdirAll(confPath, 0755);
 		return err
 	}
 	return nil

--- a/starport/services/config.go
+++ b/starport/services/config.go
@@ -18,8 +18,5 @@ func InitConfig() error {
 		return err
 	}
 
-	return os.MkdirAll(confPath, 0755);
-		return err
-	}
-	return nil
+	return os.MkdirAll(confPath, 0755)
 }

--- a/starport/services/config.go
+++ b/starport/services/config.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"os"
+
 	"github.com/tendermint/starport/starport/pkg/xfilepath"
 )
 
@@ -8,3 +10,16 @@ var (
 	// StarportConfPath returns the Starport Configuration directory
 	StarportConfPath = xfilepath.JoinFromHome(xfilepath.Path(".starport"))
 )
+
+// InitConfig creates config directory if it is not yet created
+func InitConfig() error {
+	confPath, err := StarportConfPath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(confPath, 0700); err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}

--- a/starport/services/networkbuilder/blockchain.go
+++ b/starport/services/networkbuilder/blockchain.go
@@ -109,7 +109,7 @@ func (b *Blockchain) init(
 	if _, err := chain.Build(ctx); err != nil {
 		return err
 	}
-	if err := chain.Init(ctx); err != nil {
+	if err := chain.Init(ctx, false); err != nil {
 		return err
 	}
 	b.builder.ev.Send(events.New(events.StatusDone, "Blockchain initialized"))

--- a/starport/services/networkbuilder/config.go
+++ b/starport/services/networkbuilder/config.go
@@ -58,6 +58,10 @@ func ConfigGet() (*Config, error) {
 
 // ConfigSave saves the current state of Config.
 func ConfigSave(c *Config) error {
+	if err := services.InitConfig(); err != nil {
+		return err
+	}
+
 	conf, err := confPath()
 	if err != nil {
 		return nil

--- a/starport/services/networkbuilder/networkbuilder.go
+++ b/starport/services/networkbuilder/networkbuilder.go
@@ -243,10 +243,8 @@ func (b *Builder) Init(ctx context.Context, chainID string, source SourceOption,
 		}
 
 		// ensure the path for chain source exists
-		if err := os.MkdirAll(sourcePath, 0700); err != nil && !os.IsExist(err) {
-			if !os.IsExist(err) {
-				return nil, err
-			}
+		if err := os.MkdirAll(sourcePath, 0755); err != nil {
+			return nil, err
 		}
 
 		path = filepath.Join(sourcePath, chainID)


### PR DESCRIPTION
Prevent initializing accounts from the config when using a chain from Starport Network because in this case we must create our own account

Another fix is to create `.starport` config directory when initializing `networkbuilder` config

This fixes currently known issues for Starport Network usage for `0.17.0`