### PR TITLE
docs: minor edits and change all headings to use Sentence case

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,14 +1,14 @@
 # Contributing to Starport docs
 
-- [Contributing](#contributing)
+- [Contributing to Starport docs](#contributing-to-starport-docs)
   - [Using this repo](#using-this-repo)
   - [Reviewing technical content PRs](#reviewing-technical-content-prs)
   - [Writing and contributing](#writing-and-contributing)
   - [Where can I find the tutorials and docs?](#where-can-i-find-the-tutorials-and-docs)
   - [Who works on the tutorials?](#who-works-on-the-tutorials)
-  - [Viewing Tutorial Builds](#viewing-tutorial-builds)
-    - [Preview PRs on a Deployed Preview](#preview-prs-on-a-deployed-preview)
-    - [Preview Draft PRs on a Local Web Browser](#preview-draft-prs-on-a-local-web-browser)
+  - [Viewing tutorial builds](#viewing-tutorial-builds)
+    - [Preview PRs on a deployed preview](#preview-prs-on-a-deployed-preview)
+    - [Preview draft PRs on a local web browser](#preview-draft-prs-on-a-local-web-browser)
   
 
 Thank you for considering making contributions. We appreciate your interest in helping us to create and maintain awesome tutorials and documentation.
@@ -55,8 +55,9 @@ Other useful resources:
 
 Technical content includes knowledge base articles and interactive tutorials. 
  
-- The Starport Developer Tutorials content is in the `docs/guide` folder. 
-- The Knowledge Base content is in the `docs/kb` folder. 
+- Starport Developer Tutorials content is in the `docs/guide` folder. 
+- Knowledge Base content is in the `docs/kb` folder. 
+- Migration content for required action steps required for upgrades to new Starport versions is in the `docs/migration` folder.
 
 Locations and folders for other content can vary. Explore the self-describing folders for the content that you are interested in. Some articles and tutorials reside in a single Markdown file while sub-folders might be present for other tutorials.
 
@@ -77,7 +78,7 @@ There are two ways to see what your changes will look like in production before 
 - When a PR is ready for review, you can see a deployed preview on a URL that is unique for that PR.
 - While a PR is in draft mode, you can preview a local build.
 
-### Preview PRs on a Deployed Preview
+### Preview PRs on a deployed preview
 
 After the PR moves from **Draft** to **Ready for review**, the CI status checks generate a Netlify deploy preview. Netlify keeps this preview up to date as you continue to work and commit new changes to the same branch.
 
@@ -100,7 +101,7 @@ Since the deploy preview doesn't work on Draft PRs, follow these steps to previe
 
 2. Local tutorials require JavaScript. If needed, install [npm](https://docs.npmjs.com/cli/v6/commands/npm-install).
 
-3. For each branch you work in, install the npm packages for the SDK tutorials:
+3. For each branch you work in, install the npm packages for the developer tutorials:
 
     ```bash
     npm install
@@ -120,4 +121,4 @@ Since the deploy preview doesn't work on Draft PRs, follow these steps to previe
 
 5. You can now view the docs build on a local web browser. Isn't this fun?
 
-    Tip: On a mac, press the command key and click `http://localhost:8080/` for quick access to the local preview. If you are already using port 8080 on your local machine, the preview increments to the next available port 8081, and so on. 
+    Tip: On a Mac, press the command key and click `http://localhost:8080/` for quick access to the local preview. If you are already using port 8080 on your local machine, the preview increments to the next available port 8081, and so on. 

--- a/docs/contributing/templates/concept_template.md
+++ b/docs/contributing/templates/concept_template.md
@@ -16,7 +16,7 @@ We admire and respect these resources:
 
 -->
 
-<!-- Use Title Case for all Titles, see https://capitalizemytitle.com/ -->
+<!-- Use sentence case for all Headings and Titles, see https://capitalizemytitle.com/ -->
 
 <!-- We like the way Digital Ocean explains things, you can learn about the title, introduction, and Goals sections at https://do.co/style#title-introduction-and-goals -->
 

--- a/docs/contributing/templates/readme.md
+++ b/docs/contributing/templates/readme.md
@@ -1,4 +1,4 @@
-# Starport Article Templates
+# Starport article templates
 
 Use these templates along with our style guide to help you create articles for the Starport community. 
 

--- a/docs/contributing/templates/tutorial-template.md
+++ b/docs/contributing/templates/tutorial-template.md
@@ -1,4 +1,4 @@
-# How To [Build/Create/Do Something] in Starport
+# How to [build/create/do something] in Starport
 
 <!--
 Use this tutorial template as a quick starting point when writing Starport how-to tutorials. 
@@ -21,25 +21,25 @@ We admire, respect, and rely on these resources:
 Our users must be able to follow the tutorial from beginning to end on their own computer. Before submitting a tutorial for PR review, be sure to test the content by completing all steps from start to finish exactly as they are written. Cut and paste commands from the article into your terminal to make sure that typos are not present in the commands. If you find yourself executing a command that isn't in the article, incorporate that command into the article to make sure the user gets the exact same results. 
 -->
 
-<!-- Use Title Case for all Titles, see https://capitalizemytitle.com/ -->
+<!-- Use sentence case for all headings and titles, see https://capitalizemytitle.com/ -->
 
 <!-- Use GitHub flavored Markdown, see [Mastering Markdown](https://guides.github.com/features/mastering-markdown/)  -->
 
 <!-- Our articles have a specific structure. How-To tutorials follow this structure:
 
-* Front Matter Metadata
+* Front matter metadata
 * Title
-* Introduction and Purpose (Level 2 heading)
+* Introduction and purpose (Level 2 heading)
 * Prerequisites (Level 2 heading)
-* Step 1 — Doing Something (Level 2 heading)
-* Step 2 — Doing Something (Level 2 heading)
+* Step 1 — Doing something (Level 2 heading)
+* Step 2 — Doing something (Level 2 heading)
 ...
-* Step 5 — Doing Something (Level 2 heading)
+* Step 5 — Doing something (Level 2 heading)
 * Conclusion (Level 2 heading)
 
  -->
 
-### Introduction and Purpose
+### Introduction and purpose
 
 Introductory paragraph about the topic that explains what this topic is about and why the user should care; what problem does the tutorial solve?
 
@@ -68,7 +68,7 @@ To complete this tutorial, you will need:
 
 -->
 
-## Step 1 — Doing Something
+## Step 1 — Doing something
 
 Introduction to the step. What are you going to do and why are you doing it?
 
@@ -88,8 +88,13 @@ starport --version
 
 You'll see release details like the following output:
 
-```
-starport version v0.18.4 darwin/amd64 -build date: 2021-12-01T18:34:28Z
+```bash
+Starport version:	v0.19.1
+Starport build date:	2021-12-18T05:56:36Z
+Starport source hash:	-
+Your OS:		darwin
+Your arch:		amd64
+Your go version:	go version go1.16.4 darwin/amd64
 ```
 
 <!-- When asking the user to open a file, be sure to specify the file name:
@@ -123,7 +128,7 @@ message MsgCreatePost {
 
 Now transition to the next step by telling the user what's next.
 
-## Step 2 — Title Case
+## Step 2 — Next step in sentence case
 
 Another introduction
 
@@ -131,7 +136,7 @@ Your content that guides the user to accomplish a specific step
 
 Transition to the next step.
 
-## Step 3 — Title Case
+## Step 3 — Next step in sentence case
 
 Another introduction
 

--- a/docs/kb/config.md
+++ b/docs/kb/config.md
@@ -4,13 +4,13 @@ description: Primary configuration file to describe the development environment 
 title: "config.yml Reference"
 ---
 
-# config.yml Reference
+# config.yml reference
 
 The `config.yml` file generated in your blockchain folder uses key-value pairs to describe the development environment for your blockchain.
 
 Only a default set of parameters is provided. If more nuanced configuration is required, you can add these parameters to the `config.yml` file.
 
-## `accounts`
+## accounts
 
 A list of user accounts created during genesis of the blockchain.
 
@@ -18,8 +18,8 @@ A list of user accounts created during genesis of the blockchain.
 | -------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | name     | Y        | String          | Local name of a key pair. An account name must be listed to gain access to the account tokens after the blockchain is launched. |
 | coins    | Y        | List of Strings | Initial coins with denominations. For example, "1000token"                                                                      |
-| address  | N        | String          | Account address in Bech32 address format                                                                                        |
-| mnemonic | N        | String          | Mnemonic used to generate an account. This field is ignored if `address` is specified                                           |
+| address  | N        | String          | Account address in Bech32 address format.                                                                                        |
+| mnemonic | N        | String          | Mnemonic used to generate an account. This field is ignored if `address` is specified.                                           |
 
 **accounts example**
 
@@ -32,12 +32,12 @@ accounts:
     address: cosmos1adn9gxjmrc3hrsdx5zpc9sj2ra7kgqkmphf8yw
 ```
 
-## `build`
+## build
 
 | Key    | Required | Type   | Description                                                    |
 | ------ | -------- | ------ | -------------------------------------------------------------- |
-| main   | N        | String | When an app contains more than one main Go package, it is required to define the path of the chain's main package. |
-| binary | N        | String | Name of the node binary that is built, typically ends with `d` |
+| main   | N        | String | When an app contains more than one main Go package, required to define the path of the chain's main package. |
+| binary | N        | String | Name of the node binary that is built, typically ends with `d`. |
 
 **build example**
 
@@ -46,18 +46,18 @@ build:
   binary: "mychaind"
 ```
 
-### `build.proto`
+### build.proto
 
 | Key               | Required | Type            | Description                                                                                |
 | ----------------- | -------- | --------------- | ------------------------------------------------------------------------------------------ |
-| path              | N        | String          | Path to protocol buffer files. Default: `"proto"`                                          |
-| third_party_paths | N        | List of Strings | Path to thid-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]` |
+| path              | N        | String          | Path to protocol buffer files. Default: `"proto"`.                                         |
+| third_party_paths | N        | List of Strings | Path to third-party protocol buffer files. Default: `["third_party/proto", "proto_vendor"]`. |
 
-## `client`
+## client
 
-Configures and enables client code generation. To prevent Starport from regenerating the client, remove the `client` property.
+Configures and enables client code generation. To prevent regenerating the client, remove the `client` property.
 
-### `client.vuex`
+### client.vuex
 
 ```yaml
 client:
@@ -65,9 +65,9 @@ client:
     path: "vue/src/store"
 ```
 
-`client.vuex` generates TypeScript/Vuex client for the blockchain in `path` on `serve` and `build` commands.
+Generates TypeScript Vuex client for the blockchain in `path` on `serve` and `build` commands.
 
-### `client.openapi`
+### client.openapi
 
 ```yaml
 client:
@@ -75,19 +75,19 @@ client:
     path: "docs/static/openapi.yml"
 ```
 
-`client.openapi` generates OpenAPI YAML file in `path`. By default this file is embedded into the node's binary.
+Generates OpenAPI YAML file in `path`. By default this file is embedded in the node's binary.
 
-## `faucet`
+## faucet
 
 The faucet service sends tokens to addresses. The default address for the web user interface is <http://localhost:4500>.
 
 | Key               | Required | Type            | Description                                                 |
 | ----------------- | -------- | --------------- | ----------------------------------------------------------- |
-| name              | Y        | String          | Name of a key pair. `name` must be in `accounts`            |
-| coins             | Y        | List of Strings | One or more coins with denominations sent per request       |
-| coins_max         | N        | List of Strings | One or more maximum amounts of tokens sent for each address |
+| name              | Y        | String          | Name of a key pair. The `name` key pair must be in `accounts`.            |
+| coins             | Y        | List of Strings | One or more coins with denominations sent per request.       |
+| coins_max         | N        | List of Strings | One or more maximum amounts of tokens sent for each address. |
 | host              | N        | String          | Host and port number. Default: `:4500`                      |
-| rate_limit_window | N        | String          | Time after which the token limit is reset (in seconds)      |
+| rate_limit_window | N        | String          | Time after which the token limit is reset (in seconds).      |
 
 **faucet example**
 
@@ -99,14 +99,14 @@ faucet:
   port: 4500
 ```
 
-## `validator`
+## validator
 
 A blockchain requires one or more validators.
 
 | Key    | Required | Type   | Description                                                                                     |
 | ------ | -------- | ------ | ----------------------------------------------------------------------------------------------- |
-| name   | Y        | String | The account that is used to initialize the validator. The `name` key pair must be in `accounts` |
-| staked | Y        | String | Amount of coins to bond. Must be less than or equal to the amount of coins in the account       |
+| name   | Y        | String | The account that is used to initialize the validator. The `name` key pair must be in `accounts`. |
+| staked | Y        | String | Amount of coins to bond. Must be less than or equal to the amount of coins in the account.       |
 
 **validator example**
 
@@ -119,7 +119,7 @@ validator:
   staked: "100000000stake"
 ```
 
-## `init.home`
+## init.home
 
 The path to the data directory that stores blockchain data and blockchain configuration.
 
@@ -130,15 +130,15 @@ init:
   home: "~/.myblockchain"
 ```
 
-## `init.config`
+## init.config
 
 Overwrites properties in `config/config.toml` in the data directory.
 
-## `init.app`
+## init.app
 
 Overwrites properties in `config/app.toml` in the data directory.
 
-## `init.client`
+## init.client
 
 Overwrites properties in `config/client.toml` in the data directory.
 
@@ -150,9 +150,9 @@ init:
     keyring-backend: "os"
 ```
 
-## `host`
+## host
 
-Configuration of host names and ports for processes started by Starport:
+Configuration of host names and ports for processes started by Starport.
 
 **host example**
 
@@ -165,6 +165,6 @@ host:
   api: ":1318"
 ```
 
-## `genesis`
+## genesis
 
 Use to overwrite values in `genesis.json` in the data directory to test different values in development environments. See [Genesis Overwrites for Development](../kb/genesis.md).

--- a/docs/kb/config.md
+++ b/docs/kb/config.md
@@ -1,7 +1,7 @@
 ---
 order: 4
 description: Primary configuration file to describe the development environment for your blockchain.
-title: "config.yml Reference"
+title: config.yml reference
 ---
 
 # config.yml reference

--- a/docs/kb/docker.md
+++ b/docs/kb/docker.md
@@ -17,17 +17,17 @@ Experimentation and file system impact is limited to the Docker instance. The ho
 
 Docker must be installed. See [Get Started with Docker](https://www.docker.com/get-started).
 
-## Starport Commands in Docker
+## Starport commands in Docker
 
 After you scaffold and start a chain in your Docker container, all Starport commands are available. Just type the commands after `docker run -ti starport/cli`. For example:
 
 ```bash
 docker run -ti starport/cli -h
-docker run -ti starport/cli scaffold chain github.com/test/planet
+docker run -ti starport/cli scaffold chain github.com/cosmonaut/planet
 docker run -ti starport/cli chain serve
 ```
 
-## Scaffolding a Chain
+## Scaffolding a chain
 
 When Docker is installed, you can build a blockchain with a single command.
 
@@ -49,7 +49,7 @@ Be patient, this command takes a minute or two to run because it does everything
 
     **Note:** The directory name for the `-w` and `-v` flags can be a name other then `/app`, but the same directory must be specified for both flags. If you omit `-w` and `-v`, the changes are made in the container only and are lost when that container is shut down.
 
-## Starting a Blockchain
+## Starting a blockchain
 
 To start the blockchain node in the Docker container you just created, run this command:
 
@@ -71,20 +71,20 @@ This command does the following:
 
 You can specify which version of Starport to install and run in your Docker container.
 
-### Latest Version
+### Latest version
 
 - By default, `starport/cli` resolves to `starport/cli:latest`.
 - The `latest` image tag is always the latest stable [Starport release](https://github.com/tendermint/starport/releases).
 
-For example, if latest release is [v0.15.1](https://github.com/tendermint/starport/releases/tag/v0.15.1), the `latest` tag points to the `0.15.1` tag.
+For example, if latest release is [v0.19.2](https://github.com/tendermint/starport/releases/tag/v0.19.2), the `latest` tag points to the `0.19.2` tag.
 
-### Specific Version
+### Specific version
 
 You can specify to use a specific version of Starport. All available tags are in the [starport/cli image](https://hub.docker.com/repository/docker/starport/cli/tags?page=1&ordering=last_updated) on Docker Hub.
 
 For example:
 
-- Use `starport/cli:0.15.1` (without the `v` prefix) to use version 0.15.1.
+- Use `starport/cli:0.19.2` (without the `v` prefix) to use version 0.19.2.
 - Use `starport/cli:develop` to use the `develop` branch so you can experiment with the next version.
 
 To get the latest image, run `docker pull`.

--- a/docs/kb/frontend.md
+++ b/docs/kb/frontend.md
@@ -3,13 +3,13 @@ description: Details on the Vue frontend app created by Starport.
 order: 8
 ---
 
-# Frontend Overview
+# Frontend overview
 
 A Vue frontend app is created in the `vue` directory when a blockchain is scaffolded. To start the frontend app run `npm i && npm run serve` in the `vue` directory.
 
 The frontend app is built using the `@starport/vue` and `@starport/vuex` packages. For details, see the [monorepo for Starport front-end development](https://github.com/tendermint/vue).
 
-## Client Code Generation
+## Client code generation
 
 JavaScript (JS), TypeScript (TS), and Vuex clients are automatically generated for your blockchain for custom and standard Cosmos SDK modules.
 
@@ -23,10 +23,14 @@ client:
 
 A Vuex client is generated in the `js` directory. JS and TS clients are also generated because they are dependencies of the Vuex client.
 
-## Client Code Regeneration
+## Client code regeneration
 
 By default, the filesystem is watched and the clients are regenerated automatically. Clients for standard Cosmos SDK modules are generated after you scaffold a blockchain.
 
 To regenerate all clients for custom and standard Cosmos SDK modules, run this command:
 
 `starport generate vuex`
+
+## Preventing client code regeneration
+
+To prevent regenerating the client, remove the `client` property from `config.yml`.

--- a/docs/kb/genesis.md
+++ b/docs/kb/genesis.md
@@ -3,15 +3,15 @@ order: 5
 description: Test different scenarios after the blockchain is created.
 ---
 
-# Genesis Overwrites for Development
+# Genesis overwrites for development
 
-The `genesis.json` file for all new blockchains is automatically created from the `config.yml` file.
+The `genesis.json` file for all new blockchains is automatically created from the `config.yml` file to define the initial state upon genesis of the blockchain. 
 
 In development environments, it is useful to test different scenarios after the blockchain is created. The `genesis.json` file for the blockchain is overwritten by the top-level `genesis` parameter in `config.yml`.
 
 To set and test different values, add the `genesis` parameter to `config.yml`.
 
-## Change the Value of a Single Parameter
+## Change the value of a single parameter
 
 To change the value of one parameter, add the key-value pair under the `genesis` parameter. For example, change the value of `chain-id`:
 
@@ -20,7 +20,7 @@ genesis:
   chain_id: "foobar"
 ```
 
-## Change Values in Modules
+## Change values in modules
 
 You can change one or more parameters of different modules. For example, in the `staking` module you can add a key-value pair to `bond_denom` to change which token gets staked:
 
@@ -32,11 +32,11 @@ genesis:
         bond_denom: "denom"
 ```
 
-## Genesis File
+## Genesis file
 
 For genesis file details and field definitions, see [Using Tendermint > Genesis](https://docs.tendermint.com/master/tendermint-core/using-tendermint.html#genesis).
 
-## Genesis Block Summary
+## Genesis block summary
 
 - The genesis block is the first block of a blockchain.
 

--- a/docs/kb/index.md
+++ b/docs/kb/index.md
@@ -5,8 +5,8 @@ parent:
   order: 2
 ---
 
-# Introduction
+# Knowledge Base
 
-Knowledge base contains article that cover different aspects of Starport: from scaffolding a chain to starting an IBC relayer.
+Knowledge base articles cover different aspects of Starport. This online library includes reference content on supported types, protocol buffer files, chain simulation as well as an overview of scaffolding a chain all the way to starting an IBC relayer.
 
 If you're new to Starport or want to go through a series of tutorials, visit the [Developer Tutorials](/guide/).

--- a/docs/kb/params.md
+++ b/docs/kb/params.md
@@ -1,9 +1,9 @@
 ---
 order: 15
-description: Module Parameters
+description: Scaffold module parameters to be accessible to the module.
 ---
 
-# Module Parameters
+# Module parameters
 
 Sometimes you need to set default parameters for a module. The Cosmos SDK [params package](https://docs.cosmos.network/master/modules/params) provides a globally available parameter that is saved into the key-value store. 
 
@@ -17,13 +17,13 @@ To scaffold a module with params using the `--params` flag:
 starport scaffold module launch --params minLaunch:uint,maxLaunch:int
 ```
 
-After the parameters are scaffolded, change the `x/<module>/types/params.go` file to set the default values and validate the field. 
+After the parameters are scaffolded, change the `x/<module>/types/params.go` file to set the default values and validate the fields. 
 
 The params module supports all [built-in Starport types](types.md).
 
-## Params Types
+## Params types
 
-| Type   | Code Type | Description             |
+| Type   | Code type | Description             |
 | ------ | --------- | ----------------------- |
 | string | string    | Text type               |
 | bool   | bool      | Boolean type            |

--- a/docs/kb/proto.md
+++ b/docs/kb/proto.md
@@ -1,19 +1,19 @@
 ---
-description: Protocol buffer file support in Starport
+description: Protocol buffer file support.
 order: 7
 ---
 
-# Protocol Buffer Files
+# Protocol buffer files
 
 Protocol buffer files define the data structures used by Cosmos SDK modules.
 
-## Files and Directories
+## Files and directories
 
 Inside the `proto` directory, a directory for each custom module contains `query.proto`, `tx.proto`, `genesis.proto`, and other files.
 
 The `starport chain serve` command automatically generates Go code from proto files on every file change.
 
-## Third-Party Proto Files
+## Third-party proto files
 
 Third-party proto files, including those of Cosmos SDK and Tendermint, are bundled with Starport. To import third-party proto files in your custom proto files:
 

--- a/docs/kb/relayer.md
+++ b/docs/kb/relayer.md
@@ -3,11 +3,11 @@ description: IBC relayer to connect local and remote blockchains.
 order: 9
 ---
 
-# IBC Relayer
+# IBC relayer
 
 A built-in IBC relayer in Starport lets you connect blockchains that run on your local computer to blockchains that run on remote computers. The Starport relayer uses the [TypeScript relayer](https://github.com/confio/ts-relayer).
 
-## Configure Connections
+## Configure connections
 
 The `configure` command configures a connection between two blockchains:
 
@@ -23,7 +23,7 @@ The optional `--advanced` flag lets you configure port and version for the custo
 
 By default, relayer configuration is stored in `$HOME/.relayer/`.
 
-## Relayer Configure Example
+## Relayer configure example
 
 All values can be passed with flags.
 
@@ -31,6 +31,6 @@ All values can be passed with flags.
 starport relayer configure --advanced --source-rpc "http://0.0.0.0:26657" --source-faucet "http://0.0.0.0:4500" --source-port "blog" --source-version "blog-1" --target-rpc "http://0.0.0.0:26659" --target-faucet "http://0.0.0.0:4501" --target-port "blog" --target-version "blog-1"
 ```
 
-## Connect Blockchains and Watch for IBC Packets
+## Connect blockchains and watch for IBC packets
 
 The `starport relayer connect` command connects configured blockchains and watches for IBC packets to relay.

--- a/docs/kb/scaffold-chain.md
+++ b/docs/kb/scaffold-chain.md
@@ -1,70 +1,71 @@
 ---
 order: 1
-description: Overview of a new Cosmos SDK blockchain project built with Starport.
+description: High-level overview of a new Cosmos SDK blockchain project built with Starport.
 ---
 
-# Scaffold a Chain
+# Scaffold a chain
 
 The `starport scaffold chain` command scaffolds a new Cosmos SDK blockchain project.
 
-## Build a Blockchain App
+## Build a blockchain app
 
 To build the planet application:
 
 ```bash
-starport scaffold chain github.com/hello/planet
+starport scaffold chain github.com/cosmonaut/planet
 ```
 
-## Directory Structure
+## Directory structure
 
-This command creates a directory called `planet` that contains all the files for your project and initializes a local git repository. The `github.com` URL in the argument is a string that is used for the Go module path. The repository name (`planet`, in this case) is used as the project's name.
+The `starport scaffold chain github.com/cosmonaut/planet` command creates a directory called `planet` that contains all the files for your project and initializes a local git repository. The `github.com` URL in the argument is a string that is used for the Go module path. The repository name (`planet`, in this case) is used as the project's name.
 
 The project directory structure:
 
 - `app`: files that wire the blockchain together
-- `cmd`: blockchain node's binary
+- `cmd`: binary for the blockchain node
+- `docs`: static `openapi.yml` API doc for the blockchain node
 - `proto`: protocol buffer files for custom modules
-- `x`: directory with custom modules
+- `x`: modules
 - `vue`: scaffolded web application (optional)
 - `config.yml`: configuration file
 
-### Application-Specific Logic
+### Application-specific logic
 
-Most of the logic of your application-specific blockchain is written in custom modules. Each module effectively encapsulates an independent piece of functionality. Custom modules are stored inside the `x` directory. By default, `starport scaffold chain` scaffolds a module with a name that matches the name of the project. In our example, the module name is `x/planet`.
+Most of the logic of your application-specific blockchain is written in custom modules. Each module effectively encapsulates an independent piece of functionality. Following the Cosmos SDK convention, custom modules are stored inside the `x` directory. By default, `starport scaffold chain` scaffolds a module with a name that matches the name of the project. In this example, the module name is `x/planet`.
 
-### Proto Files
+### Proto files
 
-Every Cosmos SDK module has protocol buffer files defining data structures, messages, queries, RPCs, and so on. The `proto` directory contains a directory with proto files for each custom module in `x`.
+Every Cosmos SDK module has protocol buffer files that define data structures, messages, queries, RPCs, and so on. The `proto` directory contains a directory with proto files for each custom module in the `x` directory.
 
-### Global Settings
+### Global settings
 
-Global changes to your blockchain are defined in files inside the `app` directory. This includes importing third-party modules, defining relationships between modules, and configuring blockchain-wide settings.
+Global changes to your blockchain are defined in files inside the `app` directory. These changes include importing third-party modules, defining relationships between modules, and configuring blockchain-wide settings.
 
 ### Configuration
 
-The `config.yml` file contains configuration options that Starport uses to build, initialize, and start your blockchain node in development.
+The `config.yml` file contains configuration options that Starport uses to build, initialize, and start your blockchain node in development.  
 
-## Address Prefix
+## Address prefix
 
-Account addresses on Cosmos SDK-based blockchains have string prefixes. For example, Cosmos Hub blockchain uses the default `cosmos` prefix, so that addresses look like this: `cosmos12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf`.
+Account addresses on Cosmos SDK-based blockchains have string prefixes. For example, the Cosmos Hub blockchain uses the default `cosmos` prefix, so that addresses look like this: `cosmos12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf`.
 
 ### Change prefix on new blockchains
 
-When creating a new blockchain, pass a prefix as a value to the `--address-prefix` flag:
+When you create a new blockchain, pass a prefix as a value to the `--address-prefix` flag:
 
 ```bash
-starport scaffold chain github.com/hello/planet --address-prefix moonlight
+starport scaffold chain github.com/cosmonaut/planet --address-prefix moonlight
 ```
 
 Using the `moonlight` prefix, account addresses on your blockchain look like this: `moonlight12fjzdtqfrrve7zyg9sv8j25azw2ua6tvu07ypf`.
 
-### Change Prefix on Existing Blockchains
+### Change prefix on existing blockchains
 
 To change the prefix after the blockchain has been scaffolded, modify the `AccountAddressPrefix` in the `app/prefix.go` file.
 
 1. Change the `AccountAddressPrefix` variable in the `/app/prefix.go` file. Be sure to preserve other variables in the file.
 2. To recognize the new prefix, change the `VUE_APP_ADDRESS_PREFIX` variable in `/vue/.env`.
 
-## Cosmos SDK Version
+## Cosmos SDK version
 
-By default, the `starport scaffold chain` command creates a Cosmos SDK blockchain using the latest stable version of the SDK.
+By default, the `starport scaffold chain` command creates a Cosmos SDK blockchain using the latest stable version of the Cosmos SDK.

--- a/docs/kb/serve.md
+++ b/docs/kb/serve.md
@@ -3,14 +3,14 @@ order: 2
 description: Use the Starport serve command to start your blockchain.
 ---
 
-# Start a Blockchain
+# Start a blockchain
 
 Blockchains are decentralized applications.
 
 - In production, blockchains often run the same software on many validator nodes that are run by different people and entities. To launch a blockchain in production, the validator entities coordinate the launch process to start their nodes simultaneously.
 - During development, a blockchain can be started locally on a single validator node. This convenient process lets you restart a chain quickly and iterate faster. Starting a chain on a single node in development is similar to starting a traditional web application on a local server.
 
-## Start a Blockchain Node in Development
+## Start a blockchain node in development
 
 Switch to the directory that contains a blockchain that was scaffolded with Starport. To start the blockchain node, run the following command:
 
@@ -22,9 +22,9 @@ This command initializes a chain, builds the code, starts a single validator nod
 
 Whenever a file is changed, the chain is automatically reinitialized, rebuilt, and started again. The chain's state is preserved if the changes to the source code are compatible with the previous state. This state preservation is beneficial for development purposes.
 
-Because the `starport chain serve` command is a development tool, it should not be used in a production environment. Read on to learn the process of running a blockchain in production.
+Because the `starport chain serve` command is a development tool, do not use it in a production environment. Read on to learn the process of running a blockchain in production.
 
-## The Magic of `starport chain serve`
+## The magic of `starport chain serve`
 
 The `starport chain serve` command starts a fully operational blockchain.
 
@@ -44,15 +44,15 @@ The `starport chain serve` command performs the following tasks:
 - Watches for file changes and restarts
 - Exports state
 
-You can use flags to configure how the blockchain runs. 
+You can use flags to configure how the blockchain runs.
 
-## Define How Your Blockchain Starts
+## Define how your blockchain starts
 
 Flags for the `starport chain serve` command determine how your blockchain starts. All flags are optional.
 
-`--config`, default is `config.yml`
+`--config`
 
-Custom configuration file. Using unique configuration files is required to launch two blockchains on the same machine from the same source code.
+Custom configuration file. Using unique configuration files is required to launch two blockchains on the same machine from the same source code. When omitted, the default is `config.yml`.
 
 `--reset-once`
 
@@ -64,13 +64,13 @@ Reset state on every file change. Do not import state and turn off state persist
 
 `--verbose`
 
-Enters verbose detailed mode with extensive logging.
+Enter verbose detailed mode with extensive logging.
 
 `--home`
 
-Specify a custom home directory.
+Specify a custom home directory. 
 
-## Start a Blockchain Node in Production
+## Start a blockchain node in production
 
 The `starport chain serve` and `starport chain build` commands compile the source code of the chain in a binary file and install the binary in `~/go/bin`. By default, the binary name is the name of the repository appended with `d`. For example, if you scaffold a chain using `starport scaffold chain github.com/alice/chain`, then the binary is named `chaind`.
 

--- a/docs/kb/simapp.md
+++ b/docs/kb/simapp.md
@@ -4,17 +4,17 @@ description: Test different scenarios for your chain.
 
 ---
 
-# Chain Simulation
+# Chain simulation
 
-The Starport chain simulator can help you to run your chain based in randomized inputs for you can make fuzz testing and also benchmark test for your chain, simulating the messages, blocks, and accounts. You can scaffold a template to perform simulation testing in each module along with a boilerplate simulation methods for each scaffolded message.
+The Starport chain simulator can help you to run your chain based on randomized inputs so you can conduct fuzz testing. You can also conduct benchmark tests for your chain, simulating the messages, blocks, and accounts. You can scaffold a template to perform simulation testing in each module along with boilerplate simulation methods for each scaffolded message.
 
-## Module Simulation
+## Module simulation
 
 Every new module that is scaffolded with Starport implements the Cosmos SDK [Module Simulation](https://docs.cosmos.network/master/building-modules/simulator.html). 
 
 - Each new message creates a file with the simulation methods required for the tests. 
-- Scaffolding a `CRUD` like a `list` or `map` creates a simulation file with `create`, `update`, and `delete` simulation methods in the `x/<module>/simulation` folder and registers these methods in `x/<module>/module_simulation.go`. 
-- Scaffolding a single message creates an empty simulation method to be implemented by the user. 
+- Scaffolding a `CRUD` type like a `list` or `map` creates a simulation file with `create`, `update`, and `delete` simulation methods in the `x/<module>/simulation` folder and registers these methods in `x/<module>/module_simulation.go`. 
+- Scaffolding a single message creates an empty simulation method to be implemented by the user.
 
 We recommend that you maintain the simulation methods for each new modification into the message keeper methods.
 
@@ -22,7 +22,7 @@ Every simulation is weighted because the sender of the operation is assigned ran
 
 For better randomizations, you can define a random seed. The simulation with the same random seed is deterministic with the same output.
 
-## Scaffold a Simulation
+## Scaffold a simulation
 
 To create a new chain:
 
@@ -64,7 +64,7 @@ The default `go test` command works to run the simulation:
 go test -v -benchmem -run=^$ -bench ^BenchmarkSimulation -cpuprofile cpu.out ./app -Commit=true
 ```
 
-### Skip Message
+### Skip message
 
 Use logic to avoid sending a message without returning an error. Return only `simtypes.NoOpMsg(...)` into the simulation message handler.
 
@@ -80,10 +80,11 @@ After the parameters are scaffolded, change the `x/<module>/module_simulation.go
 
 ## Invariants
 
-Simulating a chain can help you prevent [chain invariants errors](https://docs.cosmos.network/master/building-modules/invariants.html); an invariant is a function called by the chain to check if something broke, invalidating the chain data.
-To create a new invariant and check the chain integrity, you should create a method to validate the invariants and register all invariants.
+Simulating a chain can help you prevent [chain invariants errors](https://docs.cosmos.network/master/building-modules/invariants.html). An invariant is a function called by the chain to check if something broke, invalidating the chain data.
+To create a new invariant and check the chain integrity, you must create a method to validate the invariants and register all invariants.
 
-e.g.: `x/earth/keeper/invariants.go`
+For example, in `x/earth/keeper/invariants.go`:
+
 ```go
 package keeper
 
@@ -120,7 +121,7 @@ func ZeroLaunchTimestampInvariant(k Keeper) sdk.Invariant {
 }
 ```
 
-Now you register the keeper invariants into the `x/earth/module.go`:
+Now, register the keeper invariants into the `x/earth/module.go` file:
 
 ```go
 // RegisterInvariants registers the capability module's invariants.

--- a/docs/kb/types.md
+++ b/docs/kb/types.md
@@ -3,11 +3,11 @@ order: 6
 description: Reference list of supported types. 
 ---
 
-# Starport Supported Types
+# Starport supported types
 
-Types with CRUD operations are scaffolded with the `starport scaffold` command. 
+Types with CRUD operations are scaffolded with the `starport scaffold` command.
 
-## Built-in Types
+## Built-in types
 
 | Type         | Alias    | Index | Code Type   | Description                     |
 | ------------ | -------- | ----- | ----------- | ------------------------------- |
@@ -21,11 +21,11 @@ Types with CRUD operations are scaffolded with the `starport scaffold` command.
 | coin         | -        | no    | sdk.Coin    | Cosmos SDK coin type            |
 | array.coin   | coins    | no    | sdk.Coins   | List of Cosmos SDK coin types   |
 
-You cannot use some types as an index, like the map and list indexes and module params.
+Some types cannot be used an index, like the map and list indexes and module params.
 
-## Custom Types
+## Custom types
 
-You can create custom types and then use the custom type later. 
+You can create custom types and then use the custom type later.
 
 For example, you can create a `list` type called `user` and then use the `user` type in a subsequent `starport scaffold` command.
 
@@ -41,7 +41,7 @@ Now you can scaffold a message using the `CoordinatorDescription` type:
 starport scaffold message add-coordinator address:string description:CoordinatorDescription
 ```
 
-Run the chain and then send the message using the CLI. 
+Run the chain and then send the message using the CLI.
 
 To pass the custom type in JSON format:
 


### PR DESCRIPTION
We have a variety of compliance with the Title Case heading style we inherited from the Cosmos SDK docs and tutorials.

This PR changes our Titles and Headings to use Sentence case to establish a convention before we start adding more Starport Network docs 

We'll follow these guidelines:

> In document titles and headings, use sentence case. That is, capitalize only the first word in the title, the first word in a subheading after a colon, and any proper nouns or other terms that are always capitalized a certain way.

> Use sentence case for all the elements in a table: contents, headings, labels, and captions.

https://developers.google.com/style/capitalization?hl=en#capitalization-in-titles-and-headings

Scope: Knowledge Base articles