### PR TITLE
fix(`network chain prepare`): add `unsafe-reset-all` command

### DIFF
--- a/starport/services/network/networkchain/prepare.go
+++ b/starport/services/network/networkchain/prepare.go
@@ -48,7 +48,15 @@ func (c Chain) Prepare(ctx context.Context, gi networktypes.GenesisInformation) 
 		c.ev.Send(events.New(events.StatusDone, "Genesis initialized"))
 	}
 
-	return c.buildGenesis(ctx, gi)
+	if err := c.buildGenesis(ctx, gi); err != nil {
+		return err
+	}
+
+	cmd, err := c.chain.Commands(ctx)
+	if err != nil {
+		return err
+	}
+	return cmd.UnsafeReset(ctx)
 }
 
 // buildGenesis builds the genesis for the chain from the launch approved requests


### PR DESCRIPTION
Add the `unsafe-reset-all` command in `prepare` so the chain has always a fresh database once prepared