### PR TITLE
feat(template): replace `assert` with `require` from `testify` packages

### DIFF
--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/starport/starport/pkg/protoanalysis"
 )
@@ -63,7 +62,7 @@ func TestDiscover(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := Discover(context.Background(), tt.args.sourcePath, tt.args.protoDir)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/starport/pkg/localfs/search_test.go
+++ b/starport/pkg/localfs/search_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,11 +100,11 @@ func TestSearch(t *testing.T) {
 			got, err := Search(tt.args.path, tt.args.pattern)
 			if tt.err != nil {
 				require.Error(t, err)
-				assert.EqualValues(t, tt.err, err)
+				require.EqualValues(t, tt.err, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.EqualValues(t, tt.want, got)
+			require.EqualValues(t, tt.want, got)
 		})
 	}
 }

--- a/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
@@ -120,7 +119,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			for j := i; j < len(objs) && j < i+step; j++ {
-				assert.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 		}
 	})
@@ -134,7 +133,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			for j := i; j < len(objs) && j < i+step; j++ {
-				assert.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 			next = resp.Pagination.NextKey
 		}

--- a/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -89,7 +88,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 			resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			for j := i; j < len(msgs) && j < i+step; j++ {
-				assert.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 		}
 	})
@@ -100,7 +99,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 			resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			for j := i; j < len(msgs) && j < i+step; j++ {
-				assert.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 			next = resp.Pagination.NextKey
 		}

--- a/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/indexed/stargate/tests/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
     
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
@@ -31,8 +31,8 @@ func Test<%= TypeName.UpperCamel %>Get(t *testing.T) {
 		    <%= for (i, index) in Indexes { %>item.<%= index.Name.UpperCamel %>,
             <% } %>
 		)
-		assert.True(t, found)
-		assert.Equal(t, item, rst)
+		require.True(t, found)
+		require.Equal(t, item, rst)
 	}
 }
 func Test<%= TypeName.UpperCamel %>Remove(t *testing.T) {
@@ -47,12 +47,12 @@ func Test<%= TypeName.UpperCamel %>Remove(t *testing.T) {
 		    <%= for (i, index) in Indexes { %>item.<%= index.Name.UpperCamel %>,
             <% } %>
 		)
-		assert.False(t, found)
+		require.False(t, found)
 	}
 }
 
 func Test<%= TypeName.UpperCamel %>GetAll(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
-	assert.Equal(t, items, keeper.GetAll<%= TypeName.UpperCamel %>(ctx))
+	require.Equal(t, items, keeper.GetAll<%= TypeName.UpperCamel %>(ctx))
 }

--- a/starport/templates/typed/indexed/stargate/tests/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/indexed/stargate/tests/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -6,7 +6,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
@@ -32,7 +31,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerCreate(t *testing.T) {
             <% } %>
 		)
 		require.True(t, found)
-		assert.Equal(t, expected.Creator, rst.Creator)
+		require.Equal(t, expected.Creator, rst.Creator)
 	}
 }
 
@@ -90,7 +89,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
                     <% } %>
 				)
 				require.True(t, found)
-				assert.Equal(t, expected.Creator, rst.Creator)
+				require.Equal(t, expected.Creator, rst.Creator)
 			}
 		})
 	}

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
     
 	"<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
@@ -19,13 +19,13 @@ func Test<%= TypeName.UpperCamel %>Get(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	item := createTest<%= TypeName.UpperCamel %>(keeper, ctx)
 	rst, found := keeper.Get<%= TypeName.UpperCamel %>(ctx)
-    assert.True(t, found)
-    assert.Equal(t, item, rst)
+    require.True(t, found)
+    require.Equal(t, item, rst)
 }
 func Test<%= TypeName.UpperCamel %>Remove(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	createTest<%= TypeName.UpperCamel %>(keeper, ctx)
 	keeper.Remove<%= TypeName.UpperCamel %>(ctx)
     _, found := keeper.Get<%= TypeName.UpperCamel %>(ctx)
-    assert.False(t, found)
+    require.False(t, found)
 }

--- a/starport/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/singleton/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -5,7 +5,6 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
@@ -21,7 +20,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerCreate(t *testing.T) {
     require.NoError(t, err)
     rst, found := keeper.Get<%= TypeName.UpperCamel %>(ctx)
     require.True(t, found)
-    assert.Equal(t, expected.Creator, rst.Creator)
+    require.Equal(t, expected.Creator, rst.Creator)
 }
 
 func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
@@ -58,7 +57,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerUpdate(t *testing.T) {
 				require.NoError(t, err)
 				rst, found := keeper.Get<%= TypeName.UpperCamel %>(ctx)
 				require.True(t, found)
-				assert.Equal(t, expected.Creator, rst.Creator)
+				require.Equal(t, expected.Creator, rst.Creator)
 			}
 		})
 	}

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"google.golang.org/grpc/codes"
@@ -109,7 +108,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			for j := i; j < len(objs) && j < i+step; j++ {
-				assert.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 		}
 	})
@@ -123,7 +122,7 @@ func TestList<%= TypeName.UpperCamel %>(t *testing.T) {
 			var resp types.QueryAll<%= TypeName.UpperCamel %>Response
 			require.NoError(t, net.Config.Codec.UnmarshalJSON(out.Bytes(), &resp))
 			for j := i; j < len(objs) && j < i+step; j++ {
-				assert.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, objs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 			next = resp.Pagination.NextKey
 		}

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -6,7 +6,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/query"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -78,7 +77,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 			resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(nil, uint64(i), uint64(step), false))
 			require.NoError(t, err)
 			for j := i; j < len(msgs) && j < i+step; j++ {
-				assert.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 		}
 	})
@@ -89,7 +88,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 			resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(next, 0, uint64(step), false))
 			require.NoError(t, err)
 			for j := i; j < len(msgs) && j < i+step; j++ {
-				assert.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
+				require.Equal(t, msgs[j], resp.<%= TypeName.UpperCamel %>[j-i])
 			}
 			next = resp.Pagination.NextKey
 		}

--- a/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/component/x/{{moduleName}}/keeper/{{typeName}}_test.go.plush
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
 )
 
@@ -20,7 +20,7 @@ func Test<%= TypeName.UpperCamel %>Get(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
 	for _, item := range items {
-		assert.Equal(t, item, keeper.Get<%= TypeName.UpperCamel %>(ctx, item.Id))
+		require.Equal(t, item, keeper.Get<%= TypeName.UpperCamel %>(ctx, item.Id))
 	}
 }
 
@@ -28,7 +28,7 @@ func Test<%= TypeName.UpperCamel %>Exist(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
 	for _, item := range items {
-		assert.True(t, keeper.Has<%= TypeName.UpperCamel %>(ctx, item.Id))
+		require.True(t, keeper.Has<%= TypeName.UpperCamel %>(ctx, item.Id))
 	}
 }
 
@@ -37,19 +37,19 @@ func Test<%= TypeName.UpperCamel %>Remove(t *testing.T) {
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
 	for _, item := range items {
 		keeper.Remove<%= TypeName.UpperCamel %>(ctx, item.Id)
-		assert.False(t, keeper.Has<%= TypeName.UpperCamel %>(ctx, item.Id))
+		require.False(t, keeper.Has<%= TypeName.UpperCamel %>(ctx, item.Id))
 	}
 }
 
 func Test<%= TypeName.UpperCamel %>GetAll(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
-	assert.Equal(t, items, keeper.GetAll<%= TypeName.UpperCamel %>(ctx))
+	require.Equal(t, items, keeper.GetAll<%= TypeName.UpperCamel %>(ctx))
 }
 
 func Test<%= TypeName.UpperCamel %>Count(t *testing.T) {
 	keeper, ctx := setupKeeper(t)
 	items := createN<%= TypeName.UpperCamel %>(keeper, ctx, 10)
 	count := uint64(len(items))
-	assert.Equal(t, count, keeper.Get<%= TypeName.UpperCamel %>Count(ctx))
+	require.Equal(t, count, keeper.Get<%= TypeName.UpperCamel %>Count(ctx))
 }

--- a/starport/templates/typed/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/stargate/messages/x/{{moduleName}}/keeper/msg_server_{{typeName}}_test.go.plush
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
     "<%= ModulePath %>/x/<%= ModuleName %>/types"
@@ -16,7 +15,7 @@ func Test<%= TypeName.UpperCamel %>MsgServerCreate(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		resp, err := srv.Create<%= TypeName.UpperCamel %>(ctx, &types.MsgCreate<%= TypeName.UpperCamel %>{Creator: creator})
 		require.NoError(t, err)
-		assert.Equal(t, i, int(resp.Id))
+		require.Equal(t, i, int(resp.Id))
 	}
 }
 


### PR DESCRIPTION
closes #1422

### What does this MR does?

use the `require` package from `testify` instead of the `assert` package for the unit tests.

### How to test?

- Scaffold a chain and run the tests:
```shell
$ starport scaffold chain github.com/cosmonaut/test
$ go test -v ./...
```
