### PR TITLE
docs: fixed broken link to Issues page

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -17,7 +17,7 @@ To set up your environment for success, follow the [technical setup](technical-s
 
 ## Using this repo
 
-Review existing [Starport issues](../../issues/) to see if your question has already been asked and answered.
+Review existing [Starport issues](https://github.com/tendermint/starport/issues) to see if your question has already been asked and answered.
 
 - To provide feedback, file an issue and provide generous details to help us understand how we can make it better.
 - To provide a fix, make a direct contribution. If you're not a member or maintainer, fork the repo and then submit a pull request (PR) from your forked repo to the `develop` branch.


### PR DESCRIPTION
On Line 20 of this file, the link to see the current issues needing fix was broken. I replaced the broken path file with a static link, as per Barrie's instructions.