### PR TITLE
fix(template): fix "SecTrustedApplicationCreateFromPath is deprecated" to get go-keychain compiling

### DIFF
--- a/starport/templates/app/stargate/go.mod.plush
+++ b/starport/templates/app/stargate/go.mod.plush
@@ -23,3 +23,5 @@ require (
 replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+
+replace github.com/keybase/go-keychain => github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4


### PR DESCRIPTION
[Bug: 'SecTrustedApplicationCreateFromPath' is deprecated #1532 ](https://github.com/tendermint/starport/issues/1532)