### PR TITLE
fix(simapp): fix run simulation with randomized params

### DIFF
--- a/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
+++ b/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
@@ -1,7 +1,6 @@
 package <%= moduleName %>
 
 import (
-	<%= if (len(params) > 0) { %>"fmt"<% } %>
 	"math/rand"
 
 	"<%= modulePath %>/testutil/sample"
@@ -50,7 +49,7 @@ func (am AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
 	<%= if (len(params) > 0) { %><%= moduleName %>Params := types.DefaultParams()<% } %>
 	return []simtypes.ParamChange{<%= for (param) in params { %>
 		simulation.NewSimParamChange(types.ModuleName, string(types.Key<%= param.Name.UpperCamel %>), func(r *rand.Rand) string {
-			return fmt.Sprintf("%s", types.Amino.MustMarshalJSON(<%= moduleName %>Params.<%= param.Name.UpperCamel %>))
+			return string(types.Amino.MustMarshalJSON(<%= moduleName %>Params.<%= param.Name.UpperCamel %>))
 		}),<% } %>
 	}
 }

--- a/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
+++ b/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
@@ -1,6 +1,7 @@
 package <%= moduleName %>
 
 import (
+	<%= if (len(params) > 0) { %>"fmt"<% } %>
 	"math/rand"
 
 	"<%= modulePath %>/testutil/sample"

--- a/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
+++ b/starport/templates/module/create/simapp/x/{{moduleName}}/module_simulation.go.plush
@@ -1,7 +1,6 @@
 package <%= moduleName %>
 
 import (
-	<%= if (len(params) > 0) { %>"fmt"<% } %>
 	"math/rand"
 
 	"<%= modulePath %>/testutil/sample"
@@ -50,7 +49,7 @@ func (am AppModule) RandomizedParams(_ *rand.Rand) []simtypes.ParamChange {
 	<%= if (len(params) > 0) { %><%= moduleName %>Params := types.DefaultParams()<% } %>
 	return []simtypes.ParamChange{<%= for (param) in params { %>
 		simulation.NewSimParamChange(types.ModuleName, string(types.Key<%= param.Name.UpperCamel %>), func(r *rand.Rand) string {
-			return fmt.Sprintf("\"%v\"", <%= moduleName %>Params.<%= param.Name.UpperCamel %>)
+			return fmt.Sprintf("%s", types.Amino.MustMarshalJSON(<%= moduleName %>Params.<%= param.Name.UpperCamel %>))
 		}),<% } %>
 	}
 }


### PR DESCRIPTION
### Description

Fix issue to run a simulation when the module has int32 types for the params fields.

### How to reproduce

Scaffold a module with params:
```shell
starport scaffold chain github.com/cosmonaut/mars --no-module && cd mars && \
starport scaffold module launch --params minLaunch:uint,maxLaunch:int,chainDescription
```

Run the simulation:
```shell
starport c simulate --numBlocks 200 --blockSize 50
```

this error will appear:
```
Simulating... block 3/200, operation 0/196.--- FAIL: BenchmarkSimulation
    simulate.go:300: error on block  3/200, operation (90/172) from x/gov:
        failed to execute message; message index: 0: key: MaxLaunch, value: "0", err: json: cannot unmarshal string into Go value of type int32: failed to set parameter: invalid proposal content [cosmos/cosmos-sdk@v0.44.5/x/gov/keeper/proposal.go:24]
        Comment: unable to deliver tx
FAIL
```