### PR TITLE
feat(cmd): init accounts command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/tendermint/starport
 go 1.16
 
 require (
+	github.com/99designs/keyring v1.1.6 // indirect
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/Microsoft/hcsshim v0.8.17 // indirect
 	github.com/blang/semver v3.5.1+incompatible

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -13,7 +13,7 @@ import (
 const (
 	flagAddressPrefix  = "address-prefix"
 	flagPassphrase     = "passphrase"
-	flagNonInteractive = "noninteractive"
+	flagNonInteractive = "non-interactive"
 )
 
 func NewAccount() *cobra.Command {

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 
@@ -90,7 +91,19 @@ func getIsNonInteractive(cmd *cobra.Command) bool {
 	return is
 }
 
-func getPassphrase(cmd *cobra.Command) string {
+func getPassphrase(cmd *cobra.Command) (string, error) {
 	pass, _ := cmd.Flags().GetString(flagPassphrase)
-	return pass
+
+	if pass == "" && !getIsNonInteractive(cmd) {
+		if err := cliquiz.Ask(
+			cliquiz.NewQuestion("Passphrase",
+				&pass,
+				cliquiz.HideAnswer(),
+				cliquiz.GetConfirmation(),
+			)); err != nil {
+			return "", err
+		}
+	}
+
+	return pass, nil
 }

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -1,0 +1,99 @@
+package starportcmd
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+const (
+	flagAddressPrefix = "address-prefix"
+)
+
+const (
+	flagPassphrase     = "passphrase"
+	flagNonInteractive = "noninteractive"
+)
+
+func NewAccount() *cobra.Command {
+	c := &cobra.Command{
+		Use:     "account [command]",
+		Short:   "Manage your cosmos accounts",
+		Aliases: []string{"a"},
+		Args:    cobra.ExactArgs(1),
+	}
+
+	c.AddCommand(NewAccountCreate())
+	c.AddCommand(NewAccountDelete())
+	c.AddCommand(NewAccountShow())
+	c.AddCommand(NewAccountList())
+	c.AddCommand(NewAccountImport())
+	c.AddCommand(NewAccountExport())
+
+	return c
+}
+
+func printAccounts(cmd *cobra.Command, accounts ...cosmosaccount.Account) {
+	w := &tabwriter.Writer{}
+	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+
+	if len(accounts) == 0 {
+		return
+	}
+
+	fmt.Fprintln(w, "name\taddress\tpublic key")
+
+	for _, acc := range accounts {
+		fmt.Fprintf(w, "%s\t%s\t%s\n",
+			acc.Name,
+			acc.Address(getAddressPrefix(cmd)),
+			acc.PubKey(getAddressPrefix(cmd)),
+		)
+	}
+
+	fmt.Fprintln(w)
+	w.Flush()
+}
+
+func flagSetKeyringBackend() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.String(flagKeyringBackend, "test", "Keyring backend to store your account keys")
+	return fs
+}
+
+func getKeyringBackend(cmd *cobra.Command) string {
+	backend, _ := cmd.Flags().GetString(flagKeyringBackend)
+	return backend
+}
+
+func flagSetAccountPrefixes() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.String(flagAddressPrefix, "cosmos", "Account address prefix")
+	return fs
+}
+
+func getAddressPrefix(cmd *cobra.Command) string {
+	prefix, _ := cmd.Flags().GetString(flagAddressPrefix)
+	return prefix
+}
+
+func flagSetAccountImportExport() *flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.Bool(flagNonInteractive, false, "Do not enter into interactive mode")
+	fs.String(flagPassphrase, "", "Account passphrase")
+	return fs
+}
+
+func getIsNonInteractive(cmd *cobra.Command) bool {
+	is, _ := cmd.Flags().GetBool(flagNonInteractive)
+	return is
+}
+
+func getPassphrase(cmd *cobra.Command) string {
+	pass, _ := cmd.Flags().GetString(flagPassphrase)
+	return pass
+}

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	flagAddressPrefix = "address-prefix"
+	flagAddressPrefix  = "address-prefix"
 	flagPassphrase     = "passphrase"
 	flagNonInteractive = "noninteractive"
 )

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -12,9 +12,6 @@ import (
 
 const (
 	flagAddressPrefix = "address-prefix"
-)
-
-const (
 	flagPassphrase     = "passphrase"
 	flagNonInteractive = "noninteractive"
 )
@@ -22,7 +19,7 @@ const (
 func NewAccount() *cobra.Command {
 	c := &cobra.Command{
 		Use:     "account [command]",
-		Short:   "Manage your cosmos accounts",
+		Short:   "Manage your cosmos chain accounts",
 		Aliases: []string{"a"},
 		Args:    cobra.ExactArgs(1),
 	}

--- a/starport/cmd/account_create.go
+++ b/starport/cmd/account_create.go
@@ -1,0 +1,37 @@
+package starportcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountCreate() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create a new account",
+		RunE:  accountCreateHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+
+	return c
+}
+
+func accountCreateHandler(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	_, mnemonic, err := ca.Create(name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Account %q created, keep your mnemonic in a secret place:\n\n%s\n", name, mnemonic)
+	return nil
+}

--- a/starport/cmd/account_create.go
+++ b/starport/cmd/account_create.go
@@ -11,6 +11,7 @@ func NewAccountCreate() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "create [name]",
 		Short: "Create a new account",
+		Args:  cobra.ExactArgs(1),
 		RunE:  accountCreateHandler,
 	}
 

--- a/starport/cmd/account_delete.go
+++ b/starport/cmd/account_delete.go
@@ -11,6 +11,7 @@ func NewAccountDelete() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "delete [name]",
 		Short: "Delete an account",
+		Args:  cobra.ExactArgs(1),
 		RunE:  accountDeleteHandler,
 	}
 
@@ -31,6 +32,6 @@ func accountDeleteHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("Account deleted.")
+	fmt.Printf("Account %s deleted.\n", name)
 	return nil
 }

--- a/starport/cmd/account_delete.go
+++ b/starport/cmd/account_delete.go
@@ -1,0 +1,36 @@
+package starportcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountDelete() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "delete [name]",
+		Short: "Delete an account",
+		RunE:  accountDeleteHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+
+	return c
+}
+
+func accountDeleteHandler(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	if err := ca.DeleteByName(name); err != nil {
+		return err
+	}
+
+	fmt.Println("Account deleted.")
+	return nil
+}

--- a/starport/cmd/account_export.go
+++ b/starport/cmd/account_export.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 
@@ -27,15 +26,13 @@ func NewAccountExport() *cobra.Command {
 
 func accountExportHandler(cmd *cobra.Command, args []string) error {
 	var (
-		name       = args[0]
-		path, _    = cmd.Flags().GetString(flagPath)
-		passphrase = getPassphrase(cmd)
+		name    = args[0]
+		path, _ = cmd.Flags().GetString(flagPath)
 	)
 
-	if passphrase == "" && !getIsNonInteractive(cmd) {
-		if err := cliquiz.Ask(cliquiz.NewQuestion("Passphrase", &passphrase, cliquiz.HideAnswer())); err != nil {
-			return err
-		}
+	passphrase, err := getPassphrase(cmd)
+	if err != nil {
+		return err
 	}
 
 	ca, err := cosmosaccount.New(getKeyringBackend(cmd))

--- a/starport/cmd/account_export.go
+++ b/starport/cmd/account_export.go
@@ -1,0 +1,65 @@
+package starportcmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cliquiz"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountExport() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "export [name]",
+		Short: "Export an account",
+		Args:  cobra.ExactArgs(1),
+		RunE:  accountExportHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetAccountImportExport())
+	c.Flags().String(flagPath, "", "path to export private key. default: ./key_[name]")
+
+	return c
+}
+
+func accountExportHandler(cmd *cobra.Command, args []string) error {
+	var (
+		name       = args[0]
+		path, _    = cmd.Flags().GetString(flagPath)
+		passphrase = getPassphrase(cmd)
+	)
+
+	if passphrase == "" && !getIsNonInteractive(cmd) {
+		if err := cliquiz.Ask(cliquiz.NewQuestion("Passphrase", &passphrase, cliquiz.HideAnswer())); err != nil {
+			return err
+		}
+	}
+
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	armored, err := ca.Export(name, passphrase)
+	if err != nil {
+		return err
+	}
+
+	if path == "" {
+		path = fmt.Sprintf("./key_%s", name)
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(path, []byte(armored), 0644); err != nil {
+		return err
+	}
+
+	fmt.Printf("Account %q exported to file: %s\n", name, path)
+	return nil
+}

--- a/starport/cmd/account_import.go
+++ b/starport/cmd/account_import.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"

--- a/starport/cmd/account_import.go
+++ b/starport/cmd/account_import.go
@@ -1,0 +1,63 @@
+package starportcmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cosmos/go-bip39"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cliquiz"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountImport() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "import [name] [mnemonic or private_key_path]",
+		Short: "Import an account",
+		Args:  cobra.ExactArgs(2),
+		RunE:  accountImportHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetAccountImportExport())
+
+	return c
+}
+
+func accountImportHandler(cmd *cobra.Command, args []string) error {
+	var (
+		name       = args[0]
+		secret     = args[1]
+		passphrase = getPassphrase(cmd)
+	)
+
+	if passphrase == "" && !getIsNonInteractive(cmd) {
+		if err := cliquiz.Ask(cliquiz.NewQuestion("Passphrase", &passphrase, cliquiz.HideAnswer())); err != nil {
+			return err
+		}
+	}
+
+	if !bip39.IsMnemonicValid(secret) {
+		privKey, err := os.ReadFile(secret)
+		if os.IsNotExist(err) {
+			return errors.New("mnemonic is not valid or private key not found at path")
+		}
+		if err != nil {
+			return err
+		}
+		secret = string(privKey)
+	}
+
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	if _, err := ca.Import(name, secret, passphrase); err != nil {
+		return err
+	}
+
+	fmt.Printf("Account %q imported.\n", name)
+	return nil
+}

--- a/starport/cmd/account_import.go
+++ b/starport/cmd/account_import.go
@@ -28,7 +28,7 @@ func NewAccountImport() *cobra.Command {
 func accountImportHandler(cmd *cobra.Command, args []string) error {
 	var (
 		name       = args[0]
-		secret     = args[1]
+		secret     = strings.TrimSpace(args[1])
 		passphrase = getPassphrase(cmd)
 	)
 

--- a/starport/cmd/account_import.go
+++ b/starport/cmd/account_import.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"
-	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 
@@ -28,15 +27,13 @@ func NewAccountImport() *cobra.Command {
 
 func accountImportHandler(cmd *cobra.Command, args []string) error {
 	var (
-		name       = args[0]
-		secret     = strings.TrimSpace(args[1])
-		passphrase = getPassphrase(cmd)
+		name   = args[0]
+		secret = strings.TrimSpace(args[1])
 	)
 
-	if passphrase == "" && !getIsNonInteractive(cmd) {
-		if err := cliquiz.Ask(cliquiz.NewQuestion("Passphrase", &passphrase, cliquiz.HideAnswer())); err != nil {
-			return err
-		}
+	passphrase, err := getPassphrase(cmd)
+	if err != nil {
+		return err
 	}
 
 	if !bip39.IsMnemonicValid(secret) {

--- a/starport/cmd/account_list.go
+++ b/starport/cmd/account_list.go
@@ -1,0 +1,34 @@
+package starportcmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountList() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "list",
+		Short: "List accounts",
+		RunE:  accountListHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+
+	return c
+}
+
+func accountListHandler(cmd *cobra.Command, args []string) error {
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	accounts, err := ca.List()
+	if err != nil {
+		return err
+	}
+
+	printAccounts(cmd, accounts...)
+	return nil
+}

--- a/starport/cmd/account_show.go
+++ b/starport/cmd/account_show.go
@@ -1,0 +1,36 @@
+package starportcmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
+)
+
+func NewAccountShow() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "show [name]",
+		Short: "Show account",
+		RunE:  accountShowHandler,
+	}
+
+	c.Flags().AddFlagSet(flagSetKeyringBackend())
+	c.Flags().AddFlagSet(flagSetAccountPrefixes())
+
+	return c
+}
+
+func accountShowHandler(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	ca, err := cosmosaccount.New(getKeyringBackend(cmd))
+	if err != nil {
+		return err
+	}
+
+	acc, err := ca.GetByName(name)
+	if err != nil {
+		return err
+	}
+
+	printAccounts(cmd, acc)
+	return nil
+}

--- a/starport/cmd/account_show.go
+++ b/starport/cmd/account_show.go
@@ -9,6 +9,7 @@ func NewAccountShow() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "show [name]",
 		Short: "Show account",
+		Args:  cobra.ExactArgs(1),
 		RunE:  accountShowHandler,
 	}
 

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -59,6 +59,7 @@ starport scaffold chain github.com/cosmonaut/mars`,
 	c.AddCommand(NewChain())
 	c.AddCommand(NewGenerate())
 	c.AddCommand(NewNetwork())
+	c.AddCommand(NewAccount())
 	c.AddCommand(NewRelayer())
 	c.AddCommand(NewTools())
 	c.AddCommand(NewDocs())

--- a/starport/cmd/scaffold_chain.go
+++ b/starport/cmd/scaffold_chain.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	flagAddressPrefix   = "address-prefix"
 	flagNoDefaultModule = "no-module"
 )
 

--- a/starport/pkg/cosmosaccount/cosmosaccount.go
+++ b/starport/pkg/cosmosaccount/cosmosaccount.go
@@ -123,7 +123,7 @@ func (r Registry) Create(name string) (acc Account, mnemonic string, err error) 
 	return acc, mnemonic, nil
 }
 
-// Import imports an existing account with name andd passphrase and secret where secret can be a
+// Import imports an existing account with name and passphrase and secret where secret can be a
 // mnemonic or a private key.
 func (r Registry) Import(name, secret, passphrase string) (Account, error) {
 	_, err := r.GetByName(name)

--- a/starport/pkg/cosmosaccount/cosmosaccount.go
+++ b/starport/pkg/cosmosaccount/cosmosaccount.go
@@ -46,7 +46,7 @@ func New(backend string) (Registry, error) {
 	return r, nil
 }
 
-// Account represents an CosmosSDK account.
+// Account represents an Cosmos SDK account.
 type Account struct {
 	// Name of the account.
 	Name string
@@ -124,7 +124,7 @@ func (r Registry) Create(name string) (acc Account, mnemonic string, err error) 
 }
 
 // Import imports an existing account with name andd passphrase and secret where secret can be a
-// mnemonic or private key.
+// mnemonic or a private key.
 func (r Registry) Import(name, secret, passphrase string) (Account, error) {
 	_, err := r.GetByName(name)
 	if err == nil {

--- a/starport/pkg/cosmosaccount/cosmosaccount.go
+++ b/starport/pkg/cosmosaccount/cosmosaccount.go
@@ -78,7 +78,7 @@ func (a Account) PubKey(accPrefix string) string {
 	}
 
 	conf := types.GetConfig()
-	conf.SetBech32PrefixForAccount(accPrefix, pubKeyPrefix)
+	conf.SetBech32PrefixForAccount(accPrefix, accPrefix+pubKeyPrefix)
 
 	o, err := keyring.Bech32KeyOutput(a.Info)
 	if err != nil {

--- a/starport/pkg/cosmosaccount/cosmosaccount.go
+++ b/starport/pkg/cosmosaccount/cosmosaccount.go
@@ -1,0 +1,216 @@
+package cosmosaccount
+
+import (
+	"errors"
+	"os"
+
+	dkeyring "github.com/99designs/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/go-bip39"
+)
+
+// KeyringServiceName used for the name of keyring in OS backend.
+const KeyringServiceName = "starport"
+
+// KeyringHome used to store account related data.
+var KeyringHome = os.ExpandEnv("$HOME/.starport/accounts")
+
+var (
+	ErrAccountExists       = errors.New("account already exists")
+	ErrAccountDoesNotExist = errors.New("account does not exist")
+)
+
+const (
+	accountPrefixCosmos = "cosmos"
+	pubKeyPrefix        = "pub"
+)
+
+// Registry for accounts.
+type Registry struct {
+	kr keyring.Keyring
+}
+
+// New creates a new registry to manage accounts.
+func New(backend string) (Registry, error) {
+	kr, err := keyring.New(KeyringServiceName, backend, KeyringHome, os.Stdin)
+	if err != nil {
+		return Registry{}, err
+	}
+
+	r := Registry{
+		kr: kr,
+	}
+
+	return r, nil
+}
+
+// Account represents an CosmosSDK account.
+type Account struct {
+	// Name of the account.
+	Name string
+
+	// Info holds additional info about the account.
+	Info keyring.Info
+}
+
+// Address returns an address for acocunt for given prefix.
+func (a Account) Address(accPrefix string) string {
+	if accPrefix == "" {
+		accPrefix = accountPrefixCosmos
+	}
+
+	conf := types.GetConfig()
+	conf.SetBech32PrefixForAccount(accPrefix, pubKeyPrefix)
+
+	ko, err := keyring.Bech32KeyOutput(a.Info)
+	if err != nil {
+		panic(err)
+	}
+	return ko.Address
+}
+
+// PubKey returns a public key for given account prefix.
+func (a Account) PubKey(accPrefix string) string {
+	if accPrefix == "" {
+		accPrefix = accountPrefixCosmos
+	}
+
+	conf := types.GetConfig()
+	conf.SetBech32PrefixForAccount(accPrefix, pubKeyPrefix)
+
+	o, err := keyring.Bech32KeyOutput(a.Info)
+	if err != nil {
+		panic(err)
+	}
+	return o.PubKey
+}
+
+// Create creates a new account with name.
+func (r Registry) Create(name string) (acc Account, mnemonic string, err error) {
+	acc, err = r.GetByName(name)
+	if err == nil {
+		return Account{}, "", ErrAccountExists
+	}
+	if !errors.Is(err, ErrAccountDoesNotExist) {
+		return Account{}, "", err
+	}
+
+	entropySeed, err := bip39.NewEntropy(256)
+	if err != nil {
+		return Account{}, "", err
+	}
+	mnemonic, err = bip39.NewMnemonic(entropySeed)
+	if err != nil {
+		return Account{}, "", err
+	}
+
+	algo, err := r.algo()
+	if err != nil {
+		return Account{}, "", err
+	}
+	info, err := r.kr.NewAccount(name, mnemonic, "", r.hdPath(), algo)
+	if err != nil {
+		return Account{}, "", err
+	}
+
+	acc = Account{
+		Name: name,
+		Info: info,
+	}
+
+	return acc, mnemonic, nil
+}
+
+// Import imports an existing account with name andd passphrase and secret where secret can be a
+// mnemonic or private key.
+func (r Registry) Import(name, secret, passphrase string) (Account, error) {
+	_, err := r.GetByName(name)
+	if err == nil {
+		return Account{}, ErrAccountExists
+	}
+	if !errors.Is(err, ErrAccountDoesNotExist) {
+		return Account{}, err
+	}
+
+	if bip39.IsMnemonicValid(secret) {
+		algo, err := r.algo()
+		if err != nil {
+			return Account{}, err
+		}
+		_, err = r.kr.NewAccount(name, secret, passphrase, r.hdPath(), algo)
+		if err != nil {
+			return Account{}, err
+		}
+	} else if err := r.kr.ImportPrivKey(name, secret, passphrase); err != nil {
+		return Account{}, err
+	}
+
+	return r.GetByName(name)
+}
+
+// Export exports an account as a private key.
+func (r Registry) Export(name, passphrase string) (key string, err error) {
+	if _, err = r.GetByName(name); err != nil {
+		return "", err
+	}
+
+	return r.kr.ExportPrivKeyArmor(name, passphrase)
+
+}
+
+// GetByName returns an account by its name.
+func (r Registry) GetByName(name string) (Account, error) {
+	info, err := r.kr.Key(name)
+	if err == dkeyring.ErrKeyNotFound {
+		return Account{}, ErrAccountDoesNotExist
+	}
+	if err != nil {
+		return Account{}, nil
+	}
+
+	acc := Account{
+		Name: name,
+		Info: info,
+	}
+
+	return acc, nil
+}
+
+// List lists all accounts.
+func (r Registry) List() ([]Account, error) {
+	info, err := r.kr.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var accounts []Account
+
+	for _, accinfo := range info {
+		accounts = append(accounts, Account{
+			Name: accinfo.GetName(),
+			Info: accinfo,
+		})
+	}
+
+	return accounts, nil
+}
+
+// DeleteByName deletes an account by name.
+func (r Registry) DeleteByName(name string) error {
+	err := r.kr.Delete(name)
+	if err == dkeyring.ErrKeyNotFound {
+		return ErrAccountDoesNotExist
+	}
+	return err
+}
+
+func (r Registry) hdPath() string {
+	return hd.CreateHDPath(types.GetConfig().GetCoinType(), 0, 0).String()
+}
+
+func (r Registry) algo() (keyring.SignatureAlgo, error) {
+	algos, _ := r.kr.SupportedAlgorithms()
+	return keyring.NewSigningAlgoFromString(string(hd.Secp256k1Type), algos)
+}

--- a/starport/pkg/cosmosaccount/cosmosaccount.go
+++ b/starport/pkg/cosmosaccount/cosmosaccount.go
@@ -55,7 +55,7 @@ type Account struct {
 	Info keyring.Info
 }
 
-// Address returns an address for acocunt for given prefix.
+// Address returns the address of the account from given prefix.
 func (a Account) Address(accPrefix string) string {
 	if accPrefix == "" {
 		accPrefix = accountPrefixCosmos


### PR DESCRIPTION
Added `starport account` command to manage accounts.

Next, I'll use this feature in `starport relayer` to see how these two will work together and do needed improvements on the accounts feature accordingly. 