### PR TITLE
feat(CI): run the integration test in parallel

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -10,9 +10,29 @@ on:
 jobs:
   integration:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        test-file: [ './integration/cmd_app_test.go',
+                     './integration/cmd_ibc_test.go',
+                     './integration/cmd_list_test.go',
+                     './integration/cmd_map_test.go',
+                     './integration/cmd_query_test.go',
+                     './integration/cmd_serve_test.go',
+                     './integration/cmd_singleton_test.go',
+                     './integration/config_test.go',
+                     './integration/tx_test.go' ]
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16
@@ -20,4 +40,4 @@ jobs:
         run: go install ./...
 
       - name: Run Integration Tests
-        run: ./scripts/test-integration 
+        run: go test -v -timeout 120m ${{ matrix.test-file }} ./integration/env_test.go ./integration/integration_test.go


### PR DESCRIPTION
close #1557

### What does this MR does?

Decrease the integration test running time parallelizing the tests workflow.

### Changes

This PR Creates a parallel test running the test files one by one and caching the already downloaded Go modules.