### PR TITLE
chore(CI/Makefile): update the `golint` and add `go import` to the make command

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -29,6 +29,6 @@ jobs:
         if: env.GIT_DIFF
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.37
+          version: v1.41
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,7 +17,7 @@ linters:
     - gocritic
     - gofmt
     - goimports
-    - golint
+    - revive
     # - gosec
     - gosimple
     - govet

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ govet:
 format:
 	@echo Formatting...
 	@find . $(FIND_ARGS) | xargs gofmt -d -s
-	@find . $(FIND_ARGS) | xargs goimports -w -local github.com/tendermint/spn
+	@find . $(FIND_ARGS) | xargs goimports -w -local github.com/tendermint/starport
 
 ## lint: Run Golang CI Lint.
 lint:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # Project variables.
 PROJECT_NAME = starport
 DATE := $(shell date '+%Y-%m-%dT%H:%M:%S')
+FIND_ARGS := -name '*.go' -type f -not -name '*.pb.go'
 HEAD = $(shell git rev-parse HEAD)
 LD_FLAGS = -X github.com/tendermint/starport/starport/internal/version.Head='$(HEAD)' \
 	-X github.com/tendermint/starport/starport/internal/version.Date='$(DATE)'
@@ -35,7 +36,8 @@ govet:
 ## format: Run gofmt.
 format:
 	@echo Formatting...
-	@find . -name '*.go' -type f | xargs gofmt -d -s
+	@find . $(FIND_ARGS) | xargs gofmt -d -s
+	@find . $(FIND_ARGS) | xargs goimports -w -local github.com/tendermint/spn
 
 ## lint: Run Golang CI Lint.
 lint:


### PR DESCRIPTION
## Description

- Add a step in the `make format` step to run `goimports` along with the existing step of running `gofmt`.
- Changes the `golint` linter to `revive` and upgrades the lint CI tool version to v1.41.0. 

_Based on @aljo242 suggestion into the `spn` (https://github.com/tendermint/spn/pull/509 / https://github.com/tendermint/spn/pull/510)_

