### PR TITLE
feat: add an option to specify path of chain's main pkg

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - Added `starport account` commands to manage accounts (key pairs)
 - `starport version` now prints out detailed information about OS, Go version and more.
 - Module scaffolding now creates `x/.../types/genesis_test.go` for genesis validation tests
+- Added `build.main` field to config.yml for apps to specify the path of their chain's main package. This is only required to be set when an app contains multiple main packages.
 
 ### Fixes:
 

--- a/starport/chainconf/config.go
+++ b/starport/chainconf/config.go
@@ -86,6 +86,7 @@ type Validator struct {
 
 // Build holds build configs.
 type Build struct {
+	Main   string `yaml:"main"`
 	Binary string `yaml:"binary"`
 	Proto  Proto  `yaml:"proto"`
 }

--- a/starport/pkg/goanalysis/goanalysis.go
+++ b/starport/pkg/goanalysis/goanalysis.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"go/parser"
 	"go/token"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,31 +15,47 @@ const (
 	goFileExtension = ".go"
 )
 
-// DiscoverMain finds the main application package path
-func DiscoverMain(appPath string) (string, error) {
-	var (
-		fset     = token.NewFileSet()
-		mainPath = ""
-	)
-	err := filepath.Walk(appPath, func(filePath string, f os.FileInfo, err error) error {
+var (
+	// ErrMultipleMainPackagesFound is returned when multiple main packages found while expecting only one.
+	ErrMultipleMainPackagesFound = errors.New("multiple main packages found")
+)
+
+// DiscoverMain finds main Go packages under path.
+func DiscoverMain(path string) (pkgPaths []string, err error) {
+	err = filepath.Walk(path, func(filePath string, f os.FileInfo, err error) error {
 		if f.IsDir() || !strings.HasSuffix(filePath, goFileExtension) {
 			return err
 		}
-		parsed, err := parser.ParseFile(fset, filePath, nil, parser.PackageClauseOnly)
+
+		parsed, err := parser.ParseFile(token.NewFileSet(), filePath, nil, parser.PackageClauseOnly)
 		if err != nil {
 			return err
 		}
-		name := parsed.Name.Name
-		if name == mainPackage {
-			mainPath = filepath.Dir(filePath)
-			return io.EOF
+
+		if mainPackage == parsed.Name.Name {
+			pkgPaths = append(pkgPaths, filepath.Dir(filePath))
 		}
+
 		return nil
 	})
-	if err == io.EOF {
-		return mainPath, nil
-	} else if err != nil {
+
+	return
+}
+
+// DiscoverOneMain tries to find only one main Go package under path.
+func DiscoverOneMain(path string) (pkgPath string, err error) {
+	pkgPaths, err := DiscoverMain(path)
+	if err != nil {
 		return "", err
 	}
-	return "", errors.New("main package not found")
+
+	count := len(pkgPaths)
+	if count == 0 {
+		return "", errors.New("main package cannot be found")
+	}
+	if count > 1 {
+		return "", ErrMultipleMainPackagesFound
+	}
+
+	return pkgPaths[0], nil
 }

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -41,7 +41,7 @@ func (c *Chain) build(ctx context.Context, output string) (err error) {
 	defer func() {
 		var exitErr *exec.ExitError
 
-		if errors.As(err, &exitErr) {
+		if errors.As(err, &exitErr) || errors.Is(err, goanalysis.ErrMultipleMainPackagesFound) {
 			err = &CannotBuildAppError{err}
 		}
 	}()
@@ -60,7 +60,7 @@ func (c *Chain) build(ctx context.Context, output string) (err error) {
 		return err
 	}
 
-	path, err := goanalysis.DiscoverMain(c.app.Path)
+	path, err := c.discoverMain(c.app.Path)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (c *Chain) BuildRelease(ctx context.Context, output, prefix string, targets
 		return "", err
 	}
 
-	mainPath, err := goanalysis.DiscoverMain(c.app.Path)
+	mainPath, err := c.discoverMain(c.app.Path)
 	if err != nil {
 		return "", err
 	}
@@ -192,4 +192,21 @@ func (c *Chain) preBuild(ctx context.Context) (buildFlags []string, err error) {
 	fmt.Fprintln(c.stdLog().out, "🛠️  Building the blockchain...")
 
 	return buildFlags, nil
+}
+
+func (c *Chain) discoverMain(path string) (pkgPath string, err error) {
+	conf, err := c.Config()
+	if err != nil {
+		return "", err
+	}
+
+	if conf.Build.Main != "" {
+		return conf.Build.Main, nil
+	}
+
+	path, err = goanalysis.DiscoverOneMain(path)
+	if err == goanalysis.ErrMultipleMainPackagesFound {
+		return "", errors.Wrap(err, "specify the path to your chain's main package in your config.yml>build.main")
+	}
+	return path, err
 }


### PR DESCRIPTION
added `build.main` field to config.yml for apps to specify the path of their chain's main package. This is only required to be set when an app contains multiple main packages.

to test use: https://github.com/notional-labs/dig. it has `./cmd/digd` and `./airdrop` main packages.