### PR TITLE
fix(scaffolder): prevent scaffolding types with suffix `test`

### DIFF
--- a/starport/pkg/multiformatname/multiformatname.go
+++ b/starport/pkg/multiformatname/multiformatname.go
@@ -15,10 +15,10 @@ type Name struct {
 	Original   string
 	LowerCamel string
 	UpperCamel string
+	LowerCase  string
 	UpperCase  string
 	Kebab      string
 	Snake      string
-	Lowercase  string
 }
 
 type Checker func(name string) error
@@ -40,7 +40,7 @@ func NewName(name string, additionalChecks ...Checker) (Name, error) {
 		UpperCase:  strings.ToUpper(name),
 		Kebab:      strcase.ToKebab(name),
 		Snake:      strcase.ToSnake(name),
-		Lowercase:  lowercase(name),
+		LowerCase:  lowercase(name),
 	}, nil
 }
 

--- a/starport/pkg/multiformatname/multiformatname_test.go
+++ b/starport/pkg/multiformatname/multiformatname_test.go
@@ -58,7 +58,7 @@ func TestNewMultiFormatName(t *testing.T) {
 		require.Equal(
 			t,
 			testCase[5],
-			name.Lowercase,
+			name.LowerCase,
 			fmt.Sprintf("%s should be converted the correct lowercase format", testCase[0]),
 		)
 	}

--- a/starport/services/scaffolder/component.go
+++ b/starport/services/scaffolder/component.go
@@ -1,6 +1,7 @@
 package scaffolder
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -54,7 +55,7 @@ func checkForbiddenComponentName(name multiformatname.Name) error {
 	}
 
 	if strings.HasSuffix(name.LowerCase, "test") {
-		return fmt.Errorf("'test' suffix is used by Go test files")
+		return errors.New(`name cannot end with "test"`)
 	}
 
 	return checkGoReservedWord(name.LowerCamel)

--- a/starport/services/scaffolder/component.go
+++ b/starport/services/scaffolder/component.go
@@ -7,6 +7,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 )
@@ -29,8 +30,8 @@ func checkComponentValidity(appPath, moduleName string, compName multiformatname
 	}
 
 	// Ensure the name is valid, otherwise it would generate an incorrect code
-	if err := checkForbiddenComponentName(compName.LowerCamel); err != nil {
-		return fmt.Errorf("%s can't be used as a component name: %s", compName, err.Error())
+	if err := checkForbiddenComponentName(compName); err != nil {
+		return fmt.Errorf("%s can't be used as a component name: %s", compName.LowerCamel, err.Error())
 	}
 
 	// Check component name is not already used
@@ -38,9 +39,9 @@ func checkComponentValidity(appPath, moduleName string, compName multiformatname
 }
 
 // checkForbiddenComponentName returns true if the name is forbidden as a component name
-func checkForbiddenComponentName(name string) error {
+func checkForbiddenComponentName(name multiformatname.Name) error {
 	// Check with names already used from the scaffolded code
-	switch name {
+	switch name.LowerCamel {
 	case
 		"oracle",
 		"logger",
@@ -49,10 +50,14 @@ func checkForbiddenComponentName(name string) error {
 		"genesis",
 		"types",
 		"tx":
-		return fmt.Errorf("%s is used by Starport scaffolder", name)
+		return fmt.Errorf("%s is used by Starport scaffolder", name.LowerCamel)
 	}
 
-	return checkGoReservedWord(name)
+	if strings.HasSuffix(name.LowerCase, "test") {
+		return fmt.Errorf("'test' suffix is used by Go test files")
+	}
+
+	return checkGoReservedWord(name.LowerCamel)
 }
 
 // checkGoReservedWord checks if the name can't be used because it is a go reserved keyword

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -73,7 +73,7 @@ func (s *Scaffolder) AddMessage(
 	if err != nil {
 		return sm, err
 	}
-	moduleName = mfName.Lowercase
+	moduleName = mfName.LowerCase
 
 	name, err := multiformatname.NewName(msgName)
 	if err != nil {

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -88,7 +88,7 @@ func (s *Scaffolder) CreateModule(
 	if err != nil {
 		return sm, err
 	}
-	moduleName = mfName.Lowercase
+	moduleName = mfName.LowerCase
 
 	// Check if the module name is valid
 	if err := checkModuleName(moduleName); err != nil {

--- a/starport/services/scaffolder/oracle.go
+++ b/starport/services/scaffolder/oracle.go
@@ -67,7 +67,7 @@ func (s *Scaffolder) AddOracle(
 	if err != nil {
 		return sm, err
 	}
-	moduleName = mfName.Lowercase
+	moduleName = mfName.LowerCase
 
 	name, err := multiformatname.NewName(queryName)
 	if err != nil {

--- a/starport/services/scaffolder/packet.go
+++ b/starport/services/scaffolder/packet.go
@@ -72,7 +72,7 @@ func (s *Scaffolder) AddPacket(
 	if err != nil {
 		return sm, err
 	}
-	moduleName = mfName.Lowercase
+	moduleName = mfName.LowerCase
 
 	name, err := multiformatname.NewName(packetName)
 	if err != nil {

--- a/starport/services/scaffolder/query.go
+++ b/starport/services/scaffolder/query.go
@@ -35,7 +35,7 @@ func (s *Scaffolder) AddQuery(
 	if err != nil {
 		return sm, err
 	}
-	moduleName = mfName.Lowercase
+	moduleName = mfName.LowerCase
 
 	name, err := multiformatname.NewName(queryName)
 	if err != nil {

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -126,7 +126,7 @@ func (s *Scaffolder) AddType(
 	if err != nil {
 		return sm, err
 	}
-	moduleName := mfName.Lowercase
+	moduleName := mfName.LowerCase
 
 	name, err := multiformatname.NewName(typeName)
 	if err != nil {


### PR DESCRIPTION
close #1469

### What does this MR does?

Fix scaffold components with suffix `test`  Go understands the `_test.go` suffix as a test file. This PR checks the suffix and shows a message to the user.

### How to test?

```shell
$ starport s map map-test first second third:uint --index idOne,idTwo:uint,idThree
$ starport c serve -v
```