### PR TITLE
feat(pkg): add cosmosclient pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/tendermint/starport
 go 1.16
 
 require (
-	github.com/99designs/keyring v1.1.6 // indirect
+	github.com/99designs/keyring v1.1.6
 	github.com/AlecAivazis/survey/v2 v2.1.1
 	github.com/Microsoft/hcsshim v0.8.17 // indirect
 	github.com/blang/semver v3.5.1+incompatible

--- a/starport/pkg/cosmosclient/cosmosclient.go
+++ b/starport/pkg/cosmosclient/cosmosclient.go
@@ -1,4 +1,4 @@
-package spn
+package cosmosclient
 
 import (
 	"io"
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -22,7 +21,13 @@ const (
 	defaultGasLimit      = 300000
 )
 
-func NewClientCtx(kr keyring.Keyring, c *rpchttp.HTTP, out io.Writer, home string) client.Context {
+// NewContext creates a new client context.
+func NewContext(
+	c *rpchttp.HTTP,
+	out io.Writer,
+	chainID,
+	home string,
+) client.Context {
 	encodingConfig := params.MakeEncodingConfig()
 	authtypes.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 	cryptocodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
@@ -31,8 +36,7 @@ func NewClientCtx(kr keyring.Keyring, c *rpchttp.HTTP, out io.Writer, home strin
 	cryptocodec.RegisterInterfaces(encodingConfig.InterfaceRegistry)
 
 	return client.Context{}.
-		WithChainID(spn).
-		WithKeyring(kr).
+		WithChainID(chainID).
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithJSONMarshaler(encodingConfig.Marshaler).
 		WithTxConfig(encodingConfig.TxConfig).
@@ -46,7 +50,7 @@ func NewClientCtx(kr keyring.Keyring, c *rpchttp.HTTP, out io.Writer, home strin
 		WithSkipConfirmation(true)
 }
 
-// NewFactory creates a new Factory.
+// NewFactory creates a new tx factory.
 func NewFactory(clientCtx client.Context) tx.Factory {
 	return tx.Factory{}.
 		WithChainID(clientCtx.ChainID).

--- a/starport/pkg/spn/spn.go
+++ b/starport/pkg/spn/spn.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
+	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
 	"github.com/tendermint/starport/starport/pkg/xfilepath"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
@@ -70,8 +71,10 @@ func New(nodeAddress, apiAddress, faucetAddress string, option ...Option) (*Clie
 		return nil, err
 	}
 	out := &bytes.Buffer{}
-	clientCtx := NewClientCtx(kr, client, out, homePath)
-	factory := NewFactory(clientCtx)
+	clientCtx := cosmosclient.
+		NewContext(client, out, spn, homePath).
+		WithKeyring(kr)
+	factory := cosmosclient.NewFactory(clientCtx)
 	return &Client{
 		kr:            kr,
 		factory:       factory,


### PR DESCRIPTION
@toschdev I heard that you're instered in programatically accessing sdk based chains in Go.

One of the requirements of doing this is accessing to `client.Context`, which this PR provides. 

Please see [this](https://gist.github.com/ilgooz/0d87818184e9c0802c97753c47d7f47a) example of querying bank module.

For creating and broadcasting txs you can refer to [this](https://github.com/tendermint/starport/blob/12189d4fefc1806ed57e514522549ea4641273f7/starport/pkg/spn/spn.go). You can search for keywords like `clientCtx`, `cosmosclient.NewFactory` and `cosmosclient.NewContext`.

When you're dealing with tx's you need to set the keyring to `clientCtx` like this:
```go
clientCtx = clientCtx.WithKeyring(client.NewKeyringFromBackend(clientCtx, "test"))
```