### PR TITLE
docs: fix Discord link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ Starport is a free and open-source product maintained by [Tendermint](https://te
 - [Starport.com website](https://starport.com)
 - [@StarportHQ on Twitter](https://twitter.com/StarportHQ)
 - [Starport.com/blog](https://starport.com/blog/)
-- [Starport Discord](https://discord.com/starport)
+- [Starport Discord](https://discord.gg/starport)
 - [Starport YouTube](https://www.youtube.com/channel/UCXMndYLK7OuvjvElSeSWJ1Q)
 - [Starport docs](https://docs.starport.com/)
 - [Tendermint jobs](https://tendermint.com/careers)


### PR DESCRIPTION
The Discord link mentioned in the `readme` file is not correct.