### PR TITLE
fix(relayer.go): Change Latin "via" to "by using" 

### DIFF
--- a/starport/cmd/relayer.go
+++ b/starport/cmd/relayer.go
@@ -8,7 +8,7 @@ import (
 func NewRelayer() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "relayer",
-		Short: "Connects blockchains via IBC protocol",
+		Short: "Connects blockchains by using IBC protocol",
 	}
 
 	c.AddCommand(NewRelayerConfigure())

--- a/starport/cmd/relayer.go
+++ b/starport/cmd/relayer.go
@@ -8,7 +8,7 @@ import (
 func NewRelayer() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "relayer",
-		Short: "Connects blockchains by using IBC protocol",
+		Short: "Connect blockchains by using IBC protocol",
 	}
 
 	c.AddCommand(NewRelayerConfigure())


### PR DESCRIPTION
let's not use Latin, so change "via" to "by using"
per best practices for plain language and https://developers.google.com/style/abbreviations?hl=en#dont-use 

Use "Connect" for parallel construction, other verbs are imperative language, so let's make the same