### PR TITLE
feat(build): 🔨 Introduce Taskfile as a replacement (or alternative) for Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ apps/
 .vscode
 docs/.vuepress/dist
 build/
+.task/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,67 @@
+version: '3'
+includes:
+  bootstrap: ./tasks/bootstrap.yml
+  build: ./tasks/build.yml
+  test: ./tasks/tests.yml
+  go: ./tasks/go.yml
+dotenv: [.env]
+vars:
+  PROJECT_NAME: starport
+tasks:
+  default:
+    deps: [install]
+  install:
+    desc: Install the starport binary
+    cmds:
+      - task: go:install
+        vars: { tool: ./..., project: true }
+    silent: true
+  format:
+    desc: Format golang code
+    deps: [go:format]
+  test:
+    desc: Run unit, integration, and vue tests
+    summary: |
+      Running the entire test suite is extremely expensive as it needs to run
+      unit, integration, and vue tests.
+    deps: [vet, test:integration, test:unit, test:vue]
+  run:
+    desc: Build and Execute {{.PROJECT_NAME}} to test the local executable
+    summary: |
+      This target will build {{.PROJECT_NAME}} and then run it with any user
+      provided CLI arguments. These are to be passed after the classic `--` is
+      used to separate them from {{.PROJECT_NAME}}.
+
+      This greatly increases the speed by which developers can test newer
+      features quickly and not have to worry about order of operations, or
+      forgetting to run the most recent build, etc.
+    deps: [build:starport]
+    cmds:
+      - dist/{{.PROJECT_NAME}} {{.CLI_ARGS}}
+  build:
+    desc: Build {{.PROJECT_NAME}} and tooling binaries
+    summary: |
+      Building {{.PROJECT_NAME}} requires several tools to be built
+      simultaneously and in such a way as to ensure that the set of
+      dependencies needed for installation is minimal.
+
+      This target will build not only `{{.PROJECT_NAME}}`, but all the internal
+      tools used by {{.PROJECT_NAME}}.
+    deps: [build:starport, build:gen-cli-docs]
+  bootstrap:
+    desc: Install all golang tools necessary for basic development
+    summary: |
+      Building {{.PROJECT_NAME}} currently requires a minimum set of tools to
+      get started, beyond *just* golang and task. These steps will install the
+      correct set of dependencies and tools for users to get started.
+
+      This target *does not* install additional tools needed to generate every
+      possible operation within {{.PROJECT_NAME}} itself.
+    deps: [bootstrap:go]
+  lint:
+    desc: Run golangci-lint on the current codebase
+    cmds:
+      - golangci-lint run --out-format=tab --issues-exit-code=0
+  vet: [go vet ./...]
+
+# TODO: `vet` should just be removed in favor of golangci-lint

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -95,9 +95,13 @@ brew install tendermint/tap/starport
 
 ## Build from source
 
+Starport uses [Taskfile](https://taskfile.dev) for building from source. The
+instructions below include installing the latest release `task`.
+
 ```bash
 git clone https://github.com/tendermint/starport --depth=1
-cd starport && make install
+go install github.com/go-task/task/v3/cmd/task@latest
+cd starport && task install
 ```
 
 ## Summary

--- a/tasks/bootstrap.yml
+++ b/tasks/bootstrap.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+tasks:
+  go:
+    deps: [golangci-lint, godoc, delve, gopls]
+  gofumpt:
+    - task: :go:install
+      vars: { tool: mvdan.cc/gofumpt }
+  golangci-lint:
+    - task: :go:install
+      vars: { tool: github.com/golangci/golangci-lint/cmd/golangci-lint }
+  godoc:
+    - task: :go:install
+      vars: { tool: golang.org/x/tools/cmd/godoc }
+  delve:
+    - task: :go:install
+      vars: { tool: github.com/go-delve/delve/cmd/dlv }
+  gopls:
+    - task: :go:install
+      vars: { tool: golang.org/x/tools/gopls }

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,0 +1,15 @@
+version: '3'
+tasks:
+  default:
+    deps: [starport, gen-cli-docs, shell]
+  starport:
+    desc: Build the starport binary
+    cmds:
+      - task: :go:build
+        vars: { target: cmd/starport }
+    sources:
+      - starport/**/*.go
+  gen-cli-docs:
+    cmds:
+      - task: :go:build
+        vars: { target: internal/tools/gen-cli-docs }

--- a/tasks/go.yml
+++ b/tasks/go.yml
@@ -1,0 +1,29 @@
+version: '3'
+vars:
+  outdir: dist/
+  DATE: >-
+    {{ now | date "2006-01-02T15:04:05" }}
+  HEAD: { sh: git rev-parse HEAD }
+  modpath: github.com/tendermint/starport/starport/internal/version
+  goflags: >-
+    -mod=readonly
+    -ldflags '-X {{.modpath}}.Head={{.HEAD}} -X {{.modpath}}.Date={{.DATE}}'
+tasks:
+  build:
+    cmds:
+      - >-
+        go build
+        {{if (default true .verbose)}}-v{{end}}
+        {{.goflags}}
+        -o {{.outdir}}
+        ./starport/{{.target}}
+  install:
+    - >-
+      go install
+      {{if .project}}{{.goflags}}{{end}}
+      {{.tool}}
+      {{- if not .project}}@{{default "latest" .version}}{{end -}}
+  format:
+    silent: true
+    cmds:
+      - find . -name '*.go' -type f -exec gofmt -d -s '{}' +

--- a/tasks/tests.yml
+++ b/tasks/tests.yml
@@ -1,0 +1,15 @@
+version: '3'
+tasks:
+  integration:
+    desc: Run integration tests
+    cmds:
+      - go test -race -failfast -v -timeout {{default "60m" .TEST_TIMEOUT}} ./integration/...
+  unit:
+    desc: Run unit tests
+    cmds:
+      - go test -race -failfast -v ./starport/...
+  vue:
+    desc: Run vue tests
+    cmds:
+      - echo "executing vue tests..." > /dev/null
+    silent: true


### PR DESCRIPTION
Hello! This PR (and a few others I'll be submitting) is part of a brief
conversation I had in the hackatom channel on discord. I made these
changes for myself for the HackAtom VI hackathon, and figured others
would get an ease of use out of the tool.

While this [Taskfile](https://taskfile.dev) results in a larger set of
build files for building starport, it also allows to keep things more
compartmentalized and error proof. Few changes have been made at the
moment beyond the following:

1. Targets like `test-integration` and `test-unit` are now
   `test:integration` and `test:unit`.
2. Some shell commands have been removed, reducing shell output.
3. Not all targets are silent by default.
4. The `Makefile` has not been deleted.

This change also brings the following features:

1. Users can run `task --list` to get a list of all targets
2. A `bootstrap` target has been added to ensure that all *tools*
   required for editors + plugins like vscode-go or vim-go can be
   installed. This target also installs `delve`, the powerful golang debugger.
   This target is optional to call, but also means that users simply
   have to have the Taskfile tool installed before actually getting
   started with development.
3. Running `task --summary <task>` will sometimes give a detailed
   summary of what the target does or its configuration settings.
4. To get started with *developing starport itself* users only need to
5. Though not yet implemented in the `format` task, the more powerful
   and strict `gofumpt` tool is available to install via
   `bootstrap:gofumpt`.

Lastly, I do not expect this to be merged immediately as there are one
or two style pieces as well as some possibly inaccurate docs. I've also
not updated the github workflows, readme, or other documentation but am
committed (pun not intended) to pushing these changes before merge.
