### PR TITLE
fix(gitpod/chisel): fix p2p conn establishment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -46,4 +46,5 @@ ports:
   - port: 26657
   - port: 8080
   - port: 7575
+    visibility: public
   - port: 4500


### PR DESCRIPTION
gitpod now makes all the ports private by default. this pr makes the p2p conn proxy port open.