### PR TITLE
bump frontend version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/tendermint/spn v0.1.1-0.20211210094128-4ca78a240c57
 	github.com/tendermint/tendermint v0.34.14
 	github.com/tendermint/tm-db v0.6.4
-	github.com/tendermint/vue v0.1.55
+	github.com/tendermint/vue v0.1.57
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf


### PR DESCRIPTION
- #1976
- [release 0.1.57](https://github.com/tendermint/vue/releases/tag/v0.1.57)