### PR TITLE
docs: Fix the loan tutorial

### DIFF
--- a/docs/guide/loan.md
+++ b/docs/guide/loan.md
@@ -360,7 +360,7 @@ func (k msgServer) ApproveLoan(goCtx context.Context, msg *types.MsgApproveLoan)
 	borrower, _ := sdk.AccAddressFromBech32(loan.Borrower)
 	amount, err := sdk.ParseCoinsNormalized(loan.Amount)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrWrongLoanState, "Cannot parse coins in loan amount")
+		return nil, sdkerrors.Wrap(types.ErrWrongLoanState, "Cannot parse coins in loan amount")
 	}
 
 	k.bankKeeper.SendCoins(ctx, lender, borrower, amount)

--- a/docs/guide/loan.md
+++ b/docs/guide/loan.md
@@ -522,15 +522,15 @@ func (k msgServer) RepayLoan(goCtx context.Context, msg *types.MsgRepayLoan) (*t
 
 	err = k.bankKeeper.SendCoins(ctx, borrower, lender, amount)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrWrongLoanState, "Cannot send coins")
+		return nil, sdkerrors.Wrap(types.ErrWrongLoanState, "Cannot send coins")
 	}
 	err = k.bankKeeper.SendCoins(ctx, borrower, lender, fee)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrWrongLoanState, "Cannot send coins")
+		return nil, sdkerrors.Wrap(types.ErrWrongLoanState, "Cannot send coins")
 	}
 	err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, borrower, collateral)
 	if err != nil {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrWrongLoanState, "Cannot send coins")
+		return nil, sdkerrors.Wrap(types.ErrWrongLoanState, "Cannot send coins")
 	}
 
 	loan.State = "repayed"


### PR DESCRIPTION
* Replaced `sdkerrors.ErrWrongLoanState` with `types.ErrWrongLoanState`, otherwise the chain doesn't build.