### PR TITLE
fix(`network chain list`): printing chain spinner bug

### DIFF
--- a/starport/cmd/network_chain_list.go
+++ b/starport/cmd/network_chain_list.go
@@ -41,7 +41,6 @@ func networkChainListHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer nb.Cleanup()
 
 	nb.Spinner.Stop()
 
@@ -53,6 +52,8 @@ func networkChainListHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	nb.Cleanup()
 	return renderLaunchSummaries(chainLaunches, os.Stdout)
 }
 

--- a/starport/cmd/network_request_list.go
+++ b/starport/cmd/network_request_list.go
@@ -34,7 +34,6 @@ func networkRequestListHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer nb.Cleanup()
 
 	// parse launch ID
 	launchID, err := network.ParseLaunchID(args[0])
@@ -52,7 +51,7 @@ func networkRequestListHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	nb.Spinner.Stop()
+	nb.Cleanup()
 	return renderRequestSummaries(requests, os.Stdout)
 }
 

--- a/starport/services/network/queries.go
+++ b/starport/services/network/queries.go
@@ -21,8 +21,6 @@ func (n Network) ChainLaunch(ctx context.Context, id uint64) (networktypes.Chain
 		return networktypes.ChainLaunch{}, cosmoserror.Unwrap(err)
 	}
 
-	n.ev.Send(events.New(events.StatusOngoing, "Chain information fetched"))
-
 	return networktypes.ToChainLaunch(res.Chain), nil
 }
 


### PR DESCRIPTION
Remove the `Fetching chain information...` that appears sometimes when list chains

Solution: call `cleanup` of network builder utility before rendering chain list