### PR TITLE
feat(proto): Remove type `Creator` field for internal types

### DIFF
--- a/starport/pkg/field/field.go
+++ b/starport/pkg/field/field.go
@@ -23,7 +23,7 @@ type Field struct {
 	DatatypeName string
 }
 
-// parseFields parses the provided fields, analyses the types and checks there is no duplicated field
+// ParseFields parses the provided fields, analyses the types and checks there is no duplicated field
 func ParseFields(fields []string, isForbiddenField func(string) error) ([]Field, error) {
 	// Used to check duplicated field
 	existingFields := make(map[string]bool)

--- a/starport/templates/typed/indexed/stargate.go
+++ b/starport/templates/typed/indexed/stargate.go
@@ -378,7 +378,7 @@ import "%s/%s.proto";`
 				"  %s %s = %d;\n",
 				index.Datatype,
 				index.Name.LowerCamel,
-				i+1,
+				i+2,
 			)
 		}
 
@@ -388,7 +388,7 @@ import "%s/%s.proto";`
 				"  %s %s = %d;\n",
 				field.Datatype,
 				field.Name.LowerCamel,
-				i+1+len(opts.Indexes),
+				i+2+len(opts.Indexes),
 			)
 		}
 

--- a/starport/templates/typed/indexed/stargate.go
+++ b/starport/templates/typed/indexed/stargate.go
@@ -372,49 +372,46 @@ import "%s/%s.proto";`
 		content = replacer.Replace(content, typed.PlaceholderProtoTxRPC, replacementRPC)
 
 		// Messages
-		var indexes string
-		for i, index := range opts.Indexes {
-			indexes += fmt.Sprintf(
+		var fields string
+		for i, index := range append(opts.Indexes, opts.Fields...) {
+			fields += fmt.Sprintf(
 				"  %s %s = %d;\n",
 				index.Datatype,
 				index.Name.LowerCamel,
-				i+2,
+				i+1,
 			)
 		}
 
-		var fields string
-		for i, field := range opts.Fields {
-			fields += fmt.Sprintf(
+		var deleteFields string
+		for i, field := range opts.Indexes {
+			deleteFields += fmt.Sprintf(
 				"  %s %s = %d;\n",
 				field.Datatype,
 				field.Name.LowerCamel,
-				i+2+len(opts.Indexes),
+				i+1+len(opts.Indexes),
 			)
 		}
 
 		templateMessages := `%[1]v
 message MsgCreate%[2]v {
   string creator = 1;
-%[3]v
-%[4]v}
-message MsgCreate%[2]vResponse { }
+%[3]v}
+message MsgCreate%[2]vResponse {}
 
 message MsgUpdate%[2]v {
   string creator = 1;
-%[3]v
-%[4]v}
-message MsgUpdate%[2]vResponse { }
+%[3]v}
+message MsgUpdate%[2]vResponse {}
 
 message MsgDelete%[2]v {
   string creator = 1;
-%[3]v
-}
-message MsgDelete%[2]vResponse { }
+%[4]v}
+message MsgDelete%[2]vResponse {}
 `
 		replacementMessages := fmt.Sprintf(templateMessages, typed.PlaceholderProtoTxMessage,
 			opts.TypeName.UpperCamel,
-			indexes,
 			fields,
+			deleteFields,
 		)
 		content = replacer.Replace(content, typed.PlaceholderProtoTxMessage, replacementMessages)
 

--- a/starport/templates/typed/indexed/stargate.go
+++ b/starport/templates/typed/indexed/stargate.go
@@ -372,9 +372,9 @@ import "%s/%s.proto";`
 		content = replacer.Replace(content, typed.PlaceholderProtoTxRPC, replacementRPC)
 
 		// Messages
-		var fields string
-		for i, index := range append(opts.Indexes, opts.Fields...) {
-			fields += fmt.Sprintf(
+		var indexes string
+		for i, index := range opts.Indexes {
+			indexes += fmt.Sprintf(
 				"  %s %s = %d;\n",
 				index.Datatype,
 				index.Name.LowerCamel,
@@ -382,9 +382,9 @@ import "%s/%s.proto";`
 			)
 		}
 
-		var deleteFields string
-		for i, field := range opts.Indexes {
-			deleteFields += fmt.Sprintf(
+		var fields string
+		for i, field := range opts.Fields {
+			fields += fmt.Sprintf(
 				"  %s %s = %d;\n",
 				field.Datatype,
 				field.Name.LowerCamel,
@@ -395,23 +395,25 @@ import "%s/%s.proto";`
 		templateMessages := `%[1]v
 message MsgCreate%[2]v {
   string creator = 1;
-%[3]v}
-message MsgCreate%[2]vResponse {}
+%[3]v
+%[4]v}
+message MsgCreate%[2]vResponse { }
 
 message MsgUpdate%[2]v {
   string creator = 1;
-%[3]v}
-message MsgUpdate%[2]vResponse {}
+%[3]v
+%[4]v}
+message MsgUpdate%[2]vResponse { }
 
 message MsgDelete%[2]v {
   string creator = 1;
-%[4]v}
-message MsgDelete%[2]vResponse {}
+%[3]v}
+message MsgDelete%[2]vResponse { }
 `
 		replacementMessages := fmt.Sprintf(templateMessages, typed.PlaceholderProtoTxMessage,
 			opts.TypeName.UpperCamel,
+			indexes,
 			fields,
-			deleteFields,
 		)
 		content = replacer.Replace(content, typed.PlaceholderProtoTxMessage, replacementMessages)
 

--- a/starport/templates/typed/indexed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/indexed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -3,9 +3,9 @@ package <%= formatOwnerName(OwnerName) %>.<%= AppName %>.<%= ModuleName %>;
 
 option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 
-message <%= TypeName.UpperCamel %> {
-  <%= if (!NoMessage) { %>string creator = 1;<% } %><%= for (i, index) in Indexes { %>
-  <%= index.Datatype %> <%= index.Name.LowerCamel %> = <%= i+2 %>; <% } %><%= for (i, field) in Fields { %>
-  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+2+len(Indexes) %>; <% } %>
+message <%= TypeName.UpperCamel %> {<%= for (i, index) in Indexes { %>
+  <%= index.Datatype %> <%= index.Name.LowerCamel %> = <%= i+1 %>; <% } %><%= for (i, field) in Fields { %>
+  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+1+len(Indexes) %>; <% } %>
+  <%= if (!NoMessage) { %>string creator = <%= len(Fields)+len(Indexes)+1 %>;<% } %>
 }
 

--- a/starport/templates/typed/indexed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/indexed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -4,7 +4,7 @@ package <%= formatOwnerName(OwnerName) %>.<%= AppName %>.<%= ModuleName %>;
 option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 
 message <%= TypeName.UpperCamel %> {
-  string creator = 1;<%= for (i, index) in Indexes { %>
+  <%= if (!NoMessage) { %>string creator = 1;<% } %><%= for (i, index) in Indexes { %>
   <%= index.Datatype %> <%= index.Name.LowerCamel %> = <%= i+2 %>; <% } %><%= for (i, field) in Fields { %>
   <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+2+len(Indexes) %>; <% } %>
 }

--- a/starport/templates/typed/singleton/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/singleton/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -6,6 +6,6 @@ option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 import "gogoproto/gogo.proto";
 
 message <%= TypeName.UpperCamel %> {
-  string creator = 1;<%= for (i, field) in Fields { %>
+  <%= if (!NoMessage) { %>string creator = 1;<% } %><%= for (i, field) in Fields { %>
   <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+2 %>; <% } %>
 }

--- a/starport/templates/typed/singleton/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/singleton/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -5,7 +5,7 @@ option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 
 import "gogoproto/gogo.proto";
 
-message <%= TypeName.UpperCamel %> {
-  <%= if (!NoMessage) { %>string creator = 1;<% } %><%= for (i, field) in Fields { %>
-  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+2 %>; <% } %>
+message <%= TypeName.UpperCamel %> {<%= for (i, field) in Fields { %>
+  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+1 %>; <% } %>
+  <%= if (!NoMessage) { %>string creator = <%= len(Fields)+1 %>;<% } %>
 }

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -20,7 +20,9 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T) (*network.Networ
 	state := types.GenesisState{}
     require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
 
-	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{Creator: "ANY"}
+	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{
+		<%= if (!NoMessage) { %>Creator: "ANY",<% } %>
+	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
 	require.NoError(t, err)
 	cfg.GenesisState[types.ModuleName] = buf

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -20,7 +20,7 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T) (*network.Networ
 	state := types.GenesisState{}
     require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
 
-	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{<%= if (!NoMessage) { %>Creator: "ANY"<% } %>}
+	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{}
 	buf, err := cfg.Codec.MarshalJSON(&state)
 	require.NoError(t, err)
 	cfg.GenesisState[types.ModuleName] = buf

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -20,9 +20,7 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T) (*network.Networ
 	state := types.GenesisState{}
     require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
 
-	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{
-		<%= if (!NoMessage) { %>Creator: "ANY",<% } %>
-	}
+	state.<%= TypeName.UpperCamel %> = &types.<%= TypeName.UpperCamel %>{<%= if (!NoMessage) { %>Creator: "ANY"<% } %>}
 	buf, err := cfg.Codec.MarshalJSON(&state)
 	require.NoError(t, err)
 	cfg.GenesisState[types.ModuleName] = buf

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -10,7 +10,7 @@ import (
 )
 
 func createTest<%= TypeName.UpperCamel %>(keeper *Keeper, ctx sdk.Context) types.<%= TypeName.UpperCamel %> {
-	item := types.<%= TypeName.UpperCamel %>{<%= if (!NoMessage) { %>Creator: "any"<% } %>}
+	item := types.<%= TypeName.UpperCamel %>{}
 	keeper.Set<%= TypeName.UpperCamel %>(ctx, item)
 	return item
 }

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -11,7 +11,7 @@ import (
 
 func createTest<%= TypeName.UpperCamel %>(keeper *Keeper, ctx sdk.Context) types.<%= TypeName.UpperCamel %> {
 	item := types.<%= TypeName.UpperCamel %>{
-	    Creator: "any",
+	    <%= if (!NoMessage) { %>Creator: "any",<% } %>
 	}
 	keeper.Set<%= TypeName.UpperCamel %>(ctx, item)
 	return item

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -10,9 +10,7 @@ import (
 )
 
 func createTest<%= TypeName.UpperCamel %>(keeper *Keeper, ctx sdk.Context) types.<%= TypeName.UpperCamel %> {
-	item := types.<%= TypeName.UpperCamel %>{
-	    <%= if (!NoMessage) { %>Creator: "any",<% } %>
-	}
+	item := types.<%= TypeName.UpperCamel %>{<%= if (!NoMessage) { %>Creator: "any"<% } %>}
 	keeper.Set<%= TypeName.UpperCamel %>(ctx, item)
 	return item
 }

--- a/starport/templates/typed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -6,7 +6,7 @@ option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 import "gogoproto/gogo.proto";
 
 message <%= TypeName.UpperCamel %> {
-  string creator = 1;
-  uint64 id = 2;<%= for (i, field) in Fields { %>
+  uint64 id = 1;
+  <%= if (!NoMessage) { %>string creator = 2;<% } %><%= for (i, field) in Fields { %>
   <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+3 %>; <% } %>
 }

--- a/starport/templates/typed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
+++ b/starport/templates/typed/stargate/component/proto/{{moduleName}}/{{typeName}}.proto.plush
@@ -6,7 +6,7 @@ option go_package = "<%= ModulePath %>/x/<%= ModuleName %>/types";
 import "gogoproto/gogo.proto";
 
 message <%= TypeName.UpperCamel %> {
-  uint64 id = 1;
-  <%= if (!NoMessage) { %>string creator = 2;<% } %><%= for (i, field) in Fields { %>
-  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+3 %>; <% } %>
+  uint64 id = 1;<%= for (i, field) in Fields { %>
+  <%= field.Datatype %> <%= field.Name.LowerCamel %> = <%= i+2 %>; <% } %>
+  <%= if (!NoMessage) { %>string creator = <%= len(Fields)+2 %>;<% } %>
 }

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -24,7 +24,9 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network
     require.NoError(t, cfg.Codec.UnmarshalJSON(cfg.GenesisState[types.ModuleName], &state))
 
 	for i := 0; i < n; i++ {
-		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, &types.<%= TypeName.UpperCamel %>{Creator: "ANY", Id: uint64(i)})
+		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, &types.<%= TypeName.UpperCamel %>{
+			<%= if (!NoMessage) { %>Creator: "ANY",<% } %> Id: uint64(i)
+		})
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)
 	require.NoError(t, err)

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -25,7 +25,7 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network
 
 	for i := 0; i < n; i++ {
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, &types.<%= TypeName.UpperCamel %>{
-			<%= if (!NoMessage) { %>Creator: "ANY",<% } %> Id: uint64(i),
+			Id: uint64(i),
 		})
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -25,7 +25,7 @@ func networkWith<%= TypeName.UpperCamel %>Objects(t *testing.T, n int) (*network
 
 	for i := 0; i < n; i++ {
 		state.<%= TypeName.UpperCamel %>List = append(state.<%= TypeName.UpperCamel %>List, &types.<%= TypeName.UpperCamel %>{
-			<%= if (!NoMessage) { %>Creator: "ANY",<% } %> Id: uint64(i)
+			<%= if (!NoMessage) { %>Creator: "ANY",<% } %> Id: uint64(i),
 		})
 	}
 	buf, err := cfg.Codec.MarshalJSON(&state)

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}.go.plush
@@ -78,12 +78,12 @@ func (k Keeper) Has<%= TypeName.UpperCamel %>(ctx sdk.Context, id uint64) bool {
 	store :=  prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= TypeName.UpperCamel %>Key))
 	return store.Has(Get<%= TypeName.UpperCamel %>IDBytes(id))
 }
-
+<%= if (!NoMessage) { %>
 // Get<%= TypeName.UpperCamel %>Owner returns the creator of the <%= TypeName %>
 func (k Keeper) Get<%= TypeName.UpperCamel %>Owner(ctx sdk.Context, id uint64) string {
     return k.Get<%= TypeName.UpperCamel %>(ctx, id).Creator
 }
-
+<% } %>
 // Remove<%= TypeName.UpperCamel %> removes a <%= TypeName.LowerCamel %> from the store
 func (k Keeper) Remove<%= TypeName.UpperCamel %>(ctx sdk.Context, id uint64) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.<%= TypeName.UpperCamel %>Key))

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -11,7 +11,7 @@ import (
 func createN<%= TypeName.UpperCamel %>(keeper *Keeper, ctx sdk.Context, n int) []types.<%= TypeName.UpperCamel %> {
 	items := make([]types.<%= TypeName.UpperCamel %>, n)
 	for i := range items {
-		items[i].Creator = "any"
+		<%= if (!NoMessage) { %>items[i].Creator = "any"<% } %>
 		items[i].Id = keeper.Append<%= TypeName.UpperCamel%>(ctx, items[i])
 	}
 	return items

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -11,7 +11,6 @@ import (
 func createN<%= TypeName.UpperCamel %>(keeper *Keeper, ctx sdk.Context, n int) []types.<%= TypeName.UpperCamel %> {
 	items := make([]types.<%= TypeName.UpperCamel %>, n)
 	for i := range items {
-		<%= if (!NoMessage) { %>items[i].Creator = "any"<% } %>
 		items[i].Id = keeper.Append<%= TypeName.UpperCamel%>(ctx, items[i])
 	}
 	return items

--- a/starport/templates/typed/typed.go
+++ b/starport/templates/typed/typed.go
@@ -40,6 +40,7 @@ func Box(box packd.Walker, opts *Options, g *genny.Generator) error {
 	ctx.Set("ModulePath", opts.ModulePath)
 	ctx.Set("Fields", opts.Fields)
 	ctx.Set("Indexes", opts.Indexes)
+	ctx.Set("NoMessage", opts.NoMessage)
 	ctx.Set("title", strings.Title)
 	ctx.Set("strconv", func() bool {
 		strconv := false


### PR DESCRIPTION
closes #1362

### What does this MR does?

Remove type `Creator` field for internal types if `--no-message` flag is enable;

### How to test?

- Scaffold types with the messages:
```shell
$ starport scaffold chain github.com/cosmonaut/test && cd test
$ starport s single single-type desc
$ starport s map map-type desc --index addr
$ starport s list list-type desc
```

- Scaffold types without the messages:
```shell
$ starport s single single-type-no-msg desc --no-message
$ starport s map map-type-no-msg desc --index addr --no-message
$ starport s list list-type-no-msg desc --no-message
```
