### PR TITLE
fix(oracle): add a specific `bandchain` pkg version to avoid `cosmos-sdk` version conflicts

### DIFF
--- a/starport/services/scaffolder/oracle.go
+++ b/starport/services/scaffolder/oracle.go
@@ -1,15 +1,24 @@
 package scaffolder
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/gobuffalo/genny"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
+	"github.com/tendermint/starport/starport/pkg/gocmd"
 	"github.com/tendermint/starport/starport/pkg/gomodulepath"
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/ibc"
+)
+
+const (
+	bandImport  = "github.com/bandprotocol/bandchain-packet"
+	bandVersion = "v0.0.0"
 )
 
 // AddOracle adds a new BandChain oracle integration.
@@ -18,6 +27,10 @@ func (s *Scaffolder) AddOracle(
 	moduleName,
 	queryName string,
 ) (sm xgenny.SourceModification, err error) {
+	if err := s.installBandPacket(); err != nil {
+		return sm, err
+	}
+
 	path, err := gomodulepath.ParseAt(s.path)
 	if err != nil {
 		return sm, err
@@ -71,4 +84,11 @@ func (s *Scaffolder) AddOracle(
 		return sm, err
 	}
 	return sm, s.finish(pwd, path.RawPath)
+}
+
+func (s *Scaffolder) installBandPacket() error {
+	return cmdrunner.New().
+		Run(context.Background(),
+			step.New(step.Exec(gocmd.Name(), "get", gocmd.PackageLiteral(bandImport, bandVersion))),
+		)
 }


### PR DESCRIPTION
closes #1481
closes #1482

### What does this MR does?

Create a method to install a specific `bandchain` version to avoid `cosmos-sdk` version conflicts.

### How to test?

- Scaffold a chain and run the tests:
```shell
$ starport s chain github.com/cosmonaut/test
$ starport s module consuming --ibc
$ starport s band oracleone --module consuming
```
