### PR TITLE
docs: remove a note about upcoming release

### DIFF
--- a/starport/internal/tools/gen-cli-docs/main.go
+++ b/starport/internal/tools/gen-cli-docs/main.go
@@ -29,7 +29,6 @@ parent:
 
 # CLI
 Documentation for Starport CLI.
-Note: CLI docs reflect the changes in an upcoming release.
 `
 
 func main() {


### PR DESCRIPTION
Since we merge the CLI ref PR only before the release is cut, we don't need to mention that the reference describes the upcoming release. It actually describes the current version of Starport.