### PR TITLE
docs: fix the brew install to exclude M1 chip on macOS

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -89,9 +89,13 @@ After all existing Starport installations are removed, follow the [Installing St
 
 ## Installing Starport on macOS with Homebrew
 
+Using brew to install Starport is supported only for macOS machines without the M1 chip. 
+
 ```bash
 brew install tendermint/tap/starport
 ```
+
+To install Starport on macOS machines with the M1 chip, use the curl command as described in [Installing Starport](#installing-starport). 
 
 ## Build from source
 

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -95,7 +95,7 @@ Using brew to install Starport is supported only for macOS machines without the 
 brew install tendermint/tap/starport
 ```
 
-To install Starport on macOS machines with the M1 chip, use the curl command as described in [Installing Starport](#installing-starport). 
+To install Starport on macOS machines with the M1 chip, use the `curl` command as described in [Installing Starport](#installing-starport). 
 
 ## Build from source
 


### PR DESCRIPTION
clarify the docs for installing Starport on macOS with M1
https://deploy-preview-1815--starport-docs.netlify.app/guide/install.html#installing-starport 