### PR TITLE
fix(templates): use `ElementsMatch` in genesis tests for types

### DIFF
--- a/starport/templates/typed/list/genesis.go
+++ b/starport/templates/typed/list/genesis.go
@@ -176,8 +176,7 @@ func genesisTestsModify(replacer placeholder.Replacer, opts *typed.Options) genn
 		)
 		content := replacer.Replace(f.String(), module.PlaceholderGenesisTestState, replacementValid)
 
-		templateAssert := `require.Len(t, got.%[2]vList, len(genesisState.%[2]vList))
-require.Subset(t, genesisState.%[2]vList, got.%[2]vList)
+		templateAssert := `require.ElementsMatch(t, genesisState.%[2]vList, got.%[2]vList)
 require.Equal(t, genesisState.%[2]vCount, got.%[2]vCount)
 %[1]v`
 		replacementTests := fmt.Sprintf(

--- a/starport/templates/typed/map/stargate.go
+++ b/starport/templates/typed/map/stargate.go
@@ -410,8 +410,7 @@ func genesisTestsModify(replacer placeholder.Replacer, opts *typed.Options) genn
 		)
 		content := replacer.Replace(f.String(), module.PlaceholderGenesisTestState, replacementState)
 
-		templateAssert := `require.Len(t, got.%[2]vList, len(genesisState.%[2]vList))
-require.Subset(t, genesisState.%[2]vList, got.%[2]vList)
+		templateAssert := `require.ElementsMatch(t, genesisState.%[2]vList, got.%[2]vList)
 %[1]v`
 		replacementTests := fmt.Sprintf(
 			templateAssert,


### PR DESCRIPTION
Use `require.ElementsMatch` to assert array instead of `require.Len` and `require.Subset`