### PR TITLE
feat(`network`): implement method to get chain home

### DIFF
--- a/starport/services/network/path.go
+++ b/starport/services/network/path.go
@@ -1,0 +1,17 @@
+package network
+
+import (
+	"strconv"
+
+	"github.com/tendermint/starport/starport/pkg/xfilepath"
+)
+
+var (
+	// SpnPath returns the path used to store chain home from SPN
+	SpnPath = xfilepath.JoinFromHome(xfilepath.Path("spn"))
+)
+
+// ChainHome returns the default home dir used for a chain from SPN
+func ChainHome(launchID uint64) (string, error) {
+	return xfilepath.Join(SpnPath, xfilepath.Path(strconv.FormatUint(launchID, 10)))()
+}

--- a/starport/services/network/path.go
+++ b/starport/services/network/path.go
@@ -1,17 +1,16 @@
 package network
 
 import (
+	"os"
+	"path/filepath"
 	"strconv"
-
-	"github.com/tendermint/starport/starport/pkg/xfilepath"
 )
 
-var (
-	// SpnPath returns the path used to store chain home from SPN
-	SpnPath = xfilepath.JoinFromHome(xfilepath.Path("spn"))
-)
+// ChainHomeRoot is the root dir for spn chain homes
+const ChainHomeRoot = "spn"
 
 // ChainHome returns the default home dir used for a chain from SPN
 func ChainHome(launchID uint64) (string, error) {
-	return xfilepath.Join(SpnPath, xfilepath.Path(strconv.FormatUint(launchID, 10)))()
+	home, err := os.UserHomeDir()
+	return filepath.Join(home, ChainHomeRoot, strconv.FormatUint(launchID, 10)), err
 }

--- a/starport/services/network/path_test.go
+++ b/starport/services/network/path_test.go
@@ -1,0 +1,23 @@
+package network_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/starport/starport/services/network"
+)
+
+func TestChainHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	chainHome, err := network.ChainHome(0)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "spn", "0"), chainHome)
+
+	chainHome, err = network.ChainHome(10)
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(home, "spn", "10"), chainHome)
+}

--- a/starport/services/network/path_test.go
+++ b/starport/services/network/path_test.go
@@ -15,9 +15,9 @@ func TestChainHome(t *testing.T) {
 
 	chainHome, err := network.ChainHome(0)
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(home, "spn", "0"), chainHome)
+	require.Equal(t, filepath.Join(home, network.ChainHomeRoot, "0"), chainHome)
 
 	chainHome, err = network.ChainHome(10)
 	require.NoError(t, err)
-	require.Equal(t, filepath.Join(home, "spn", "10"), chainHome)
+	require.Equal(t, filepath.Join(home, network.ChainHomeRoot, "10"), chainHome)
 }


### PR DESCRIPTION
Implement a utility method that returns the default chain home `~/spn/<launchID>` in this PR since it should be used for almost all command