### PR TITLE
chore: release v0.18.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/tendermint/spm v0.1.5
 	github.com/tendermint/spn v0.0.0-20210915093512-0d7e688be0fe
 	github.com/tendermint/tendermint v0.34.13
-	github.com/tendermint/vue v0.1.53
+	github.com/tendermint/vue v0.1.54
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d

--- a/go.sum
+++ b/go.sum
@@ -1408,8 +1408,8 @@ github.com/tendermint/tm-db v0.6.3/go.mod h1:lfA1dL9/Y/Y8wwyPp2NMLyn5P5Ptr/gvDFN
 github.com/tendermint/tm-db v0.6.4 h1:3N2jlnYQkXNQclQwd/eKV/NzlqPlfK21cpRRIx80XXQ=
 github.com/tendermint/tm-db v0.6.4/go.mod h1:dptYhIpJ2M5kUuenLr+Yyf3zQOv1SgBZcl8/BmWlMBw=
 github.com/tendermint/vue v0.1.49/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
-github.com/tendermint/vue v0.1.53 h1:7xWnjBjgCG0qRy8/HT2UsYO1zC6miaOk2p2Qb8syVc0=
-github.com/tendermint/vue v0.1.53/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
+github.com/tendermint/vue v0.1.54 h1:NfyVVw73oBfbwXxGSGDdiVdjkZEFwBvSUTCy1Z22Rr0=
+github.com/tendermint/vue v0.1.54/go.mod h1:Sg9MGPF+uY+SJ79sdZgtC2LnH+FDU2qWuiRxoZn5bmw=
 github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/starport/templates/app/stargate/go.mod.plush
+++ b/starport/templates/app/stargate/go.mod.plush
@@ -3,7 +3,7 @@ module <%= ModulePath %>
 go 1.16
 
 require (
-	github.com/cosmos/cosmos-sdk v0.44.0
+	github.com/cosmos/cosmos-sdk v0.44.1
 	github.com/cosmos/ibc-go v1.2.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/google/go-cmp v0.5.6 // indirect


### PR DESCRIPTION
### HOTFIX

- Update Cosmos SDK version to `0.44.1` to prevent the IAVL race condition issue that poses a problem for front-end development
- Bump `tendermint/vue` to `v0.1.54`