### PR TITLE
fix(templates): add missing assertion in grpc query tests

### DIFF
--- a/starport/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/list/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -95,6 +95,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 		resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.ElementsMatch(t, msgs, resp.<%= TypeName.UpperCamel %>)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.<%= TypeName.UpperCamel %>All(wctx, nil)

--- a/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -106,6 +106,7 @@ func Test<%= TypeName.UpperCamel %>QueryPaginated(t *testing.T) {
 		resp, err := keeper.<%= TypeName.UpperCamel %>All(wctx, request(nil, 0, 0, true))
 		require.NoError(t, err)
 		require.Equal(t, len(msgs), int(resp.Pagination.Total))
+		require.ElementsMatch(t, msgs, resp.<%= TypeName.UpperCamel %>)
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.<%= TypeName.UpperCamel %>All(wctx, nil)


### PR DESCRIPTION
Add an assertion in grpc query tests for list and map that the All query returns all elements with `ElementsMatch`