### PR TITLE
fix(docs/band): Update the bandchain relayer sourc port

### DIFF
--- a/docs/kb/band.md
+++ b/docs/kb/band.md
@@ -52,13 +52,13 @@ const Version = "bandchain-1"
 
 After scaffold and change the data, run the chain:
 ```shell
-staport chain server
+$ starport chain server
 ```
 
 In another tab, configure and run the starport relayer.
 ```shell
-$ starport relayer configure -a \
---source-rpc "http://rpc-laozi-testnet4.bandchain.org:26657" \
+$ starport relayer configure -a \                                              
+--source-rpc "http://rpc-laozi-testnet4.bandchain.org:80" \
 --source-faucet "https://laozi-testnet4.bandchain.org/faucet" \
 --source-port "oracle" \
 --source-gasprice "0uband" \

--- a/docs/kb/band.md
+++ b/docs/kb/band.md
@@ -52,7 +52,7 @@ const Version = "bandchain-1"
 
 After scaffold and change the data, run the chain:
 ```shell
-$ starport chain server
+$ starport chain serve
 ```
 
 In another tab, configure and run the starport relayer.

--- a/docs/kb/band.md
+++ b/docs/kb/band.md
@@ -57,7 +57,7 @@ $ starport chain server
 
 In another tab, configure and run the starport relayer.
 ```shell
-$ starport relayer configure -a \                                              
+$ starport relayer configure -a \
 --source-rpc "http://rpc-laozi-testnet4.bandchain.org:80" \
 --source-faucet "https://laozi-testnet4.bandchain.org/faucet" \
 --source-port "oracle" \


### PR DESCRIPTION
# Description

The Bandchain team asked to change the relayer port from `26657` to `80`. Both are working.

### Changes

- Use the port `80` instead of the `26657`;
- Fix typo for starport command;