### PR TITLE
fix(`template`): inconsistency with proto generated code and camel case

### DIFF
--- a/integration/map/cmd_map_test.go
+++ b/integration/map/cmd_map_test.go
@@ -19,7 +19,7 @@ func TestCreateMapWithStargate(t *testing.T) {
 
 	env.Must(env.Exec("create a map",
 		step.NewSteps(step.New(
-			step.Exec("starport", "s", "map", "user", "email"),
+			step.Exec("starport", "s", "map", "user", "user-id", "email"),
 			step.Workdir(path),
 		)),
 	))

--- a/integration/other_components/cmd_query_test.go
+++ b/integration/other_components/cmd_query_test.go
@@ -94,11 +94,19 @@ func TestGenerateAnAppWithQuery(t *testing.T) {
 		)),
 	))
 
-	env.Must(env.Exec("create a query with the custom field type",
+	env.Must(env.Exec("create a query with the custom field type as a response",
 		step.NewSteps(step.New(
-			step.Exec("starport", "s", "query", "foobaz", "bar:CustomType"),
+			step.Exec("starport", "s", "query", "foobaz", "-r", "bar:CustomType"),
 			step.Workdir(path),
 		)),
+	))
+
+	env.Must(env.Exec("should prevent using custom type in request params",
+		step.NewSteps(step.New(
+			step.Exec("starport", "s", "query", "bur", "bar:CustomType"),
+			step.Workdir(path),
+		)),
+		envtest.ExecShouldError(),
 	))
 
 	env.Must(env.Exec("create an empty query",

--- a/starport/services/scaffolder/component.go
+++ b/starport/services/scaffolder/component.go
@@ -223,3 +223,18 @@ func checkCustomTypes(ctx context.Context, path, module string, fields []string)
 	}
 	return protoanalysis.HasMessages(ctx, protoPath, customFields...)
 }
+
+// containCustomTypes returns true if the list of fields contains at least one custom type
+func containCustomTypes(fields []string) bool {
+	for _, name := range fields {
+		fieldSplit := strings.Split(name, datatype.Separator)
+		if len(fieldSplit) <= 1 {
+			continue
+		}
+		fieldType := datatype.Name(fieldSplit[1])
+		if _, ok := datatype.SupportedTypes[fieldType]; !ok {
+			return true
+		}
+	}
+	return false
+}

--- a/starport/services/scaffolder/query.go
+++ b/starport/services/scaffolder/query.go
@@ -2,6 +2,7 @@ package scaffolder
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gobuffalo/genny"
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
@@ -42,8 +43,8 @@ func (s Scaffolder) AddQuery(
 	}
 
 	// Check and parse provided request fields
-	if err := checkCustomTypes(ctx, s.path, moduleName, reqFields); err != nil {
-		return sm, err
+	if ok := containCustomTypes(reqFields); ok {
+		return sm, errors.New("query request params can't contain custom type")
 	}
 	parsedReqFields, err := field.ParseFields(reqFields, checkGoReservedWord)
 	if err != nil {

--- a/starport/templates/field/field.go
+++ b/starport/templates/field/field.go
@@ -25,13 +25,18 @@ func (f Field) DataType() string {
 	return dt.DataType(f.Datatype)
 }
 
+// ProtoFieldName returns the field name used in proto
+func (f Field) ProtoFieldName() string {
+	return f.Name.LowerCamel
+}
+
 // ProtoType returns the field proto Datatype
 func (f Field) ProtoType(index int) string {
 	dt, ok := datatype.SupportedTypes[f.DatatypeName]
 	if !ok {
 		panic(fmt.Sprintf("unknown type %s", f.DatatypeName))
 	}
-	return dt.ProtoType(f.Datatype, f.Name.LowerCamel, index)
+	return dt.ProtoType(f.Datatype, f.ProtoFieldName(), index)
 }
 
 // DefaultTestValue returns the Datatype value default

--- a/starport/templates/field/field.go
+++ b/starport/templates/field/field.go
@@ -31,7 +31,7 @@ func (f Field) ProtoType(index int) string {
 	if !ok {
 		panic(fmt.Sprintf("unknown type %s", f.DatatypeName))
 	}
-	return dt.ProtoType(f.Datatype, f.Name.Snake, index)
+	return dt.ProtoType(f.Datatype, f.Name.LowerCamel, index)
 }
 
 // DefaultTestValue returns the Datatype value default

--- a/starport/templates/query/stargate.go
+++ b/starport/templates/query/stargate.go
@@ -37,12 +37,9 @@ func protoQueryModify(replacer placeholder.Replacer, opts *Options) genny.RunFn 
 
 		// if the query has request fields, they are appended to the rpc query
 		var reqPath string
-		if len(opts.ReqFields) > 0 {
-			var protoReqFields []string
-			for _, field := range opts.ReqFields {
-				protoReqFields = append(protoReqFields, fmt.Sprintf("{%s}", field.ProtoFieldName()))
-			}
-			reqPath = "/" + strings.Join(protoReqFields, "/")
+		for _, field := range opts.ReqFields {
+			reqPath += "/"
+			reqPath = filepath.Join(reqPath, fmt.Sprintf("{%s}", field.ProtoFieldName()))
 		}
 
 		// RPC service

--- a/starport/templates/query/stargate.go
+++ b/starport/templates/query/stargate.go
@@ -35,10 +35,20 @@ func protoQueryModify(replacer placeholder.Replacer, opts *Options) genny.RunFn 
 			return err
 		}
 
+		// if the query has request fields, they are appended to the rpc query
+		var reqPath string
+		if len(opts.ReqFields) > 0 {
+			var protoReqFields []string
+			for _, field := range opts.ReqFields {
+				protoReqFields = append(protoReqFields, fmt.Sprintf("{%s}", field.ProtoFieldName()))
+			}
+			reqPath = "/" + strings.Join(protoReqFields, "/")
+		}
+
 		// RPC service
 		templateRPC := `// Queries a list of %[2]v items.
 	rpc %[2]v(Query%[2]vRequest) returns (Query%[2]vResponse) {
-		option (google.api.http).get = "/%[3]v/%[4]v/%[5]v/%[6]v";
+		option (google.api.http).get = "/%[3]v/%[4]v/%[5]v/%[6]v%[7]v";
 	}
 
 %[1]v`
@@ -50,6 +60,7 @@ func protoQueryModify(replacer placeholder.Replacer, opts *Options) genny.RunFn 
 			opts.AppName,
 			opts.ModuleName,
 			opts.QueryName.Snake,
+			reqPath,
 		)
 		content := replacer.Replace(f.String(), Placeholder2, replacementRPC)
 

--- a/starport/templates/typed/map/stargate.go
+++ b/starport/templates/typed/map/stargate.go
@@ -121,11 +121,11 @@ func protoRPCModify(replacer placeholder.Replacer, opts *typed.Options) genny.Ru
 		replacementGogoImport := typed.EnsureGogoProtoImported(path, typed.Placeholder)
 		content = replacer.Replace(content, typed.Placeholder, replacementGogoImport)
 
-		var snakeIndexes []string
+		var protoIndexes []string
 		for _, index := range opts.Indexes {
-			snakeIndexes = append(snakeIndexes, fmt.Sprintf("{%s}", index.Name.Snake))
+			protoIndexes = append(protoIndexes, fmt.Sprintf("{%s}", index.ProtoFieldName()))
 		}
-		indexPath := strings.Join(snakeIndexes, "/")
+		indexPath := strings.Join(protoIndexes, "/")
 
 		// Add the service
 		templateService := `// Queries a %[2]v by index.


### PR DESCRIPTION
To follow the proto standard we set the proto message fields as `Snake` case

However, for a field name that contains a full uppercase component: `postID`, the proto field is `post_id` and then the generated code from proto is `PostId` while our `LowerCamel` conversion set it to `postID`, making some inconsistency in the code

This PR set back the proto field to camel case `postID` so that the generated field will be `PostID`

We're unfortunately out of the proto standard, this PR is a quickfix. The workaround would be to generate `postId` with our camel case conversion but then we would be out of this standard as well

Other fixes
- add the query's request fields into the rpc URL for the `starport s query` command
- prevent using custom type as query-s request field