### PR TITLE
feat(cmd/message): add `--signer` flag

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Features
 
 - `client.toml` is initialized and used by node's CLI, can be configured through `config.yml` with the `init.client` property
+- Added `--signer` flag to `scaffold message` to allow customising the name of the signer of the message
 
 ## `v0.17.1`
 

--- a/integration/cmd_message_test.go
+++ b/integration/cmd_message_test.go
@@ -39,9 +39,9 @@ func TestGenerateAnAppWithMessage(t *testing.T) {
 		ExecShouldError(),
 	))
 
-	env.Must(env.Exec("create a second message",
+	env.Must(env.Exec("create a message with a custom signer name",
 		step.NewSteps(step.New(
-			step.Exec("starport", "s", "message", "do-bar", "bar"),
+			step.Exec("starport", "s", "message", "do-bar", "bar", "--signer", "bar-doer"),
 			step.Workdir(path),
 		)),
 	))

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -33,10 +33,10 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 	defer s.Stop()
 
 	var (
-		module, _ = cmd.Flags().GetString(flagModule)
+		module, _    = cmd.Flags().GetString(flagModule)
 		resFields, _ = cmd.Flags().GetStringSlice(flagResponse)
-		desc, _ = cmd.Flags().GetString(flagDescription)
-		signer, _ = cmd.Flags().GetString(flagSigner)
+		desc, _      = cmd.Flags().GetString(flagDescription)
+		signer, _    = cmd.Flags().GetString(flagSigner)
 	)
 
 	var options []scaffolder.MessageOption

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -23,7 +23,7 @@ func NewScaffoldMessage() *cobra.Command {
 	c.Flags().String(flagModule, "", "Module to add the message into. Default: app's main module")
 	c.Flags().StringSliceP(flagResponse, "r", []string{}, "Response fields")
 	c.Flags().StringP(flagDescription, "d", "", "Description of the command")
-	c.Flags().String(flagSigner, "", "Name of the message signer")
+	c.Flags().String(flagSigner, "", "Label for the message signer (default: creator)")
 
 	return c
 }

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -32,34 +32,21 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 	s := clispinner.New().SetText("Scaffolding...")
 	defer s.Stop()
 
-	// Get the module to add the type into
-	module, err := cmd.Flags().GetString(flagModule)
-	if err != nil {
-		return err
-	}
-
-	// Get response fields
-	resFields, err := cmd.Flags().GetStringSlice(flagResponse)
-	if err != nil {
-		return err
-	}
+	var (
+		module, _ = cmd.Flags().GetString(flagModule)
+		resFields, _ = cmd.Flags().GetStringSlice(flagResponse)
+		desc, _ = cmd.Flags().GetString(flagDescription)
+		signer, _ = cmd.Flags().GetString(flagSigner)
+	)
 
 	var options []scaffolder.MessageOption
 
 	// Get description
-	desc, err := cmd.Flags().GetString(flagDescription)
-	if err != nil {
-		return err
-	}
 	if desc != "" {
 		options = append(options, scaffolder.WithDescription(desc))
 	}
 
 	// Get signer
-	signer, err := cmd.Flags().GetString(flagSigner)
-	if err != nil {
-		return err
-	}
 	if signer != "" {
 		options = append(options, scaffolder.WithSigner(signer))
 	}

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -9,6 +9,8 @@ import (
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )
 
+const flagSigner = "signer"
+
 // NewScaffoldMessage returns the command to scaffold messages
 func NewScaffoldMessage() *cobra.Command {
 	c := &cobra.Command{
@@ -21,6 +23,7 @@ func NewScaffoldMessage() *cobra.Command {
 	c.Flags().String(flagModule, "", "Module to add the message into. Default: app's main module")
 	c.Flags().StringSliceP(flagResponse, "r", []string{}, "Response fields")
 	c.Flags().StringP(flagDescription, "d", "", "Description of the command")
+	c.Flags().String(flagSigner, "", "Name of the message signer")
 
 	return c
 }
@@ -49,6 +52,11 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 	if desc == "" {
 		// Use a default description
 		desc = fmt.Sprintf("Broadcast message %s", args[0])
+	}
+
+	signer, err := cmd.Flags().GetString(flagSigner)
+	if err != nil {
+		return err
 	}
 
 	sc, err := scaffolder.New(appPath)

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -44,26 +44,31 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	var options []scaffolder.MessageOption
+
 	// Get description
 	desc, err := cmd.Flags().GetString(flagDescription)
 	if err != nil {
 		return err
 	}
 	if desc == "" {
-		// Use a default description
-		desc = fmt.Sprintf("Broadcast message %s", args[0])
+		options = append(options, scaffolder.WithDescription(desc))
 	}
 
+	// Get signer
 	signer, err := cmd.Flags().GetString(flagSigner)
 	if err != nil {
 		return err
+	}
+	if signer == "" {
+		options = append(options, scaffolder.WithSigner(signer))
 	}
 
 	sc, err := scaffolder.New(appPath)
 	if err != nil {
 		return err
 	}
-	sm, err := sc.AddMessage(placeholder.New(), module, args[0], desc, args[1:], resFields)
+	sm, err := sc.AddMessage(placeholder.New(), module, args[0], args[1:], resFields, options...)
 	if err != nil {
 		return err
 	}

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -51,7 +51,7 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if desc == "" {
+	if desc != "" {
 		options = append(options, scaffolder.WithDescription(desc))
 	}
 
@@ -60,7 +60,7 @@ func messageHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if signer == "" {
+	if signer != "" {
 		options = append(options, scaffolder.WithSigner(signer))
 	}
 

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -94,7 +94,7 @@ func (s *Scaffolder) AddMessage(
 		return sm, err
 	}
 
-	mfSigner, err := multiformatname.NewName(scaffoldingOpts.signer, multiformatname.NoNumber)
+	mfSigner, err := multiformatname.NewName(scaffoldingOpts.signer)
 	if err != nil {
 		return sm, err
 	}

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -14,18 +14,55 @@ import (
 	modulecreate "github.com/tendermint/starport/starport/templates/module/create"
 )
 
+// messageOptions represents configuration for the message scaffolding
+type messageOptions struct {
+	description string
+	signer string
+}
+
+// newMessageOptions returns a messageOptions with default options
+func newMessageOptions(messageName string) messageOptions {
+	return messageOptions {
+		description: fmt.Sprintf("Broadcast message %s", messageName),
+		signer: "creator",
+	}
+}
+
+// MessageOption configures the message scaffolding
+type MessageOption func(*messageOptions)
+
+// WithDescription provides a custom description for the message CLI command
+func WithDescription(desc string) MessageOption {
+	return func(m *messageOptions) {
+		m.description = desc
+	}
+}
+
+// WithSigner provides a custom signer name for the message
+func WithSigner(signer string) MessageOption {
+	return func(m *messageOptions) {
+		m.signer = signer
+	}
+}
+
 // AddMessage adds a new message to scaffolded app
 func (s *Scaffolder) AddMessage(
 	tracer *placeholder.Tracer,
 	moduleName,
-	msgName,
-	msgDesc string,
+	msgName string,
 	fields,
 	resFields []string,
+	options ...MessageOption,
 ) (sm xgenny.SourceModification, err error) {
 	path, err := gomodulepath.ParseAt(s.path)
 	if err != nil {
 		return sm, err
+	}
+
+	// Create the options
+	scaffoldingOpts := newMessageOptions(msgName)
+	for _, apply := range options {
+		apply(&scaffoldingOpts)
 	}
 
 	// If no module is provided, we add the type to the app's module
@@ -67,7 +104,7 @@ func (s *Scaffolder) AddMessage(
 			MsgName:    name,
 			Fields:     parsedMsgFields,
 			ResFields:  parsedResFields,
-			MsgDesc:    msgDesc,
+			MsgDesc:    scaffoldingOpts.description,
 		}
 	)
 

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -17,14 +17,14 @@ import (
 // messageOptions represents configuration for the message scaffolding
 type messageOptions struct {
 	description string
-	signer string
+	signer      string
 }
 
 // newMessageOptions returns a messageOptions with default options
 func newMessageOptions(messageName string) messageOptions {
-	return messageOptions {
+	return messageOptions{
 		description: fmt.Sprintf("Broadcast message %s", messageName),
-		signer: "creator",
+		signer:      "creator",
 	}
 }
 
@@ -110,7 +110,7 @@ func (s *Scaffolder) AddMessage(
 			Fields:     parsedMsgFields,
 			ResFields:  parsedResFields,
 			MsgDesc:    scaffoldingOpts.description,
-			MsgSigner: mfSigner,
+			MsgSigner:  mfSigner,
 		}
 	)
 

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -94,6 +94,11 @@ func (s *Scaffolder) AddMessage(
 		return sm, err
 	}
 
+	mfSigner, err := multiformatname.NewName(scaffoldingOpts.signer, multiformatname.NoNumber)
+	if err != nil {
+		return sm, err
+	}
+
 	var (
 		g    *genny.Generator
 		opts = &message.Options{
@@ -105,6 +110,7 @@ func (s *Scaffolder) AddMessage(
 			Fields:     parsedMsgFields,
 			ResFields:  parsedResFields,
 			MsgDesc:    scaffoldingOpts.description,
+			MsgSigner: mfSigner,
 		}
 	)
 

--- a/starport/templates/message/message.go
+++ b/starport/templates/message/message.go
@@ -27,6 +27,7 @@ func Box(box packd.Walker, opts *Options, g *genny.Generator) error {
 	ctx.Set("AppName", opts.AppName)
 	ctx.Set("MsgName", opts.MsgName)
 	ctx.Set("MsgDesc", opts.MsgDesc)
+	ctx.Set("MsgSigner", opts.MsgSigner)
 	ctx.Set("OwnerName", opts.OwnerName)
 	ctx.Set("ModulePath", opts.ModulePath)
 	ctx.Set("Fields", opts.Fields)

--- a/starport/templates/message/options.go
+++ b/starport/templates/message/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	OwnerName  string
 	MsgName    multiformatname.Name
 	MsgDesc    string
+	MsgSigner  multiformatname.Name
 	Fields     []field.Field
 	ResFields  []field.Field
 }

--- a/starport/templates/message/stargate.go
+++ b/starport/templates/message/stargate.go
@@ -84,16 +84,18 @@ func protoTxMessageModify(replacer placeholder.Replacer, opts *Options) genny.Ru
 
 		template := `%[1]v
 message Msg%[2]v {
-  string creator = 1;
+  string %[5]v = 1;
 %[3]v}
 
 message Msg%[2]vResponse {
 %[4]v}
 `
-		replacement := fmt.Sprintf(template, PlaceholderProtoTxMessage,
+		replacement := fmt.Sprintf(template,
+			PlaceholderProtoTxMessage,
 			opts.MsgName.UpperCamel,
 			msgFields,
 			resFields,
+			opts.MsgSigner.LowerCamel,
 		)
 		content := replacer.Replace(f.String(), PlaceholderProtoTxMessage, replacement)
 		newFile := genny.NewFileS(path, content)

--- a/starport/templates/message/stargate/x/{{moduleName}}/types/message_{{msgName}}.go.plush
+++ b/starport/templates/message/stargate/x/{{moduleName}}/types/message_{{msgName}}.go.plush
@@ -7,9 +7,9 @@ import (
 
 var _ sdk.Msg = &Msg<%= MsgName.UpperCamel %>{}
 
-func NewMsg<%= MsgName.UpperCamel %>(creator string<%= for (field) in Fields { %>, <%= field.Name.LowerCamel %> <%= field.Datatype %><% } %>) *Msg<%= MsgName.UpperCamel %> {
+func NewMsg<%= MsgName.UpperCamel %>(<%= MsgSigner.LowerCamel %> string<%= for (field) in Fields { %>, <%= field.Name.LowerCamel %> <%= field.Datatype %><% } %>) *Msg<%= MsgName.UpperCamel %> {
   return &Msg<%= MsgName.UpperCamel %>{
-		Creator: creator,<%= for (field) in Fields { %>
+		<%= MsgSigner.UpperCamel %>: <%= MsgSigner.LowerCamel %>,<%= for (field) in Fields { %>
     <%= field.Name.UpperCamel %>: <%= field.Name.LowerCamel %>,<% } %>
 	}
 }
@@ -23,11 +23,11 @@ func (msg *Msg<%= MsgName.UpperCamel %>) Type() string {
 }
 
 func (msg *Msg<%= MsgName.UpperCamel %>) GetSigners() []sdk.AccAddress {
-  creator, err := sdk.AccAddressFromBech32(msg.Creator)
+  <%= MsgSigner.LowerCamel %>, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   if err != nil {
     panic(err)
   }
-  return []sdk.AccAddress{creator}
+  return []sdk.AccAddress{<%= MsgSigner.LowerCamel %>}
 }
 
 func (msg *Msg<%= MsgName.UpperCamel %>) GetSignBytes() []byte {
@@ -36,9 +36,9 @@ func (msg *Msg<%= MsgName.UpperCamel %>) GetSignBytes() []byte {
 }
 
 func (msg *Msg<%= MsgName.UpperCamel %>) ValidateBasic() error {
-  _, err := sdk.AccAddressFromBech32(msg.Creator)
+  _, err := sdk.AccAddressFromBech32(msg.<%= MsgSigner.UpperCamel %>)
   	if err != nil {
-  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+  		return sdkerrors.Wrapf(sdkerrors.ErrInvalidAddress, "invalid <%= MsgSigner.LowerCamel %> address (%s)", err)
   	}
   return nil
 }


### PR DESCRIPTION
The `--signer` flag for `message` allows to determine a custom name for the signer of the message instead of "creator"