### PR TITLE
docs: changelog and migration doc edits for consistency and style

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
     - `spm/ibckeeper` is now `pkg/cosmosibckeeper`
     - `spm/cosmoscmd` is now `pkg/cosmoscmd` 
     - `spm/openapiconsole` is now `pkg/openapiconsole`
+    - `testutil/sample` is now `cosmostestutil/sample`
 
 - Updated the faucet HTTP API schema. See API changes in [fix: improve faucet reliability #1974](https://github.com/tendermint/starport/pull/1974/files#diff-0e157f4f60d6fbd95e695764df176c8978d85f1df61475fbfa30edef62fe35cd)
 
@@ -288,7 +289,7 @@
 
 - Added experimental [Stargate](https://stargate.cosmos.network/) scaffolding option with `--sdk-version stargate` flag on `starport app` command
 - Pi Image Generation for chains generated with Starport
-- Github action with capture of binary artifacts for chains generted with starport
+- Github action with capture of binary artifacts for chains generated with Starport
 - Gitpod: added guidelines and changed working directory into `docs`
 - Updated web scaffold with an improved sign in, balance list and a simple wallet
 - Added CRUD actions for scaffolded types: delete, update, and get

--- a/changelog.md
+++ b/changelog.md
@@ -2,40 +2,47 @@
 
 ## [`v0.19.2`](https://github.com/tendermint/starport/milestone/14)
 
-### Fixes:
+### Fixes
 
-- Fixed race condition during faucet transfer.
-- Fixed account sequence mistmatch issue on faucet and relayer.
-- Fixed templates for IBC code scaffolding.
+- Fixed race condition during faucet transfer
+- Fixed account sequence mismatch issue on faucet and relayer
+- Fixed templates for IBC code scaffolding
 
-### Features:
+### Features
 
-- Upgraded templates to use IBC v2.0.2. 
+- Upgraded blockchain templates to use IBC v2.0.2
 
-### Breaking Changes:
+### Breaking Changes
 
-- Deprecated `tendermint/spm` and moved its content to this repo under `pkg/`.
-- Updated faucet's HTTP API schema, see changes on the API from [here](https://github.com/tendermint/starport/pull/1974/files#diff-0e157f4f60d6fbd95e695764df176c8978d85f1df61475fbfa30edef62fe35cd).
+- Deprecated the Starport Modules [tendermint/spm](https://github.com/tendermint/spm) repo and moved the contents to the Starport repo [`starport/pkg/`](https://github.com/tendermint/starport/tree/develop/starport/pkg/) in [PR 1971](https://github.com/tendermint/starport/pull/1971/files) 
+ 
+    Updates are required if your chain uses these packages: 
+
+    - `spm/ibckeeper` is now `pkg/cosmosibckeeper`
+    - `spm/cosmoscmd` is now `pkg/cosmoscmd` 
+    - `spm/openapiconsole` is now `pkg/openapiconsole`
+
+- Updated the faucet HTTP API schema. See API changes in [fix: improve faucet reliability #1974](https://github.com/tendermint/starport/pull/1974/files#diff-0e157f4f60d6fbd95e695764df176c8978d85f1df61475fbfa30edef62fe35cd)
 
 ## `v0.19.1`
 
-### Fixes:
+### Fixes
 
-- Enabled `scaffold flutter` cmd.
+- Enabled the `scaffold flutter` command
 
 ## `v0.19.0`
 
-### Features:
+### Features
 
 - `starport scaffold` commands support `ints`, `uints`, `strings`, `coin`, `coins` as field types (#1579)
-- Simulation testing with `simapp` has been added to the default template (#1731)
+- Added simulation testing with `simapp` to the default template (#1731)
 - Added `starport generate dart` to generate a Dart client from protocol buffer files
 - Added `starport scaffold flutter` to scaffold a Flutter mobile app template
 - Parameters can be specified with a new `--params` flag when scaffolding modules (#1716)
 - Simulations can be run with `starport chain simulate`
-- `cointype` for accounts can be set in the `config.yml` (#1663)
+- Set `cointype` for accounts in  `config.yml` (#1663)
 
-### Fixes:
+### Fixes
 
 - Allow using a `creator` field when scaffolding a model with a `--no-message` flag (#1730)
 - Improved error handling when generating code (#1907)
@@ -44,7 +51,7 @@
 
 ## `v0.18.0`
 
-### Breaking Changes:
+### Breaking Changes
 
 - Starport v0.18 comes with Cosmos SDK v0.44 that introduced changes that are not compatible with chains that were scaffolded with Starport versions lower than v0.18. After upgrading from Starport v0.17.3 to Starport v0.18, you must update the default blockchain template to use blockchains that were scaffolded with earlier versions. See [Migration](./docs/migration/index.md).
 
@@ -64,10 +71,10 @@
 - `starport relayer` uses `starport account`
 - Added `--path` flag for all `scaffold`, `generate` and `chain` commands
 - Added `--output` flag to the `build` command
-- Port of gRPC web can be configured with in `config.yml` with the `host.grpc-web` property
-- Added `build.main` field to `config.yml` for apps to specify the path of their chain's main package. This is only required to be set when an app contains multiple main packages.
+- Configure port of gRPC web in `config.yml` with the `host.grpc-web` property
+- Added `build.main` field to `config.yml` for apps to specify the path of the chain's main package. This property is required to be set only when an app contains multiple main packages.
 
-### Fixes:
+### Fixes
 
 - Scaffolding a message no longer prevents scaffolding a map, list, or single that has the same type name when using the `--no-message` flag
 - Generate Go code from proto files only from default directories or directories specified in `config.yml`
@@ -77,20 +84,20 @@
 
 ## `v0.17.3`
 
-### Fixes:
+### Fixes
 
 - oracle: add a specific BandChain pkg version to avoid Cosmos SDK version conflicts
 
 ## `v0.17.2`
 
-### Features:
+### Features
 
 - `client.toml` is initialized and used by node's CLI, can be configured through `config.yml` with the `init.client` property
-- Support serving Cosmos SDK `v0.43.x` based chains.
+- Support serving Cosmos SDK `v0.43.x` based chains
 
 ## `v0.17.1`
 
-### Fixes:
+### Fixes
 
 - Set visibility to `public` on Gitpod's port 7575 to enable peer discovery for SPN
 - Fixed GitHub action that releases blockchain node's binary
@@ -99,7 +106,7 @@
 
 ## `v0.17`
 
-### Features:
+### Features
 
 - Added GitHub action that automatically builds and releases a binary
 - The `--release` flag for the `build` command adds the ability to release binaries in a tarball with a checksum file.
@@ -110,14 +117,14 @@
 - Added `starport generate` namespace with commands to generate Go, Vuex and OpenAPI
 - Added `starport chain init` command to initialize a chain without starting a node
 - Scaffold a type that contains a single instance in the store
-- Introduced `starport tools` command for advanced users. Existing `starport relayer lowlevel *` commands are also moved under `tools`.
+- Introduced `starport tools` command for advanced users. Existing `starport relayer lowlevel *` commands are also moved under `tools`
 - Added `faucet.rate_limit_window` property to `config.yml`
 - Simplified the `cmd` package in the template
 - Added `starport scaffold band` oracle query scaffolding
 - Updated TypeScript relayer to 0.2.0
 - Added customizable gas limits for the relayer
 
-### Fixes:
+### Fixes
 
 - Use snake case for generated files
 - Prevent using incorrect module name
@@ -127,26 +134,26 @@
 
 ## `v0.16.2`
 
-### Fix:
+### Fix
 
-- Prevent indirect Buf dependency.
+- Prevent indirect Buf dependency
 
 ## `v0.16.1`
 
-### Features:
+### Features
 
-- Ensure that CLI operates fine even if the installation directory (bin) of Go programs is not configured properly.
+- Ensure that CLI operates fine even if the installation directory (bin) of Go programs is not configured properly
 
 ## `v0.16.0`
 
-### Features:
+### Features
 
 - The new `join` flag adds the ability to pass a `--genesis` file and `--peers` address list with `starport network chain join`
 - The new `show` flag adds the ability to show `--genesis` and `--peers` list with `starport network chain show`
-- `protoc` is now bundled with Starport CLI. You don't need to install it anymore.
+- `protoc` is now bundled with Starport CLI so you don't need to install it anymore
 - Starport is now published automatically on the Docker Hub
-- `starport relayer` `configure` and `connect` commands now use the [confio/ts-relayer](https://github.com/confio/ts-relayer) under the hood. Also, checkout the new `starport relayer lowlevel` command.
-- An OpenAPI spec for your chain now automatically generated with `serve` and `build` commands. A console is available at `localhost:1317` and spec at `localhost:1317/static/openapi.yml` by default for the newly scaffolded chains.
+- `starport relayer` `configure` and `connect` commands now use the [confio/ts-relayer](https://github.com/confio/ts-relayer) under the hood. Also, checkout the new `starport relayer lowlevel` command
+- An OpenAPI spec for your chain is now automatically generated with `serve` and `build` commands: a console is available at `localhost:1317` and spec at `localhost:1317/static/openapi.yml` by default for the newly scaffolded chains
 - Keplr extension is supported on web apps created with Starport
 - Added tests to the scaffold
 - Improved reliability of scaffolding by detecting placeholders
@@ -159,12 +166,12 @@
 - Published documentation on https://docs.starport.network
 - Added `mnemonic` property to account in the `accounts` list to generate a key from a mnemonic
 
-### Fixes:
+### Fixes
 
 - `starport network chain join` hanging issue when creating an account
 - Error when scaffolding a chain with an underscore in the repo name (thanks @bensooraj!)
 
-### Changes:
+### Changes
 
 - `starport serve` no longer starts the web app in the `vue` directory (use `npm` to start it manually)
 - Default scaffold no longer includes legacy REST API endpoints (thanks @bensooraj!)
@@ -172,7 +179,7 @@
 
 ## `v0.15.0`
 
-### Features:
+### Features
 
 - IBC module scaffolding
 - IBC packet scaffolding with acknowledgements
@@ -187,14 +194,14 @@
 - Added spinners to indicate progress for long-running commands
 - Updated to Cosmos SDK v0.42.1
 
-### Changes:
+### Changes
 
 - Replaced `packr` with Go 1.16 `embed`
 - Renamed `servers` top-level property to `host`
 
 ## `v0.14.0`
 
-### Features:
+### Features
 
 - Chain state persistence between `starport serve` launches
 - Integrated Stargate app's `scripts/protocgen` into Starport as a native feature. Running `starport build/serve` will automatically take care of building proto files without a need of script in the app's source code.
@@ -220,24 +227,24 @@
 
 ## `v0.13.0`
 
-### Features:
+### Features
 
 - Added `starport network` commands for launching blockchains
 - Added proxy (Chisel) to support launching blockchains from Gitpod
 - Upgraded the template (Stargate) to Cosmos SDK v0.40.0-rc3
-- Added a gRPC-Web proxy, which is available under http://localhost:12345/grpc.
+- Added a gRPC-Web proxy that is available under http://localhost:12345/grpc
 - Added chain id configurability by recognizing `chain_id` from `genesis` section of `config.yml`.
-- Added `config/app.toml` and `config/config.toml` configurability for appd under new `init.app` and `init.config` sections of `config.yml`.
-- Point to Stargate as default SDK version for scaffolding.
-- Covered CRUD operations for Stargate scaffolding.
+- Added `config/app.toml` and `config/config.toml` configurability for appd under new `init.app` and `init.config` sections of `config.yml`
+- Point to Stargate as default SDK version for scaffolding
+- Covered CRUD operations for Stargate scaffolding
 - Added docs on gopath to build from source directions
 - Arch Linux Based Raspberry Pi development environment
 - Calculate the necessary gas for sending transactions to SPN
 
-### Fixes:
+### Fixes
 
-- Routing REST API endpoints of querier on Stargate.
-- Evaluate `--address-prefix` option when scaffolding for Stargate.
+- Routing REST API endpoints of querier on Stargate
+- Evaluate `--address-prefix` option when scaffolding for Stargate
 - Use a deterministic method to generate scaffolded type IDs
 - Modify scaffolded type's creator type from address to string
 - Copy built starport arm64 binary from tendermintdevelopment/starport:arm64 for device images
@@ -246,20 +253,20 @@
 
 ## `v0.12.0`
 
-### Features:
+### Features
 
 - Added Github CLI to gitpod environment for greater ease of use
-- Added `starport build` command to build and install app binaries.
-- Improved the first-time experience for readers of the Starport readme and parts of the Starport Handbook.
+- Added `starport build` command to build and install app binaries
+- Improved the first-time experience for readers of the Starport readme and parts of the Starport Handbook
 - Added `starport module create` command to scaffold custom modules
 - Raspberry Pi now installs, builds, and serves the Vue UI
 - Improved documentation for Raspberry Pi Device Images
-- Added IBC and some other modules.
-- Added an option to configure server addresses under `servers` section in `config.yml`.
+- Added IBC and some other modules
+- Added an option to configure server addresses under `servers` section in `config.yml`
 
-### Fixes:
+### Fixes
 
-- `--address-prefix` will always be translated to lowercase while scaffolding with `app` command.
+- `--address-prefix` will always be translated to lowercase while scaffolding with `app` command
 - HTTP API: accept strings in JSON and cast them to int and bool
 - Update @tendermint/vue to `v0.1.7`
 - Removed "Starport Pi"
@@ -267,69 +274,69 @@
 - Fixed Downstream Pi image Github Action
 - Prevent duplicated fields with `type` command
 - Fixed handling of protobufs profiler: prof_laddr -> pprof_laddr
-- Fix an error, when a Stargate `serve` cmd doesn't start if a user doesn't have a relayer installed.
+- Fix an error, when a Stargate `serve` cmd doesn't start if a user doesn't have a relayer installed
 
 ## `v0.11.1`
 
-### Features:
+### Features
 
-- Published on Snapcraft.
+- Published on Snapcraft
 
 ## `v0.11.0`
 
-### Features:
+### Features
 
-- Added experimental [Stargate](https://stargate.cosmos.network/) scaffolding option with `--sdk-version stargate` flag on `starport app` command.
+- Added experimental [Stargate](https://stargate.cosmos.network/) scaffolding option with `--sdk-version stargate` flag on `starport app` command
 - Pi Image Generation for chains generated with Starport
 - Github action with capture of binary artifacts for chains generted with starport
-- Gitpod: added guidelines and changed working directory into `docs`.
-- Updated web scaffold with an improved sign in, balance list and a simple wallet.
-- Added CRUD actions for scaffolded types: delete, update and get.
+- Gitpod: added guidelines and changed working directory into `docs`
+- Updated web scaffold with an improved sign in, balance list and a simple wallet
+- Added CRUD actions for scaffolded types: delete, update, and get
 
 ## `v0.0.10`
 
-### Features:
+### Features
 
-- Add ARM64 releases.
+- Add ARM64 releases
 - OS Image Generation for Raspberry Pi 3 and 4
 - Added `version` command
 - Added support for _validator_ configuration in _config.yml_.
 - Starport can be launched on Gitpod
 - Added `make clean`
 
-### Fixes:
+### Fixes
 
 - Compile with go1.15
 - Running `starport add type...` multiple times no longer breaks the app
-- Running `appcli tx app create-x` now checks for all required args. -#173.
-- Removed unused `--denom` flag from the `app` command. It previously has moved as a prop to the `config.yml` under `accounts` section.
-- Disabled proxy server in the Vue app (this was causing to some compatibilitiy issues) and enabled CORS for `appcli rest-server` instead.
-- `type` command supports dashes in app names.
+- Running `appcli tx app create-x` now checks for all required args
+- Removed unused `--denom` flag from the `app` command. It previously has moved as a prop to the `config.yml` under `accounts` section
+- Disabled proxy server in the Vue app (this was causing to some compatibilitiy issues) and enabled CORS for `appcli rest-server` instead
+- `type` command supports dashes in app names
 
 ## `v0.0.10-rc.3`
 
-### Features:
+### Features
 
 - Configure `genesis.json` through `genesis` field in `config.yml`
 - Initialize git repository on `app` scaffolding
 - Check Go and GOPATH when running `serve`
 
-### Changes:
+### Changes
 
 - verbose is --verbose, not -v, in the cli
 - Renamed `frontend` directory to `vue`
 - Added first E2E tests (for `app` and `add wasm` subcommands)
 
-### Fixes:
+### Fixes
 
-- No longer crashes, when git is initialized, but doesn't have commits
+- No longer crashes when git is initialized but doesn't have commits
 - Failure to start the frontend doesn't prevent Starport from running
 - Changes to `config.yml` trigger reinitialization of the app
 - Running `starport add wasm` multiple times no longer breaks the app
 
 ## `v0.0.10-rc.X`
 
-### Features:
+### Features
 
 - Initialize with accounts defined `config.yml`
 - `starport serve --verbose` shows detailed output from every process

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -17,4 +17,4 @@ To migrate your chain that was scaffolded with Starport versions lower than v0.1
 
 1. **IBC upgrade**: Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
 
-2. Upgrade your chain's `go.mod` file to remove `tendermint/spm` and addn the v0.19.2 version of `tendermint/starport`.
+2. Upgrade your chain's `go.mod` file to remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -15,6 +15,12 @@ With Starport v0.19.2, the contents of the deprecated Starport Modules `tendermi
 
 To migrate your chain that was scaffolded with Starport versions lower than v0.19.2: 
 
-1. **IBC upgrade**: Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+1. IBC upgrade: Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+   
+2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown: 
 
-2. Upgrade your chain's `go.mod` file to remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`.
+    - `spm/ibckeeper` moved to `pkg/cosmosibckeeper`
+    - `spm/cosmoscmd` moved to `pkg/cosmoscmd` 
+    - `spm/openapiconsole` moved to `pkg/openapiconsole`
+    - `testutil/sample` moved to `cosmostestutil/sample`
+

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -7,8 +7,14 @@ parent:
 description: For chains that were scaffolded with Starport versions lower than v0.19.2, changes are required to use Starport v0.19.2. 
 ---
 
-# Upgrading a Blockchain to use Starport v0.19.2
+# Upgrading a blockchain to use Starport v0.19.2
 
-Starport _v0.19.2_ comes with IBC _v2.0.2_. To migrate your chain scaffold with _v0.19_ or _v0.18_ version of Starport, apply changes introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+Starport v0.19.2 comes with IBC v2.0.2. 
 
-With _v0.19.2_, contents of `tendermint/spm` moved to Starport's own repo. Upgrade your chain's `go.mod` by removing `tendermint/spm` and adding _v0.19.2_ version of `tendermint/starport`.
+With Starport v0.19.2, the contents of the deprecated Starport Modules `tendermint/spm` repo are moved to the official Starport repo which introduces breaking changes.
+
+To migrate your chain that was scaffolded with Starport versions lower than v0.19.2: 
+
+1. Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+
+2. Upgrade your chain's `go.mod` file to remove `tendermint/spm` and addn the v0.19.2 version of `tendermint/starport`.

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -15,6 +15,6 @@ With Starport v0.19.2, the contents of the deprecated Starport Modules `tendermi
 
 To migrate your chain that was scaffolded with Starport versions lower than v0.19.2: 
 
-1. Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+1. **IBC upgrade**: Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
 
 2. Upgrade your chain's `go.mod` file to remove `tendermint/spm` and addn the v0.19.2 version of `tendermint/starport`.


### PR DESCRIPTION
- omit punctuation from end of headings (remove colon)
- omit punctuation from end of list items (we had mostly sentence fragments, so let's omit throughout)
- omit italics from version references, emphasis is not required see https://docs.starport.com/migration/v0.18.html
- provide actionable numbered steps for migration

@ilgooz let's go through migration doc and other changes to make sure I didn't inadvertently introduce technical inaccuracy

