### PR TITLE
fix(cosmosgen): handle replaced cosmos-sdk

### DIFF
--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -86,6 +86,7 @@ type generator struct {
 	appPath      string
 	protoDir     string
 	o            *generateOptions
+	sdkImport    string
 	deps         []gomodmodule.Version
 	appModules   []module.Module
 	thirdModules map[string][]module.Module // app dependency-modules pair.


### PR DESCRIPTION
When trying to integrate starport with my application I got the following error:

```
[STARPORT] 🛠️  Building proto...
[STARPORT] cannot build app:
[STARPORT] 
[STARPORT]      go.mod has missing proto modules
```

This seems to happen because of the hardcoded cosmos-sdk path in https://github.com/tendermint/starport/blob/develop/starport/pkg/cosmosgen/generate.go#L14, along with my application replacing the cosmos-sdk in the go.mod file.

This PR allows replacing the cosmos-sdk import path if a custom one is defined in the go.mod file, or keep using the default path otherwise.



