### PR TITLE
fix(`scaffold chain {id}`): fixed error handler for generated path copy

### DIFF
--- a/starport/pkg/cosmosgen/generate_go.go
+++ b/starport/pkg/cosmosgen/generate_go.go
@@ -50,12 +50,16 @@ func (g *generator) generateGo() error {
 	generatedPath := filepath.Join(tmp, g.o.gomodPath)
 
 	_, err = os.Stat(generatedPath)
-	if err == nil {
-		err = copy.Copy(generatedPath, g.appPath)
-		return errors.Wrap(err, "cannot copy path")
-	}
 	if !os.IsNotExist(err) {
 		return err
 	}
-	return nil
+
+	if err == nil {
+		err = copy.Copy(generatedPath, g.appPath)
+		if err != nil {
+			return errors.Wrap(err, "cannot copy path")
+		}
+	}
+
+	return err
 }


### PR DESCRIPTION
When I run `scaffold chain {id}`, it caused `cannot copy path error`.
I found it weird logic to handle error right after copying path from tmp to `appPath`.

I've fixed to return error only if copy causes an error.