### PR TITLE
fix(pkg/cosmosclient): ensure account has funds after faucet transfer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/briandowns/spinner v1.11.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/charmbracelet/glow v1.4.0
 	github.com/containerd/containerd v1.5.8 // indirect
 	github.com/cosmos/cosmos-sdk v0.44.3

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
+github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/starport/pkg/chaincmd/chaincmd.go
+++ b/starport/pkg/chaincmd/chaincmd.go
@@ -38,9 +38,11 @@ const (
 	optionValidatorGasPrices               = "--gas-prices"
 	optionYes                              = "--yes"
 	optionHomeClient                       = "--home-client"
+	optionBroadcastMode                    = "--broadcast-mode"
 
 	constTendermint = "tendermint"
 	constJSON       = "json"
+	constSync       = "sync"
 )
 
 type KeyringBackend string
@@ -435,6 +437,8 @@ func (c ChainCmd) BankSendCommand(fromAddress, toAddress, amount string) step.Op
 		fromAddress,
 		toAddress,
 		amount,
+		optionBroadcastMode,
+		constSync,
 		optionYes,
 	)
 


### PR DESCRIPTION
this is useful if tx for faucet transfer not sent in the `sync` mode.

* pkg/cosmosclient: improve faucet defaults.
* pkg/cosmosfaucet: ensure that transfer tx uses `syncA mode.`