### PR TITLE
fix(template): use kebab case for cli command parameter 

### DIFF
--- a/starport/templates/ibc/packet/messages/x/{{moduleName}}/client/cli/tx_{{packetName}}.go.plush
+++ b/starport/templates/ibc/packet/messages/x/{{moduleName}}/client/cli/tx_{{packetName}}.go.plush
@@ -15,7 +15,7 @@ var _ = strconv.Itoa(0)
 
 func CmdSend<%= packetName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "send-<%= packetName.Kebab %> [src-port] [src-channel]<%= for (i, field) in fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "send-<%= packetName.Kebab %> [src-port] [src-channel]<%= for (i, field) in fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Send a <%= packetName.Original %> over IBC",
 		Args:  cobra.ExactArgs(<%= len(fields) + 2 %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/message/stargate/x/{{moduleName}}/client/cli/tx_{{msgName}}.go.plush
+++ b/starport/templates/message/stargate/x/{{moduleName}}/client/cli/tx_{{msgName}}.go.plush
@@ -14,7 +14,7 @@ var _ = strconv.Itoa(0)
 
 func Cmd<%= MsgName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "<%= MsgName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "<%= MsgName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "<%= MsgDesc %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/query/stargate/x/{{moduleName}}/client/cli/query_{{queryName}}.go.plush
+++ b/starport/templates/query/stargate/x/{{moduleName}}/client/cli/query_{{queryName}}.go.plush
@@ -13,7 +13,7 @@ var _ = strconv.Itoa(0)
 
 func Cmd<%= QueryName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "<%= QueryName.Kebab %><%= for (i, field) in ReqFields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "<%= QueryName.Kebab %><%= for (i, field) in ReqFields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "<%= Description %>",
 		Args:  cobra.ExactArgs(<%= len(ReqFields) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/typed/indexed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}.go.plush
+++ b/starport/templates/typed/indexed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}.go.plush
@@ -45,7 +45,7 @@ func CmdList<%= TypeName.UpperCamel %>() *cobra.Command {
 
 func CmdShow<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "show-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.LowerCamel %>]<% } %>",
+		Use:   "show-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.Kebab %>]<% } %>",
 		Short: "shows a <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Indexes) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/typed/indexed/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
+++ b/starport/templates/typed/indexed/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
@@ -12,7 +12,7 @@ import (
 
 func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
     cmd := &cobra.Command{
-		Use:   "create-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.LowerCamel %>]<% } %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "create-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.Kebab %>]<% } %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Create a new <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) + len(Indexes) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -54,7 +54,7 @@ func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
 
 func CmdUpdate<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.LowerCamel %>]<% } %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "update-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.Kebab %>]<% } %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Update a <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) + len(Indexes) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -96,7 +96,7 @@ func CmdUpdate<%= TypeName.UpperCamel %>() *cobra.Command {
 
 func CmdDelete<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.LowerCamel %>]<% } %>",
+		Use:   "delete-<%= TypeName.Kebab %><%= for (i, index) in Indexes { %> [<%= index.Name.Kebab %>]<% } %>",
 		Short: "Delete a <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Indexes) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
+++ b/starport/templates/typed/singleton/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
@@ -15,7 +15,7 @@ import (
 
 func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
     cmd := &cobra.Command{
-		Use:   "create-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "create-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Create <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -45,7 +45,7 @@ func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
 
 func CmdUpdate<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "update-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Update <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/starport/templates/typed/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate/messages/x/{{moduleName}}/client/cli/tx_{{typeName}}.go.plush
@@ -16,7 +16,7 @@ import (
 
 func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "create-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "create-<%= TypeName.Kebab %><%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Create a new <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) %>),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -45,7 +45,7 @@ func CmdCreate<%= TypeName.UpperCamel %>() *cobra.Command {
 
 func CmdUpdate<%= TypeName.UpperCamel %>() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "update-<%= TypeName.Kebab %> [id]<%= for (i, field) in Fields { %> [<%= field.Name.LowerCamel %>]<% } %>",
+		Use:   "update-<%= TypeName.Kebab %> [id]<%= for (i, field) in Fields { %> [<%= field.Name.Kebab %>]<% } %>",
 		Short: "Update a <%= TypeName.Original %>",
 		Args:  cobra.ExactArgs(<%= len(Fields) + 1 %>),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Based on this fix on `spn` https://github.com/tendermint/spn/pull/241

The cli command parameters in prompt help should use kebab case