### PR TITLE
docs: fix title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
-# Introduction to Starport
+# Starport CLI
 
-[Starport](https://github.com/tendermint/starport) offers everything you need to build, test, and launch your blockchain with a decentralized worldwide community. Starport is built on top of [Cosmos SDK](https://docs.cosmos.network), the world’s most popular blockchain framework. Starport accelerates chain development by scaffolding everything you need so you can focus on business logic.
+[Starport CLI](https://github.com/tendermint/starport) offers everything you need to build, test, and launch your blockchain with a decentralized worldwide community. Starport is built on top of [Cosmos SDK](https://docs.cosmos.network), the world’s most popular blockchain framework. Starport accelerates chain development by scaffolding everything you need so you can focus on business logic.
 
 ## What is Starport?
 
-Starport is an easy-to-use CLI tool for creating sovereign application-specific blockchains. Blockchains created with Starport use Cosmos SDK and Tendermint. Starport and the Cosmos SDK modules are written in the Go programming language. The scaffolded blockchain created with Starport includes a command line interface that lets you manage keys, create validators, and send tokens.
+Starport is an easy-to-use CLI tool for creating and maintaining sovereign application-specific blockchains. Blockchains created with Starport use Cosmos SDK and Tendermint. Starport and the Cosmos SDK modules are written in the Go programming language. The scaffolded blockchain that is created with Starport includes a command line interface that lets you manage keys, create validators, and send tokens.
 
 With just a few commands, you can use Starport to:
 
@@ -25,7 +25,7 @@ curl https://get.starport.network/starport! | bash
 
 ## Projects using Tendermint and Cosmos SDK
 
-Many projects already showcase the Tendermint BFT Consensus Engine and the Cosmos SDK. Explore the [Cosmos Network Ecosystem](https://cosmos.network/ecosystem/apps) to discover a wide variety of apps, blockchains, wallets, and explorers that are built in the Cosmos ecosystem.
+Many projects already showcase the Tendermint BFT consensus engine and the Cosmos SDK. Explore the [Cosmos Network Ecosystem](https://cosmos.network/ecosystem/apps) to discover a wide variety of apps, blockchains, wallets, and explorers that are built in the Cosmos ecosystem.
 
 ## Projects building with Starport
 


### PR DESCRIPTION
improve title and add maintenance to the virtues

I always get distracted when I see the preview of Starport docs with "Introduction to Starport"
let's change it to "Starport CLI" or even just "Starport"

