### PR TITLE
refactor(templates): use wasm from tendermint/spm-extras

### DIFF
--- a/starport/pkg/gocmd/gocmd.go
+++ b/starport/pkg/gocmd/gocmd.go
@@ -101,3 +101,8 @@ func ParseTarget(t string) (goos, goarch string, err error) {
 
 	return parsed[0], parsed[1], nil
 }
+
+// PackageLiteral returns the string representation of package part of go get [package].
+func PackageLiteral(path, version string) string {
+	return fmt.Sprintf("%s@%s", path, version)
+}

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -27,10 +27,12 @@ import (
 )
 
 const (
-	wasmImport  = "github.com/CosmWasm/wasmd"
-	appPkg      = "app"
-	moduleDir   = "x"
-	wasmVersion = "v0.16.0"
+	wasmImport    = "github.com/CosmWasm/wasmd"
+	wasmVersion   = "v0.16.0"
+	extrasImport  = "github.com/tendermint/spm-extras"
+	extrasVersion = "v0.1.0"
+	appPkg        = "app"
+	moduleDir     = "x"
 )
 
 // moduleCreationOptions holds options for creating a new module
@@ -290,17 +292,10 @@ func (s *Scaffolder) installWasm() error {
 	switch s.version {
 	case cosmosver.StargateZeroFourtyAndAbove:
 		return cmdrunner.
-			New(
-				cmdrunner.DefaultStderr(os.Stderr),
-			).
+			New().
 			Run(context.Background(),
-				step.New(
-					step.Exec(
-						gocmd.Name(),
-						"get",
-						wasmImport+"@"+wasmVersion,
-					),
-				),
+				step.New(step.Exec(gocmd.Name(), "get", gocmd.PackageLiteral(wasmImport, wasmVersion))),
+				step.New(step.Exec(gocmd.Name(), "get", gocmd.PackageLiteral(extrasImport, extrasVersion))),
 			)
 	default:
 		return errors.New("version not supported")

--- a/starport/templates/app/stargate/go.mod.plush
+++ b/starport/templates/app/stargate/go.mod.plush
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/tendermint/spm v0.1.0
+	github.com/tendermint/spm v0.1.1 
 	github.com/tendermint/tendermint v0.34.11
 	github.com/tendermint/tm-db v0.6.4
 	google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced

--- a/starport/templates/app/stargate/go.mod.plush
+++ b/starport/templates/app/stargate/go.mod.plush
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/tendermint/spm v0.1.1 
+	github.com/tendermint/spm v0.1.2 
 	github.com/tendermint/tendermint v0.34.11
 	github.com/tendermint/tm-db v0.6.4
 	google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced

--- a/starport/templates/module/import/stargate.go
+++ b/starport/templates/module/import/stargate.go
@@ -150,10 +150,15 @@ func cmdModifyStargate(replacer placeholder.Replacer, opts *ImportOptions) genny
 			return err
 		}
 
-		templateArgs := `cosmoscmd.WithWasm(),
+		templateArgs := `cosmoscmd.AddSubCmd(wasmcmd.GenesisWasmMsgCmd(app.DefaultNodeHome)),
+cosmoscmd.CustomizeStartCmd(wasmcmd.AddModuleInitFlags),
 		%[1]v`
 		replacementArgs := fmt.Sprintf(templateArgs, module.PlaceholderSgRootArgument)
 		content := replacer.Replace(f.String(), module.PlaceholderSgRootArgument, replacementArgs)
+
+		// import spm-extras.
+		content = replacer.Replace(f.String(), "package main", `package main
+import "github.com/tendermint/spm-extras/wasmcmd"`)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)

--- a/starport/templates/module/import/stargate.go
+++ b/starport/templates/module/import/stargate.go
@@ -32,6 +32,7 @@ func appModifyStargate(replacer placeholder.Replacer) genny.RunFn {
 		}
 
 		templateImport := `%[1]v
+		"github.com/tendermint/spm-extras/wasmcmd"
 		"github.com/CosmWasm/wasmd/x/wasm"
 		wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"`
 		replacementImport := fmt.Sprintf(templateImport, module.PlaceholderSgAppModuleImport)
@@ -114,7 +115,7 @@ func appModifyStargate(replacer placeholder.Replacer) genny.RunFn {
 		)
 	
 		// The gov proposal types can be individually enabled
-		enabledProposals := cosmoscmd.GetEnabledProposals(ProposalsEnabled, EnableSpecificProposals)
+		enabledProposals := wasmcmd.GetEnabledProposals(ProposalsEnabled, EnableSpecificProposals)
 		if len(enabledProposals) != 0 {
 			govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(app.wasmKeeper, enabledProposals))
 		}`

--- a/starport/templates/module/import/stargate.go
+++ b/starport/templates/module/import/stargate.go
@@ -157,7 +157,7 @@ cosmoscmd.CustomizeStartCmd(wasmcmd.AddModuleInitFlags),
 		content := replacer.Replace(f.String(), module.PlaceholderSgRootArgument, replacementArgs)
 
 		// import spm-extras.
-		content = replacer.Replace(f.String(), "package main", `package main
+		content = replacer.Replace(content, "package main", `package main
 import "github.com/tendermint/spm-extras/wasmcmd"`)
 
 		newFile := genny.NewFileS(path, content)


### PR DESCRIPTION
depends on https://github.com/tendermint/spm-extras/pull/1, https://github.com/tendermint/spm/pull/2.

we also need to make release for spm and spm-extras.

and go mod tidy this PR after.