### PR TITLE
docs: add build.main to kb/config.md

### DIFF
--- a/docs/kb/config.md
+++ b/docs/kb/config.md
@@ -36,6 +36,7 @@ accounts:
 
 | Key    | Required | Type   | Description                                                    |
 | ------ | -------- | ------ | -------------------------------------------------------------- |
+| main   | N        | String | When an app contains more than one main Go package, it is required to define the path of the chain's main package. |
 | binary | N        | String | Name of the node binary that is built, typically ends with `d` |
 
 **build example**
@@ -51,15 +52,6 @@ build:
 | ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
 | path              | N        | String          | Path to protocol buffer files. Default: `"proto"`                                          |
 | third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]` |
-
-### `build.main`
-
-When an app contains more than one main Go package, define the path of the chain's main package. 
-
-| Key               | Required | Type            | Description                                                                                |
-| ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
-| path              | N        | String          | Path to the main Go package. Required only when an app contains multiple main packages.    |
-
 
 ## `client`
 

--- a/docs/kb/config.md
+++ b/docs/kb/config.md
@@ -45,12 +45,21 @@ build:
   binary: "mychaind"
 ```
 
-## `build.proto`
+### `build.proto`
 
 | Key               | Required | Type            | Description                                                                                |
 | ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
 | path              | N        | String          | Path to protocol buffer files. Default: `"proto"`                                          |
 | third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]` |
+
+### `build.main`
+
+When an app contains more than one main Go package, define the path of the chain's main package. 
+
+| Key               | Required | Type            | Description                                                                                |
+| ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
+| path              | N        | String          | Path to the main Go package. Required only when an app contains multiple main packages.    |
+
 
 ## `client`
 


### PR DESCRIPTION
add https://github.com/tendermint/starport/blob/develop/docs/kb/config.md#configyml-reference
closes https://github.com/tendermint/starport/issues/1617 

for update to https://docs.starport.network/kb/config.html 