### PR TITLE
docs(install): remove TOC, add M1 sudo, minor install doc improvements

### DIFF
--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -60,7 +60,7 @@ Then run this command to move the `starport` executable to `/usr/local/bin/`:
 sudo mv starport /usr/local/bin/
 ```
 
-On some M1 chip machines, a permissions error occurs:
+On some machines, a permissions error occurs:
 
 ```bash
 mv: rename ./starport to /usr/local/bin/starport: Permission denied

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -3,17 +3,6 @@ order: 1
 description: Steps to install Starport on your local computer.
 ---
 
-[Install Starport](#install-starport)
-    - [Operating Systems](#operating-systems)
-    - [Go](#go)
-  - [Verify Your Starport Version](#verify-your-starport-version)
-  - [Installing Starport](#installing-starport)
-    - [Write permission](#write-permission)
-  - [Upgrading Your Starport Installation](#upgrading-your-starport-installation)
-  - [Installing Starport on macOS with Homebrew](#installing-starport-on-macos-with-homebrew)
-  - [Build from source](#build-from-source)
-  - [Summary](#summary)
-
 # Install Starport
 
 You can run [Starport](https://github.com/tendermint/starport) in a web-based Gitpod IDE or you can install Starport on your local computer.
@@ -22,7 +11,7 @@ You can run [Starport](https://github.com/tendermint/starport) in a web-based Gi
 
 Be sure you have met the prerequisites before you install and use Starport.
 
-### Operating Systems
+### Operating systems
 
 Starport is supported for the following operating systems:
 
@@ -37,7 +26,7 @@ Starport is written in the Go programming language. To use Starport on a local s
 - Install [Go](https://golang.org/doc/install) (**version 1.16** or higher)
 - Ensure the Go environment variables are [set properly](https://golang.org/doc/gopath_code#GOPATH) on your system
 
-## Verify Your Starport Version
+## Verify your Starport version
 
 To verify the version of Starport you have installed, run the following command:
 
@@ -55,9 +44,9 @@ curl https://get.starport.network/starport! | bash
 
 This command invokes `curl` to download the install script and pipes the output to `bash` to perform the installation. The `starport` binary is installed in `/usr/local/bin`.
 
-To learn more or customize the installation process, see [Starport installer docs](https://github.com/allinbits/starport-installer) on GitHub.
+To learn more or customize the installation process, see the [installer docs](https://github.com/allinbits/starport-installer) on GitHub.
 
-### Write Permission
+### Write permission
 
 Starport installation requires write permission to the `/usr/local/bin/` directory. If the installation fails because you do not have write permission to `/usr/local/bin/`, run the following command:
 
@@ -71,7 +60,21 @@ Then run this command to move the `starport` executable to `/usr/local/bin/`:
 sudo mv starport /usr/local/bin/
 ```
 
-## Upgrading Your Starport Installation
+On some M1 chip machines, a permissions error occurs:
+
+```bash
+mv: rename ./starport to /usr/local/bin/starport: Permission denied
+============
+Error: mv failed
+```
+
+In this case, use sudo before `curl` and before `bash`:
+
+```bash
+sudo curl https://get.starport.network/starport! | sudo bash
+```
+
+## Upgrading your Starport installation
 
 Before you install a new version of Starport, remove all existing Starport installations.
 
@@ -82,11 +85,13 @@ To remove the current Starport installation:
    Depending on your user permissions, run the command with or without `sudo`.
 1. Repeat this step until all `starport` installations are removed from your system.
 
-After all existing Starport installations are removed, follow the [Installing Starport with cURL](#installing-starport-with-curl) instructions. For details on version features and changes, see the [changelog.md](https://github.com/tendermint/starport/blob/develop/changelog.md) in the repo.
+After all existing Starport installations are removed, follow the  [Installing Starport](#installing-starport) instructions. 
+
+For details on version features and changes, see the [changelog.md](https://github.com/tendermint/starport/blob/develop/changelog.md) in the repo.
 
 ## Installing Starport on macOS with Homebrew
 
-Using brew to install Starport is supported only for macOS machines without the M1 chip.
+Using `brew` to install Starport is supported only for macOS machines without the M1 chip.
 
 ```bash
 brew install tendermint/tap/starport


### PR DESCRIPTION
Thanks Waleed for working through sudo for curl and for bash to install Starport on an M1 chip machine
Thanks @nassdonald  for reporting the redundant TOC in the install doc

Docs are updated