### PR TITLE
docs(hello.md): fix misleading context import step

### DIFF
--- a/docs/guide/hello.md
+++ b/docs/guide/hello.md
@@ -200,7 +200,9 @@ Save the file to restart your chain. Visit the [posts endpoint](http://localhost
 
 ## Register Query Handlers
 
-Make the required changes to the `x/hello/module.go` file. As shown in the following example, in the import `"context"` section, search for `RegisterGRPCGatewayRoutes`, and register the query handlers:
+Make the required changes to the `x/hello/module.go` file. 
+
+As shown in the following example, add `"context"` to the list of packages in the import statement, search for `RegisterGRPCGatewayRoutes`, and register the query handlers:
 
 ```go
 import (


### PR DESCRIPTION
thanks to Simon for asking about a murky bit in the docs, we need to add context to the imports
from this Slack convo in #devx https://allinbits.slack.com/archives/C014GFM3FRQ/p1632228436124700?thread_ts=1632227946.123000&cid=C014GFM3FRQ 