### PR TITLE
fix(cosmosanalysis/module): discover proto files only in certain dirs

### DIFF
--- a/starport/pkg/cosmosanalysis/module/module.go
+++ b/starport/pkg/cosmosanalysis/module/module.go
@@ -44,7 +44,7 @@ type Msg struct {
 	FilePath string
 }
 
-// Query is an sdk Query.
+// HTTPQuery is an sdk Query.
 type HTTPQuery struct {
 	// Name of the RPC func.
 	Name string

--- a/starport/pkg/cosmosanalysis/module/module.go
+++ b/starport/pkg/cosmosanalysis/module/module.go
@@ -65,7 +65,9 @@ type Type struct {
 }
 
 type moduleDiscoverer struct {
-	sourcePath, basegopath string
+	sourcePath string
+	protoPath  string
+	basegopath string
 }
 
 // Discover discovers and returns modules and their types that implements sdk.Msg.
@@ -78,7 +80,7 @@ type moduleDiscoverer struct {
 // for a more opinionated check:
 //   - go/types.Implements() might be utilized and as needed.
 //   - instead of just comparing method names, their full signatures can be compared.
-func Discover(ctx context.Context, sourcePath string) ([]Module, error) {
+func Discover(ctx context.Context, sourcePath, protoDir string) ([]Module, error) {
 	// find out base Go import path of the blockchain.
 	gm, err := gomodule.ParseAt(sourcePath)
 	if err != nil {
@@ -89,6 +91,7 @@ func Discover(ctx context.Context, sourcePath string) ([]Module, error) {
 	}
 
 	md := &moduleDiscoverer{
+		protoPath:  filepath.Join(sourcePath, protoDir),
 		sourcePath: sourcePath,
 		basegopath: gm.Module.Mod.Path,
 	}
@@ -207,7 +210,7 @@ func (d *moduleDiscoverer) discover(pkg protoanalysis.Package) (Module, error) {
 
 func (d *moduleDiscoverer) findModuleProtoPkgs(ctx context.Context) ([]protoanalysis.Package, error) {
 	// find out all proto packages inside blockchain.
-	allprotopkgs, err := protoanalysis.Parse(ctx, d.sourcePath)
+	allprotopkgs, err := protoanalysis.Parse(ctx, d.protoPath)
 	if err != nil {
 		return nil, err
 	}

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -8,5 +8,9 @@ import (
 )
 
 func TestExampleDiscover(t *testing.T) {
-	pretty.Println(Discover(context.Background(), "/home/ilker/Documents/code/src/github.com/tendermint/starport/local_test/mars"))
+	pretty.Println(Discover(
+		context.Background(),
+		"$GOPATH/github.com/tendermint/starport/local_test/mars",
+		"proto",
+	))
 }

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -2,8 +2,6 @@ package module
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,10 +10,6 @@ import (
 )
 
 func TestDiscover(t *testing.T) {
-	goPath := os.Getenv("GOPATH")
-	testDataPath := filepath.Join(goPath,
-		"src/github.com/tendermint/starport/starport/pkg/cosmosanalysis/module/testdata")
-
 	type args struct {
 		sourcePath string
 		protoDir   string
@@ -28,7 +22,7 @@ func TestDiscover(t *testing.T) {
 		{
 			name: "test valid",
 			args: args{
-				sourcePath: filepath.Join(testDataPath, "planet"),
+				sourcePath: "testdata/planet",
 				protoDir:   "proto",
 			},
 			want: []Module{
@@ -37,7 +31,7 @@ func TestDiscover(t *testing.T) {
 		}, {
 			name: "test no proto folder",
 			args: args{
-				sourcePath: filepath.Join(testDataPath, "planet"),
+				sourcePath: "testdata/planet",
 				protoDir:   "",
 			},
 			want: []Module{
@@ -46,21 +40,21 @@ func TestDiscover(t *testing.T) {
 		}, {
 			name: "test invalid proto folder",
 			args: args{
-				sourcePath: filepath.Join(testDataPath, "planet"),
+				sourcePath: "testdata/planet",
 				protoDir:   "invalid",
 			},
 			want: nil,
 		}, {
 			name: "test invalid folder",
 			args: args{
-				sourcePath: filepath.Join(testDataPath, "invalid"),
+				sourcePath: "testdata/invalid",
 				protoDir:   "",
 			},
 			want: []Module{},
 		}, {
 			name: "test invalid main and proto folder",
 			args: args{
-				sourcePath: filepath.Join(testDataPath, "../../.."),
+				sourcePath: "../../..",
 				protoDir:   "proto",
 			},
 			want: []Module{},

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -24,7 +24,6 @@ func TestDiscover(t *testing.T) {
 		name string
 		args args
 		want []Module
-		err  error
 	}{
 		{
 			name: "test valid",
@@ -70,10 +69,6 @@ func TestDiscover(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Discover(context.Background(), tt.args.sourcePath, tt.args.protoDir)
-			if tt.err != nil {
-				require.ErrorIs(t, err, tt.err)
-				return
-			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -43,7 +43,6 @@ func TestDiscover(t *testing.T) {
 				sourcePath: "testdata/planet",
 				protoDir:   "invalid",
 			},
-			want: nil,
 		}, {
 			name: "test invalid folder",
 			args: args{

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -2,15 +2,27 @@ package module
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kr/pretty"
 )
 
 func TestExampleDiscover(t *testing.T) {
-	pretty.Println(Discover(
-		context.Background(),
-		"$GOPATH/github.com/tendermint/starport/local_test/mars",
-		"proto",
-	))
+	goPath := os.Getenv("GOPATH")
+	t.Run("test folder without proto files", func(t *testing.T) {
+		pretty.Println(Discover(
+			context.Background(),
+			filepath.Join(goPath, "src/github.com/tendermint/starport/local_test/mars"),
+			"proto",
+		))
+	})
+	t.Run("test folder with proto files", func(t *testing.T) {
+		pretty.Println(Discover(
+			context.Background(),
+			filepath.Join(goPath, "src/github.com/tendermint/starport"),
+			"starport/pkg/protoc/data/include/google/protobuf",
+		))
+	})
 }

--- a/starport/pkg/cosmosanalysis/module/testdata/planet/go.mod
+++ b/starport/pkg/cosmosanalysis/module/testdata/planet/go.mod
@@ -1,0 +1,4 @@
+module github.com/tendermint/planet
+
+go 1.16
+

--- a/starport/pkg/cosmosanalysis/module/testdata/planet/proto/planet/planet.proto
+++ b/starport/pkg/cosmosanalysis/module/testdata/planet/proto/planet/planet.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package tendermint.planet.planet;
+option go_package = "github.com/tendermint/planet/x/planet/types";
+

--- a/starport/pkg/cosmosanalysis/module/testdata/planet/x/planet/types/types.go
+++ b/starport/pkg/cosmosanalysis/module/testdata/planet/x/planet/types/types.go
@@ -1,0 +1,1 @@
+package types

--- a/starport/pkg/cosmosgen/generate.go
+++ b/starport/pkg/cosmosgen/generate.go
@@ -40,7 +40,7 @@ func (g *generator) setup() (err error) {
 	}
 
 	// this is for user's app itself. it may contain custom modules. it is the first place to look for.
-	g.appModules, err = g.discoverModules(g.appPath)
+	g.appModules, err = g.discoverModules(g.appPath, g.protoDir)
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (g *generator) setup() (err error) {
 		if err != nil {
 			return err
 		}
-		modules, err := g.discoverModules(path)
+		modules, err := g.discoverModules(path, "")
 		if err != nil {
 			return err
 		}
@@ -89,10 +89,10 @@ func (g *generator) resolveInclude(path string) (paths []string, err error) {
 	return paths, nil
 }
 
-func (g *generator) discoverModules(path string) ([]module.Module, error) {
+func (g *generator) discoverModules(path, protoDir string) ([]module.Module, error) {
 	var filteredModules []module.Module
 
-	modules, err := module.Discover(g.ctx, path)
+	modules, err := module.Discover(g.ctx, path, protoDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes #1342

### What does this MR does?

- Compile proto only from `build.proto.path`; instead, compile all proto files from the project.

### Changes

- Specify the proto folder to be analyzed.

### How to test?

- Compile [Ethermint](https://github.com/tharsis/ethermint) with proto files generated by tests:

```shell
$ git clone git@github.com:tharsis/ethermint.git
$ cd ethermint && make install
$ cd tests/solidity && yarn install
$ cd ../..
$ starport c serve -v
```
