### PR TITLE
docs: Fix the blog tutorial

### DIFF
--- a/docs/guide/blog.md
+++ b/docs/guide/blog.md
@@ -133,28 +133,6 @@ func (k msgServer) CreatePost(goCtx context.Context, msg *types.MsgCreatePost) (
 }
 ```
 
-## Add gRPC to the Module Handler
-
-In the `x/blog/module.go` file:
-
-1. Add `"context"` to the imports.
-
-    ```go
-    import (
-	"context"
-	// ... other imports
-    )
-    ```
-
-2. Register the query handler:
-
-    ```go
-    // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
-    func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	    types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
-    }
-    ```
-
 ## Write Data to the Store
 
 Define the `Post` type and the `AppendPost` keeper method.
@@ -387,6 +365,29 @@ func (k Keeper) Posts(c context.Context, req *types.QueryPostsRequest) (*types.Q
   return &types.QueryPostsResponse{Post: posts, Pagination: pageRes}, nil
 }
 ```
+
+## Add gRPC to the Module Handler
+
+In the `x/blog/module.go` file:
+
+1. Add `"context"` to the imports.
+
+    ```go
+    import (
+	"context"
+	// ... other imports
+    )
+    ```
+
+2. Register the query handler:
+
+    ```go
+    // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the module.
+    func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
+	    types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+    }
+    ```
+
 
 ## Use the CLI To Create And Display Posts
 


### PR DESCRIPTION
Right now `types.RegisterQueryHandlerClient` is used too early (in the "Create post" section), and it throws an error.`

> types.RegisterQueryHandlerClient` is needed for querying, and it needs `query.proto` to be populated before `protoc-gen-grpc-gateway` generates `query.pb.gw.go`, which contains RegisterQueryHandlerClient.