### PR TITLE
chore(cmd): simplify version display on Starport's update message

### DIFF
--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -239,7 +239,7 @@ func checkNewVersion(ctx context.Context) {
 	}
 
 	fmt.Printf(`·
-· 🛸 Starport %q is available!
+· 🛸 Starport %s is available!
 ·
 · If you're looking to upgrade check out the instructions: https://docs.starport.network/guide/install.html#upgrading-your-starport-installation
 ·


### PR DESCRIPTION
I agree with @barriebyron that it looks better without the quotes.  There are no other impacts to the modification.