### PR TITLE
fix(template/module): prevent scaffolding ibc placeholders for non-IBC modules

### DIFF
--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -16,14 +16,11 @@ import (
 func NewIBC(replacer placeholder.Replacer, opts *CreateOptions) (*genny.Generator, error) {
 	g := genny.New()
 
-	g.RunFn(moduleModify(replacer, opts))
 	g.RunFn(genesisModify(replacer, opts))
-	g.RunFn(errorsModify(replacer, opts))
 	g.RunFn(genesisTypeModify(replacer, opts))
 	g.RunFn(genesisProtoModify(replacer, opts))
 	g.RunFn(genesisTestsModify(replacer, opts))
 	g.RunFn(keysModify(replacer, opts))
-	g.RunFn(keeperModify(replacer, opts))
 
 	if err := g.Box(ibcTemplate); err != nil {
 		return g, err
@@ -43,27 +40,6 @@ func NewIBC(replacer placeholder.Replacer, opts *CreateOptions) (*genny.Generato
 	g.Transformer(plushgen.Transformer(ctx))
 	g.Transformer(genny.Replace("{{moduleName}}", opts.ModuleName))
 	return g, nil
-}
-
-func moduleModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
-	return func(r *genny.Runner) error {
-		path := fmt.Sprintf("x/%s/module.go", opts.ModuleName)
-		f, err := r.Disk.Find(path)
-		if err != nil {
-			return err
-		}
-
-		// Import
-		templateImport := `porttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/05-port/types"`
-		content := replacer.Replace(f.String(), module.PlaceholderIBCModuleImport, templateImport)
-
-		// Interface to implement
-		templateInterface := `_ porttypes.IBCModule   = AppModule{}`
-		content = replacer.Replace(content, module.PlaceholderIBCModuleInterface, templateInterface)
-
-		newFile := genny.NewFileS(path, content)
-		return r.File(newFile)
-	}
 }
 
 func genesisModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
@@ -91,24 +67,6 @@ if !k.IsBound(ctx, genState.PortId) {
 		// Genesis export
 		templateExport := `genesis.PortId = k.GetPort(ctx)`
 		content = replacer.Replace(content, module.PlaceholderIBCGenesisExport, templateExport)
-
-		newFile := genny.NewFileS(path, content)
-		return r.File(newFile)
-	}
-}
-
-func errorsModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
-	return func(r *genny.Runner) error {
-		path := fmt.Sprintf("x/%s/types/errors.go", opts.ModuleName)
-		f, err := r.Disk.Find(path)
-		if err != nil {
-			return err
-		}
-
-		// IBC errors
-		template := `ErrInvalidPacketTimeout = sdkerrors.Register(ModuleName, 1500, "invalid packet timeout")
-ErrInvalidVersion = sdkerrors.Register(ModuleName, 1501, "invalid version")`
-		content := replacer.Replace(f.String(), module.PlaceholderIBCErrors, template)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)
@@ -204,37 +162,6 @@ PortID = "%[1]v"`
 )`
 		replacementPort := fmt.Sprintf(templatePort, opts.ModuleName)
 		content = replacer.Replace(content, module.PlaceholderIBCKeysPort, replacementPort)
-
-		newFile := genny.NewFileS(path, content)
-		return r.File(newFile)
-	}
-}
-
-func keeperModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunFn {
-	return func(r *genny.Runner) error {
-		path := fmt.Sprintf("x/%s/keeper/keeper.go", opts.ModuleName)
-		f, err := r.Disk.Find(path)
-		if err != nil {
-			return err
-		}
-
-		// Keeper new attributes
-		templateAttribute := `channelKeeper types.ChannelKeeper
-portKeeper    types.PortKeeper
-scopedKeeper  types.ScopedKeeper`
-		content := replacer.Replace(f.String(), module.PlaceholderIBCKeeperAttribute, templateAttribute)
-
-		// New parameter for the constructor
-		templateParameter := `channelKeeper types.ChannelKeeper,
-portKeeper types.PortKeeper,
-scopedKeeper types.ScopedKeeper,`
-		content = replacer.Replace(content, module.PlaceholderIBCKeeperParameter, templateParameter)
-
-		// New return values for the constructor
-		templateReturn := `channelKeeper: channelKeeper,
-portKeeper:    portKeeper,
-scopedKeeper:  scopedKeeper,`
-		content = replacer.Replace(content, module.PlaceholderIBCKeeperReturn, templateReturn)
 
 		newFile := genny.NewFileS(path, content)
 		return r.File(newFile)

--- a/starport/templates/module/create/stargate.go
+++ b/starport/templates/module/create/stargate.go
@@ -31,6 +31,7 @@ func NewStargate(opts *CreateOptions) (*genny.Generator, error) {
 	ctx.Set("ownerName", opts.OwnerName)
 	ctx.Set("title", strings.Title)
 	ctx.Set("dependencies", opts.Dependencies)
+	ctx.Set("isIBC", opts.IsIBC)
 
 	// Used for proto package name
 	ctx.Set("formatOwnerName", xstrings.FormatUsername)

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper.go.plush
@@ -15,7 +15,7 @@ type (
 		cdc      codec.Marshaler
 		storeKey sdk.StoreKey
 		memKey   sdk.StoreKey
-		// this line is used by starport scaffolding # ibc/keeper/attribute
+		<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/attribute<% } %>
 		<%= for (dependency) in dependencies { %>
         <%= dependency.Name %>Keeper types.<%= title(dependency.Name) %>Keeper<% } %>
 	}
@@ -25,14 +25,14 @@ func NewKeeper(
     cdc codec.Marshaler,
     storeKey,
     memKey sdk.StoreKey,
-    // this line is used by starport scaffolding # ibc/keeper/parameter
+    <%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/parameter<% } %>
     <%= for (dependency) in dependencies { %><%= dependency.Name %>Keeper types.<%= title(dependency.Name) %>Keeper,<% } %>
 ) *Keeper {
 	return &Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,
 		memKey:   memKey,
-		// this line is used by starport scaffolding # ibc/keeper/return
+		<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/return<% } %>
 		<%= for (dependency) in dependencies { %><%= dependency.Name %>Keeper: <%= dependency.Name %>Keeper,<% } %>
 	}
 }

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/keeper/keeper.go.plush
@@ -15,7 +15,9 @@ type (
 		cdc      codec.Marshaler
 		storeKey sdk.StoreKey
 		memKey   sdk.StoreKey
-		<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/attribute<% } %>
+		<%= if (isIBC) { %>channelKeeper types.ChannelKeeper
+        portKeeper    types.PortKeeper
+        scopedKeeper  types.ScopedKeeper<% } %>
 		<%= for (dependency) in dependencies { %>
         <%= dependency.Name %>Keeper types.<%= title(dependency.Name) %>Keeper<% } %>
 	}
@@ -25,14 +27,18 @@ func NewKeeper(
     cdc codec.Marshaler,
     storeKey,
     memKey sdk.StoreKey,
-    <%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/parameter<% } %>
+    <%= if (isIBC) { %>channelKeeper types.ChannelKeeper,
+    portKeeper types.PortKeeper,
+    scopedKeeper types.ScopedKeeper,<% } %>
     <%= for (dependency) in dependencies { %><%= dependency.Name %>Keeper types.<%= title(dependency.Name) %>Keeper,<% } %>
 ) *Keeper {
 	return &Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,
 		memKey:   memKey,
-		<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keeper/return<% } %>
+		<%= if (isIBC) { %>channelKeeper: channelKeeper,
+        portKeeper:    portKeeper,
+        scopedKeeper:  scopedKeeper,<% } %>
 		<%= for (dependency) in dependencies { %><%= dependency.Name %>Keeper: <%= dependency.Name %>Keeper,<% } %>
 	}
 }

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
@@ -19,13 +19,13 @@ import (
 	"<%= modulePath %>/x/<%= moduleName %>/keeper"
 	"<%= modulePath %>/x/<%= moduleName %>/types"
 	"<%= modulePath %>/x/<%= moduleName %>/client/cli"
-	// this line is used by starport scaffolding # ibc/module/import
+	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/module/import<% } %>
 )
 
 var (
 	_ module.AppModule      = AppModule{}
 	_ module.AppModuleBasic = AppModuleBasic{}
-	// this line is used by starport scaffolding # ibc/module/interface
+	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/module/interface<% } %>
 )
 
 // ----------------------------------------------------------------------------

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/module.go.plush
@@ -19,13 +19,13 @@ import (
 	"<%= modulePath %>/x/<%= moduleName %>/keeper"
 	"<%= modulePath %>/x/<%= moduleName %>/types"
 	"<%= modulePath %>/x/<%= moduleName %>/client/cli"
-	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/module/import<% } %>
+	<%= if (isIBC) { %>porttypes "github.com/cosmos/cosmos-sdk/x/ibc/core/05-port/types"<% } %>
 )
 
 var (
 	_ module.AppModule      = AppModule{}
 	_ module.AppModuleBasic = AppModuleBasic{}
-	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/module/interface<% } %>
+	<%= if (isIBC) { %>_ porttypes.IBCModule   = AppModule{}<% } %>
 )
 
 // ----------------------------------------------------------------------------

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
@@ -9,5 +9,6 @@ import (
 // x/<%= moduleName %> module sentinel errors
 var (
 	ErrSample = sdkerrors.Register(ModuleName, 1100, "sample error")
-	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/errors<% } %>
+	<%= if (isIBC) { %>ErrInvalidPacketTimeout = sdkerrors.Register(ModuleName, 1500, "invalid packet timeout")
+    ErrInvalidVersion = sdkerrors.Register(ModuleName, 1501, "invalid version")<% } %>
 )

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/errors.go.plush
@@ -9,5 +9,5 @@ import (
 // x/<%= moduleName %> module sentinel errors
 var (
 	ErrSample = sdkerrors.Register(ModuleName, 1100, "sample error")
-	// this line is used by starport scaffolding # ibc/errors
+	<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/errors<% } %>
 )

--- a/starport/templates/module/create/stargate/x/{{moduleName}}/types/keys.go.plush
+++ b/starport/templates/module/create/stargate/x/{{moduleName}}/types/keys.go.plush
@@ -16,10 +16,10 @@ const (
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_<%= moduleName %>"
 
-    // this line is used by starport scaffolding # ibc/keys/name
+    <%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keys/name<% } %>
 )
 
-// this line is used by starport scaffolding # ibc/keys/port
+<%= if (isIBC) { %>// this line is used by starport scaffolding # ibc/keys/port<% } %>
 
 func KeyPrefix(p string) []byte {
     return []byte(p)

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -26,8 +26,6 @@ const (
 	PlaceholderGenesisProtoStateField = "// this line is used by starport scaffolding # genesis/proto/stateField"
 
 	// Placeholders IBC
-	PlaceholderIBCModuleImport               = "// this line is used by starport scaffolding # ibc/module/import"
-	PlaceholderIBCModuleInterface            = "// this line is used by starport scaffolding # ibc/module/interface"
 	PlaceholderIBCGenesisInit                = "// this line is used by starport scaffolding # ibc/genesis/init"
 	PlaceholderIBCGenesisExport              = "// this line is used by starport scaffolding # ibc/genesis/export"
 	PlaceholderIBCErrors                     = "// this line is used by starport scaffolding # ibc/errors"
@@ -37,10 +35,7 @@ const (
 	PlaceholderIBCGenesisProto               = "// this line is used by starport scaffolding # ibc/genesis/proto"
 	PlaceholderIBCKeysName                   = "// this line is used by starport scaffolding # ibc/keys/name"
 	PlaceholderIBCKeysPort                   = "// this line is used by starport scaffolding # ibc/keys/port"
-	PlaceholderIBCKeeperAttribute            = "// this line is used by starport scaffolding # ibc/keeper/attribute"
-	PlaceholderIBCKeeperParameter            = "// this line is used by starport scaffolding # ibc/keeper/parameter"
-	PlaceholderIBCKeeperReturn               = "// this line is used by starport scaffolding # ibc/keeper/return"
-	PlaceholderIBCAppScopedKeeperDeclaration = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/declaration"
+ d	PlaceholderIBCAppScopedKeeperDeclaration = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/declaration"
 	PlaceholderIBCAppScopedKeeperDefinition  = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/definition"
 	PlaceholderIBCAppKeeperArgument          = "// this line is used by starport scaffolding # ibc/app/keeper/argument"
 	PlaceholderIBCAppRouter                  = "// this line is used by starport scaffolding # ibc/app/router"

--- a/starport/templates/module/placeholders.go
+++ b/starport/templates/module/placeholders.go
@@ -35,7 +35,7 @@ const (
 	PlaceholderIBCGenesisProto               = "// this line is used by starport scaffolding # ibc/genesis/proto"
 	PlaceholderIBCKeysName                   = "// this line is used by starport scaffolding # ibc/keys/name"
 	PlaceholderIBCKeysPort                   = "// this line is used by starport scaffolding # ibc/keys/port"
- d	PlaceholderIBCAppScopedKeeperDeclaration = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/declaration"
+	PlaceholderIBCAppScopedKeeperDeclaration = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/declaration"
 	PlaceholderIBCAppScopedKeeperDefinition  = "// this line is used by starport scaffolding # ibc/app/scopedKeeper/definition"
 	PlaceholderIBCAppKeeperArgument          = "// this line is used by starport scaffolding # ibc/app/keeper/argument"
 	PlaceholderIBCAppRouter                  = "// this line is used by starport scaffolding # ibc/app/router"


### PR DESCRIPTION
Prevent scaffolding ibc placeholders for non-IBC modules to make non-IBC module code cleaner.

Remove placeholder for some places where replacement is short and can be added inline in the template