### PR TITLE
fix(template): remove extra placeholders in genesis files

### DIFF
--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -2,6 +2,7 @@ package modulecreate
 
 import (
 	"fmt"
+	"github.com/tendermint/starport/starport/templates/typed"
 	"strings"
 
 	"github.com/gobuffalo/genny"
@@ -86,11 +87,11 @@ if !k.IsBound(ctx, genState.PortId) {
 		panic("could not claim port capability: " + err.Error())
 	}
 }`
-		content := replacer.Replace(f.String(), module.PlaceholderIBCGenesisInit, templateInit)
+		content := replacer.Replace(f.String(), typed.PlaceholderGenesisModuleInit, templateInit)
 
 		// Genesis export
 		templateExport := `genesis.PortId = k.GetPort(ctx)`
-		content = replacer.Replace(content, module.PlaceholderIBCGenesisExport, templateExport)
+		content = replacer.Replace(content, typed.PlaceholderGenesisModuleExport, templateExport)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
@@ -125,18 +126,18 @@ func genesisTypeModify(replacer placeholder.Replacer, opts *CreateOptions) genny
 
 		// Import
 		templateImport := `host "github.com/cosmos/cosmos-sdk/x/ibc/core/24-host"`
-		content := replacer.Replace(f.String(), module.PlaceholderIBCGenesisTypeImport, templateImport)
+		content := replacer.Replace(f.String(), typed.PlaceholderGenesisTypesImport, templateImport)
 
 		// Default genesis
 		templateDefault := `PortId: PortID,`
-		content = replacer.Replace(content, module.PlaceholderIBCGenesisTypeDefault, templateDefault)
+		content = replacer.Replace(content, typed.PlaceholderGenesisTypesDefault, templateDefault)
 
 		// Validate genesis
 		// PlaceholderIBCGenesisTypeValidate
 		templateValidate := `if err := host.PortIdentifierValidator(gs.PortId); err != nil {
 	return err
 }`
-		content = replacer.Replace(content, module.PlaceholderIBCGenesisTypeValidate, templateValidate)
+		content = replacer.Replace(content, typed.PlaceholderGenesisTypesValidate, templateValidate)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -166,9 +166,10 @@ func genesisProtoModify(replacer placeholder.Replacer, opts *CreateOptions) genn
 		content := f.String()
 		fieldNumber := strings.Count(content, module.PlaceholderGenesisProtoStateField) + 1
 
-		template := `string port_id = %[1]v; %[2]v`
-		replacement := fmt.Sprintf(template, fieldNumber, module.PlaceholderGenesisProtoStateField)
-		content = replacer.Replace(content, module.PlaceholderIBCGenesisProto, replacement)
+		template := `%[1]v
+  string port_id = %[2]v; %[3]v`
+		replacement := fmt.Sprintf(template, typed.PlaceholderGenesisProtoState, fieldNumber, module.PlaceholderGenesisProtoStateField)
+		content = replacer.Replace(content, typed.PlaceholderGenesisProtoState, replacement)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -76,7 +76,8 @@ func genesisModify(replacer placeholder.Replacer, opts *CreateOptions) genny.Run
 		}
 
 		// Genesis init
-		templateInit := `k.SetPort(ctx, genState.PortId)
+		templateInit := `%s
+k.SetPort(ctx, genState.PortId)
 // Only try to bind to port if it is not already bound, since we may already own
 // port capability from capability InitGenesis
 if !k.IsBound(ctx, genState.PortId) {
@@ -87,11 +88,14 @@ if !k.IsBound(ctx, genState.PortId) {
 		panic("could not claim port capability: " + err.Error())
 	}
 }`
-		content := replacer.Replace(f.String(), typed.PlaceholderGenesisModuleInit, templateInit)
+		replacementInit := fmt.Sprintf(templateInit, typed.PlaceholderGenesisModuleInit)
+		content := replacer.Replace(f.String(), typed.PlaceholderGenesisModuleInit, replacementInit)
 
 		// Genesis export
-		templateExport := `genesis.PortId = k.GetPort(ctx)`
-		content = replacer.Replace(content, typed.PlaceholderGenesisModuleExport, templateExport)
+		templateExport := `%s
+genesis.PortId = k.GetPort(ctx)`
+		replacementExport := fmt.Sprintf(templateExport, typed.PlaceholderGenesisModuleExport)
+		content = replacer.Replace(content, typed.PlaceholderGenesisModuleExport, replacementExport)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
@@ -125,19 +129,25 @@ func genesisTypeModify(replacer placeholder.Replacer, opts *CreateOptions) genny
 		}
 
 		// Import
-		templateImport := `host "github.com/cosmos/cosmos-sdk/x/ibc/core/24-host"`
-		content := replacer.Replace(f.String(), typed.PlaceholderGenesisTypesImport, templateImport)
+		templateImport := `%s
+host "github.com/cosmos/cosmos-sdk/x/ibc/core/24-host"`
+		replacementImport := fmt.Sprintf(templateImport, typed.PlaceholderGenesisTypesImport)
+		content := replacer.Replace(f.String(), typed.PlaceholderGenesisTypesImport, replacementImport)
 
 		// Default genesis
-		templateDefault := `PortId: PortID,`
-		content = replacer.Replace(content, typed.PlaceholderGenesisTypesDefault, templateDefault)
+		templateDefault := `%s
+PortId: PortID,`
+		replacementDefault := fmt.Sprintf(templateDefault, typed.PlaceholderGenesisTypesDefault)
+		content = replacer.Replace(content, typed.PlaceholderGenesisTypesDefault, replacementDefault)
 
 		// Validate genesis
 		// PlaceholderIBCGenesisTypeValidate
-		templateValidate := `if err := host.PortIdentifierValidator(gs.PortId); err != nil {
+		templateValidate := `%s
+if err := host.PortIdentifierValidator(gs.PortId); err != nil {
 	return err
 }`
-		content = replacer.Replace(content, typed.PlaceholderGenesisTypesValidate, templateValidate)
+		replacementValidate := fmt.Sprintf(templateValidate, typed.PlaceholderGenesisTypesValidate)
+		content = replacer.Replace(content, typed.PlaceholderGenesisTypesValidate, replacementValidate)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -2,7 +2,6 @@ package modulecreate
 
 import (
 	"fmt"
-	"github.com/tendermint/starport/starport/templates/typed"
 	"strings"
 
 	"github.com/gobuffalo/genny"
@@ -11,6 +10,7 @@ import (
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/module"
+	"github.com/tendermint/starport/starport/templates/typed"
 )
 
 // NewIBC returns the generator to scaffold the implementation of the IBCModule interface inside a module

--- a/starport/templates/module/create/stargate/proto/{{moduleName}}/genesis.proto.plush
+++ b/starport/templates/module/create/stargate/proto/{{moduleName}}/genesis.proto.plush
@@ -8,5 +8,4 @@ option go_package = "<%= modulePath %>/x/<%= moduleName %>/types";
 // GenesisState defines the <%= moduleName %> module's genesis state.
 message GenesisState {
     // this line is used by starport scaffolding # genesis/proto/state
-    // this line is used by starport scaffolding # ibc/genesis/proto
 }

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/genesis.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/genesis.go.plush
@@ -10,8 +10,6 @@ import (
 // state.
 func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) {
     // this line is used by starport scaffolding # genesis/module/init
-
-    // this line is used by starport scaffolding # ibc/genesis/init
 }
 
 // ExportGenesis returns the capability module's exported genesis.
@@ -19,8 +17,6 @@ func ExportGenesis(ctx sdk.Context, k keeper.Keeper) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 
     // this line is used by starport scaffolding # genesis/module/export
-
-    // this line is used by starport scaffolding # ibc/genesis/export
 
     return genesis
 }

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/genesis.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/genesis.go.plush
@@ -2,7 +2,6 @@ package types
 
 import (
 // this line is used by starport scaffolding # genesis/types/import
-// this line is used by starport scaffolding # ibc/genesistype/import
 )
 
 // DefaultIndex is the default capability global index
@@ -11,7 +10,6 @@ const DefaultIndex uint64 = 1
 // DefaultGenesis returns the default Capability genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
-		// this line is used by starport scaffolding # ibc/genesistype/default
 	    // this line is used by starport scaffolding # genesis/types/default
 	}
 }
@@ -19,8 +17,6 @@ func DefaultGenesis() *GenesisState {
 // Validate performs basic genesis state validation returning an error upon any
 // failure.
 func (gs GenesisState) Validate() error {
-	// this line is used by starport scaffolding # ibc/genesistype/validate
-
     // this line is used by starport scaffolding # genesis/types/validate
 
 	return nil

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -28,12 +28,7 @@ const (
 	// Placeholders IBC
 	PlaceholderIBCModuleImport               = "// this line is used by starport scaffolding # ibc/module/import"
 	PlaceholderIBCModuleInterface            = "// this line is used by starport scaffolding # ibc/module/interface"
-	PlaceholderIBCGenesisInit                = "// this line is used by starport scaffolding # ibc/genesis/init"
-	PlaceholderIBCGenesisExport              = "// this line is used by starport scaffolding # ibc/genesis/export"
 	PlaceholderIBCErrors                     = "// this line is used by starport scaffolding # ibc/errors"
-	PlaceholderIBCGenesisTypeImport          = "// this line is used by starport scaffolding # ibc/genesistype/import"
-	PlaceholderIBCGenesisTypeDefault         = "// this line is used by starport scaffolding # ibc/genesistype/default"
-	PlaceholderIBCGenesisTypeValidate        = "// this line is used by starport scaffolding # ibc/genesistype/validate"
 	PlaceholderIBCGenesisProto               = "// this line is used by starport scaffolding # ibc/genesis/proto"
 	PlaceholderIBCKeysName                   = "// this line is used by starport scaffolding # ibc/keys/name"
 	PlaceholderIBCKeysPort                   = "// this line is used by starport scaffolding # ibc/keys/port"

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -29,7 +29,6 @@ const (
 	PlaceholderIBCModuleImport               = "// this line is used by starport scaffolding # ibc/module/import"
 	PlaceholderIBCModuleInterface            = "// this line is used by starport scaffolding # ibc/module/interface"
 	PlaceholderIBCErrors                     = "// this line is used by starport scaffolding # ibc/errors"
-	PlaceholderIBCGenesisProto               = "// this line is used by starport scaffolding # ibc/genesis/proto"
 	PlaceholderIBCKeysName                   = "// this line is used by starport scaffolding # ibc/keys/name"
 	PlaceholderIBCKeysPort                   = "// this line is used by starport scaffolding # ibc/keys/port"
 	PlaceholderIBCKeeperAttribute            = "// this line is used by starport scaffolding # ibc/keeper/attribute"


### PR DESCRIPTION
Remove the extra placeholders used for IBC modules in `genesis.go`, `types/genesis.go` and `genesis.proto`