### PR TITLE
feat(template): scaffold tests for genesis export and import

### DIFF
--- a/starport/services/scaffolder/patch.go
+++ b/starport/services/scaffolder/patch.go
@@ -18,11 +18,11 @@ func supportGenesisTests(
 	modulePath,
 	moduleName string,
 ) ([]*genny.Generator, error) {
-	filepath, err := filepath.Abs(filepath.Join(appPath, "x", moduleName, "types", "genesis_test.go"))
+	path, err := filepath.Abs(filepath.Join(appPath, "x", moduleName, "genesis_test.go"))
 	if err != nil {
 		return nil, err
 	}
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
 		g, err := modulecreate.AddGenesisTest(appName, modulePath, moduleName)
 		if err != nil {
 			return nil, err

--- a/starport/templates/module/create/genesistest/x/{{moduleName}}/genesis_test.go.plush
+++ b/starport/templates/module/create/genesistest/x/{{moduleName}}/genesis_test.go.plush
@@ -1,0 +1,57 @@
+package <%= moduleName %>_test
+
+import (
+	"testing"
+
+	"<%= modulePath %>/x/<%= moduleName %>"
+	"<%= modulePath %>/x/<%= moduleName %>/keeper"
+	"<%= modulePath %>/x/<%= moduleName %>/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+// setupApp returns the keeper and the sdk context
+func setupApp(t testing.TB) (*keeper.Keeper, sdk.Context) {
+	storeKey := sdk.NewKVStoreKey(types.StoreKey)
+	memStoreKey := storetypes.NewMemoryStoreKey(types.MemStoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db)
+	stateStore.MountStoreWithDB(storeKey, sdk.StoreTypeIAVL, db)
+	stateStore.MountStoreWithDB(memStoreKey, sdk.StoreTypeMemory, nil)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	k := keeper.NewKeeper(
+		codec.NewProtoCodec(registry),
+		storeKey,
+		memStoreKey,
+	)
+
+	ctx := sdk.NewContext(
+		stateStore,
+		tmproto.Header{},
+		false,
+		log.NewNopLogger(),
+	)
+	return k, ctx
+}
+
+func TestGenesis(t *testing.T) {
+	genesisState := types.GenesisState{
+		// this line is used by starport scaffolding # genesis/test/state
+	}
+
+	k, ctx := setupApp(t)
+	<%= moduleName %>.InitGenesis(ctx, *k, genesisState)
+	got := <%= moduleName %>.ExportGenesis(ctx, *k)
+
+	// this line is used by starport scaffolding # genesis/test/assert
+}

--- a/starport/templates/module/create/genesistest/x/{{moduleName}}/types/genesis_test.go.plush
+++ b/starport/templates/module/create/genesistest/x/{{moduleName}}/types/genesis_test.go.plush
@@ -26,7 +26,6 @@ func TestGenesisState_Validate(t *testing.T) {
         },
         // this line is used by starport scaffolding # types/genesis/testcase
     } {
-        tc := tc
         t.Run(tc.desc, func(t *testing.T) {
             err := tc.genState.Validate()
             if tc.valid {

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -22,6 +22,7 @@ func NewIBC(replacer placeholder.Replacer, opts *CreateOptions) (*genny.Generato
 	g.RunFn(genesisTypeModify(replacer, opts))
 	g.RunFn(genesisProtoModify(replacer, opts))
 	g.RunFn(genesisTestsModify(replacer, opts))
+	g.RunFn(genesisTypesTestsModify(replacer, opts))
 	g.RunFn(keysModify(replacer, opts))
 	g.RunFn(keeperModify(replacer, opts))
 
@@ -165,6 +166,25 @@ func genesisProtoModify(replacer placeholder.Replacer, opts *CreateOptions) genn
 }
 
 func genesisTestsModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
+	return func(r *genny.Runner) error {
+		path := fmt.Sprintf("x/%s/genesis_test.go", opts.ModuleName)
+		f, err := r.Disk.Find(path)
+		if err != nil {
+			return err
+		}
+
+		replacementState := fmt.Sprintf("PortId: types.PortID,\n%s", module.PlaceholderGenesisTestState)
+		content := replacer.Replace(f.String(), module.PlaceholderGenesisTestState, replacementState)
+
+		replacementAssert := fmt.Sprintf("require.Equal(t, genesisState.PortID, got.PortID)\n%s", module.PlaceholderGenesisTestAssert)
+		content = replacer.Replace(content, module.PlaceholderGenesisTestAssert, replacementAssert)
+
+		newFile := genny.NewFileS(path, content)
+		return r.File(newFile)
+	}
+}
+
+func genesisTypesTestsModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
 	return func(r *genny.Runner) error {
 		path := fmt.Sprintf("x/%s/types/genesis_test.go", opts.ModuleName)
 		f, err := r.Disk.Find(path)

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -48,4 +48,6 @@ const (
 	// Genesis test
 	PlaceholderTypesGenesisTestcase   = "// this line is used by starport scaffolding # types/genesis/testcase"
 	PlaceholderTypesGenesisValidField = "// this line is used by starport scaffolding # types/genesis/validField"
+	PlaceholderGenesisTestState       = "// this line is used by starport scaffolding # genesis/test/state"
+	PlaceholderGenesisTestAssert      = "// this line is used by starport scaffolding # genesis/test/assert"
 )

--- a/starport/templates/typed/singleton/stargate.go
+++ b/starport/templates/typed/singleton/stargate.go
@@ -3,11 +3,13 @@ package singleton
 import (
 	"embed"
 	"fmt"
+	"math/rand"
 	"strings"
 
 	"github.com/gobuffalo/genny"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
+	"github.com/tendermint/starport/starport/templates/module"
 	"github.com/tendermint/starport/starport/templates/typed"
 )
 
@@ -36,6 +38,8 @@ func NewStargate(replacer placeholder.Replacer, opts *typed.Options) (*genny.Gen
 	g.RunFn(genesisProtoModify(replacer, opts))
 	g.RunFn(genesisTypesModify(replacer, opts))
 	g.RunFn(genesisModuleModify(replacer, opts))
+	g.RunFn(genesisTestsModify(replacer, opts))
+	g.RunFn(genesisTypesTestsModify(replacer, opts))
 
 	// Modifications for new messages
 	if !opts.NoMessage {
@@ -218,6 +222,92 @@ func genesisTypesModify(replacer placeholder.Replacer, opts *typed.Options) genn
 			opts.TypeName.UpperCamel,
 		)
 		content = replacer.Replace(content, typed.PlaceholderGenesisTypesDefault, replacementTypesDefault)
+
+		newFile := genny.NewFileS(path, content)
+		return r.File(newFile)
+	}
+}
+
+func genesisTestsModify(replacer placeholder.Replacer, opts *typed.Options) genny.RunFn {
+	return func(r *genny.Runner) error {
+		path := fmt.Sprintf("x/%s/genesis_test.go", opts.ModuleName)
+		f, err := r.Disk.Find(path)
+		if err != nil {
+			return err
+		}
+
+		// Create a fields
+		sampleFields := ""
+		for _, f := range opts.Fields {
+			switch f.DatatypeName {
+			case "string":
+				sampleFields += fmt.Sprintf("%s: \"%s\",\n", f.Name.UpperCamel, f.Name.LowerCamel)
+			case "int", "uint":
+				sampleFields += fmt.Sprintf("%s: %d,\n", f.Name.UpperCamel, rand.Intn(100))
+			case "bool":
+				sampleFields += fmt.Sprintf("%s: %t,\n", f.Name.UpperCamel, rand.Intn(2) == 0)
+			}
+		}
+
+		templateState := `%[1]v
+%[2]v: &types.%[2]v{
+		%[3]v},
+`
+		replacementState := fmt.Sprintf(
+			templateState,
+			module.PlaceholderGenesisTestState,
+			opts.TypeName.UpperCamel,
+			sampleFields,
+		)
+		content := replacer.Replace(f.String(), module.PlaceholderGenesisTestState, replacementState)
+
+		templateAssert := `%[1]v
+require.Equal(t, genesisState.%[2]v, got.%[2]v)
+`
+		replacementTests := fmt.Sprintf(
+			templateAssert,
+			module.PlaceholderGenesisTestAssert,
+			opts.TypeName.UpperCamel,
+		)
+		content = replacer.Replace(content, module.PlaceholderGenesisTestAssert, replacementTests)
+
+		newFile := genny.NewFileS(path, content)
+		return r.File(newFile)
+	}
+}
+
+func genesisTypesTestsModify(replacer placeholder.Replacer, opts *typed.Options) genny.RunFn {
+	return func(r *genny.Runner) error {
+		path := fmt.Sprintf("x/%s/types/genesis_test.go", opts.ModuleName)
+		f, err := r.Disk.Find(path)
+		if err != nil {
+			return err
+		}
+
+		// Create a fields
+		sampleFields := ""
+		for _, f := range opts.Fields {
+			switch f.DatatypeName {
+			case "string":
+				sampleFields += fmt.Sprintf("%s: \"%s\",\n", f.Name.UpperCamel, f.Name.LowerCamel)
+			case "int", "uint":
+				sampleFields += fmt.Sprintf("%s: %d,\n", f.Name.UpperCamel, rand.Intn(100))
+			case "bool":
+				sampleFields += fmt.Sprintf("%s: %t,\n", f.Name.UpperCamel, rand.Intn(2) == 0)
+			}
+		}
+
+		templateValid := `%[1]v
+%[2]v: &types.%[2]v{
+		%[3]v},
+`
+		replacementValid := fmt.Sprintf(
+			templateValid,
+			module.PlaceholderTypesGenesisValidField,
+			opts.TypeName.UpperCamel,
+			sampleFields,
+		)
+		content := replacer.Replace(f.String(), module.PlaceholderTypesGenesisValidField, replacementValid)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)


### PR DESCRIPTION
close #1126

### What does this MR does?

When a module is scaffolded with `starport s module` a file `x/<Module>/genesis_test.go` and `x/<Module>/genesis_test.go` are created for genesis validation tests.

### Solution

- Create template for `<Module>/genesis_test.go`;
- Add singleton parameters for the valid test case in `<Module>/types/genesis_test.go`;

### How to test?

- Scaffold a new chain:
```shell
$  starport s chain github.com/cosmonaut/foo
$ cd foo
```

- Scaffold some types:
```shell
$ starport s map map-test first second third:uint --index idOne,idTwo:uint,idThree
$ starport s single singleExample test desc
$ starport s list coordinator address:string validatorID:uint --no-message
```

- Run the unit tests:
```shell
$ go test ./x/foo/...
```

