### PR TITLE
docs: fix v0.19.2 migration Github import paths

### DIFF
--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -19,7 +19,7 @@ To migrate your chain that was scaffolded with Starport versions lower than v0.1
    
 2. In your chain's `go.mod` file, remove `tendermint/spm` and add the v0.19.2 version of `tendermint/starport`. If your chain uses these packages, change the import paths as shown: 
 
-    - `github.com/tendermint/spm/ibckeeper` moved to `github.com/tendermint/starport/pkg/cosmosibckeeper`
-    - `github.com/tendermint/spm/cosmoscmd` moved to `github.com/tendermint/starport/pkg/cosmoscmd` 
-    - `github.com/tendermint/spm/openapiconsole` moved to `github.com/tendermint/starport/pkg/openapiconsole`
-    - `github.com/tendermint/spm/testutil/sample` moved to `github.com/tendermint/starport/cosmostestutil/sample`
+    - `github.com/tendermint/spm/ibckeeper` moved to `github.com/tendermint/starport/starport/pkg/cosmosibckeeper`
+    - `github.com/tendermint/spm/cosmoscmd` moved to `github.com/tendermint/starport/starport/pkg/cosmoscmd` 
+    - `github.com/tendermint/spm/openapiconsole` moved to `github.com/tendermint/starport/starport/pkg/openapiconsole`
+    - `github.com/tendermint/spm/testutil/sample` moved to `github.com/tendermint/starport/starport/pkg/cosmostestutil/sample`


### PR DESCRIPTION
Noticed incorrect Github imports path in Starport v0.19.2 migration doc. Fixed it.