### PR TITLE
fix(codegen): adjust Go's camelCasing for templates to match JS' 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
+	github.com/takuoki/gocase v1.0.0 // indirect
 	github.com/tendermint/flutter/v2 v2.0.3
 	github.com/tendermint/spn v0.1.1-0.20220125123630-1268765f1209
 	github.com/tendermint/tendermint v0.34.14

--- a/go.sum
+++ b/go.sum
@@ -1491,6 +1491,8 @@ github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca h1:Ld/zXl5t4+D69SiV4JoN7kkfvJdOWlPpfxrzxpLMoUk=
 github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
+github.com/takuoki/gocase v1.0.0 h1:gPwLJTWVm2T1kUiCsKirg/faaIUGVTI0FA3SYr75a44=
+github.com/takuoki/gocase v1.0.0/go.mod h1:QgOKJrbuJoDrtoKswBX1/Dw8mJrkOV9tbQZJaxaJ6zc=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=

--- a/starport/pkg/cosmosgen/template.go
+++ b/starport/pkg/cosmosgen/template.go
@@ -48,7 +48,8 @@ func (t templateWriter) Write(destDir, protoPath string, data interface{}) error
 	}
 
 	funcs := template.FuncMap{
-		"camelCase": func(word string) string {
+		"camelCase": strcase.ToLowerCamel,
+		"camelCaseSta": func(word string) string {
 			return gocase.Revert(strcase.ToLowerCamel(word))
 		},
 		"resolveFile": func(fullPath string) string {

--- a/starport/pkg/cosmosgen/template.go
+++ b/starport/pkg/cosmosgen/template.go
@@ -8,6 +8,7 @@ import (
 	"text/template"
 
 	"github.com/iancoleman/strcase"
+	"github.com/takuoki/gocase"
 )
 
 var (
@@ -47,7 +48,9 @@ func (t templateWriter) Write(destDir, protoPath string, data interface{}) error
 	}
 
 	funcs := template.FuncMap{
-		"camelCase": strcase.ToLowerCamel,
+		"camelCase": func(word string) string {
+			return gocase.Revert(strcase.ToLowerCamel(word))
+		},
 		"resolveFile": func(fullPath string) string {
 			rel, _ := filepath.Rel(protoPath, fullPath)
 			rel = strings.TrimSuffix(rel, ".proto")

--- a/starport/pkg/cosmosgen/templates/vuex/store/index.ts.tpl
+++ b/starport/pkg/cosmosgen/templates/vuex/store/index.ts.tpl
@@ -126,7 +126,7 @@ export default {
 			try {
 				const key = params ?? {};
 				const queryClient=await initQueryClient(rootGetters)
-				let value= (await queryClient.{{ camelCase $FullName -}}
+				let value= (await queryClient.{{ camelCaseSta $FullName -}}
 				{{- $n -}}(
 					{{- range $j,$a :=$rule.Params -}}
 						{{- if (gt $j 0) -}}, {{ end }} key.{{ $a -}}
@@ -143,7 +143,7 @@ export default {
 				
 					{{ if $rule.HasQuery }}
 				while (all && (<any> value).pagination && (<any> value).pagination.next_key!=null) {
-					let next_values=(await queryClient.{{ camelCase $FullName -}}
+					let next_values=(await queryClient.{{ camelCaseSta $FullName -}}
 					{{- $n -}}(
 						{{- range $j,$a :=$rule.Params }} key.{{$a}}, {{ end -}}{...query, 'pagination.key':(<any> value).pagination.next_key}
 						{{- if $rule.HasBody -}}, {...key}


### PR DESCRIPTION
The `swagger-typescript-api` library used to generate the API class when generating vuex/js code uses a different ruleset for camelCasing than `strcase` in golang.

This PR uses `https://github.com/takuoki/gocase` to revert Go's common initialisms in order for resulting strings to match.