### PR TITLE
docs(migration): improve v0.19.2 upgrade guideline 

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -15,7 +15,7 @@ With Starport v0.19.2, the contents of the deprecated Starport Modules `tendermi
 
 To migrate your chain that was scaffolded with Starport versions lower than v0.19.2: 
 
-1. IBC upgrade: Apply the changes that are introduced in PR [#1975](https://github.com/tendermint/starport/pull/1975/files) to your chain.
+1. IBC upgrade: Use the [IBC migration documents](https://github.com/cosmos/ibc-go/blob/main/docs/migrations/v1-to-v2.md)
    
 2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown: 
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -19,8 +19,8 @@ To migrate your chain that was scaffolded with Starport versions lower than v0.1
    
 2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown: 
 
-    - `spm/ibckeeper` moved to `pkg/cosmosibckeeper`
-    - `spm/cosmoscmd` moved to `pkg/cosmoscmd` 
-    - `spm/openapiconsole` moved to `pkg/openapiconsole`
-    - `testutil/sample` moved to `cosmostestutil/sample`
+    - `github.com/tendermint/spm/ibckeeper` moved to `github.com/tendermint/starport/pkg/cosmosibckeeper`
+    - `github.com/tendermint/spm/cosmoscmd` moved to `github.com/tendermint/starport/pkg/cosmoscmd` 
+    - `github.com/tendermint/spm/openapiconsole` moved to `github.com/tendermint/starport/pkg/openapiconsole`
+    - `github.com/tendermint/spm/testutil/sample` moved to `github.com/tendermint/starport/cosmostestutil/sample`
 


### PR DESCRIPTION
IBC-go provides really great migration docs, best to link them instead of linking to the PR that changes the template.