### PR TITLE
creates `network campaign account list [campaign-id]` command

### DIFF
--- a/starport/cmd/network.go
+++ b/starport/cmd/network.go
@@ -61,6 +61,7 @@ func NewNetwork() *cobra.Command {
 	c.AddCommand(
 		NewNetworkChain(),
 		NewNetworkRequest(),
+		NewNetworkCampaign(),
 	)
 
 	return c

--- a/starport/cmd/network_campaign.go
+++ b/starport/cmd/network_campaign.go
@@ -1,0 +1,20 @@
+package starportcmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewNetworkCampaign creates a new campaign command that holds some other
+// sub commands related to launching a network for a campaign.
+func NewNetworkCampaign() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "campaign",
+		Short: "Handle campaigns",
+	}
+
+	c.AddCommand(
+		NewNetworkCampaignAccount(),
+	)
+
+	return c
+}

--- a/starport/cmd/network_campaign_account.go
+++ b/starport/cmd/network_campaign_account.go
@@ -1,0 +1,103 @@
+package starportcmd
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/tendermint/starport/starport/pkg/entrywriter"
+)
+
+var (
+	campaignMainnetsAccSummaryHeader = []string{"Mainnet Account", "Shares"}
+	campaignVestingAccSummaryHeader  = []string{"Vesting Account", "Total Shares", "Vesting", "EndTime"}
+)
+
+// NewNetworkCampaignAccount creates a new campaign account command that holds some other
+// sub commands related to account for a campaign.
+func NewNetworkCampaignAccount() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "account",
+		Short: "Handle campaign accounts",
+	}
+
+	c.AddCommand(
+		newNetworkCampaignAccountList(),
+	)
+	c.PersistentFlags().AddFlagSet(flagNetworkFrom())
+	c.PersistentFlags().AddFlagSet(flagSetKeyringBackend())
+
+	return c
+}
+
+func newNetworkCampaignAccountList() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "list [campaign-id]",
+		Short: "Show all mainnet and mainnet vesting of the campaign",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			nb, campaignID, err := networkChainLaunch(cmd, args)
+			if err != nil {
+				return err
+			}
+			defer nb.Cleanup()
+			n, err := nb.Network()
+			if err != nil {
+				return err
+			}
+
+			accountSummary := bytes.NewBufferString("")
+
+			// get all campaign mainnet accounts
+			mainnetAccs, err := n.MainnetAccounts(cmd.Context(), campaignID)
+			if err != nil {
+				return err
+			}
+			mainnetAccEntries := make([][]string, 0)
+			for _, acc := range mainnetAccs {
+				mainnetAccEntries = append(mainnetAccEntries, []string{
+					acc.Address,
+					acc.Shares,
+				})
+			}
+			if len(mainnetAccEntries) > 0 {
+				if err = entrywriter.MustWrite(
+					accountSummary,
+					campaignMainnetsAccSummaryHeader,
+					mainnetAccEntries...,
+				); err != nil {
+					return err
+				}
+			}
+
+			// get all campaign vesting accounts
+			vestingAccs, err := n.MainnetVestingAccounts(cmd.Context(), campaignID)
+			if err != nil {
+				return err
+			}
+			mainnetVestingAccEntries := make([][]string, 0)
+			for _, acc := range vestingAccs {
+				mainnetVestingAccEntries = append(mainnetVestingAccEntries, []string{
+					acc.Address,
+					acc.TotalShares,
+					acc.Vesting,
+					strconv.FormatInt(acc.EndTime, 10),
+				})
+			}
+			if len(mainnetVestingAccEntries) > 0 {
+				if err = entrywriter.MustWrite(
+					accountSummary,
+					campaignVestingAccSummaryHeader,
+					mainnetVestingAccEntries...,
+				); err != nil {
+					return err
+				}
+			}
+			nb.Spinner.Stop()
+			fmt.Print(accountSummary.String())
+			return nil
+		},
+	}
+	return c
+}

--- a/starport/services/network/networktypes/campaign.go
+++ b/starport/services/network/networktypes/campaign.go
@@ -1,0 +1,41 @@
+package networktypes
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	campaigntypes "github.com/tendermint/spn/x/campaign/types"
+)
+
+// MainnetAccount represents the campaign mainnet account of a chain on SPN
+type MainnetAccount struct {
+	Address string `json:"Address"`
+	Shares  string `json:"Shares"`
+}
+
+// ToMainnetAccount converts a mainnet account data from SPN and returns a MainnetAccount object
+func ToMainnetAccount(acc campaigntypes.MainnetAccount) MainnetAccount {
+	launch := MainnetAccount{
+		Address: acc.Address,
+		Shares:  sdk.Coins(acc.Shares).String(),
+	}
+	return launch
+}
+
+// MainnetVestingAccount represents the campaign mainnet vesting account of a chain on SPN
+type MainnetVestingAccount struct {
+	Address     string `json:"Address"`
+	TotalShares string `json:"TotalShares"`
+	Vesting     string `json:"Vesting"`
+	EndTime     int64  `json:"EndTime"`
+}
+
+// ToMainnetVestingAccount converts a mainnet vesting account data from SPN and returns a MainnetVestingAccount object
+func ToMainnetVestingAccount(acc campaigntypes.MainnetVestingAccount) MainnetVestingAccount {
+	delaydVesting := acc.VestingOptions.GetDelayedVesting()
+	launch := MainnetVestingAccount{
+		Address:     acc.Address,
+		TotalShares: sdk.Coins(delaydVesting.TotalShares).String(),
+		Vesting:     sdk.Coins(delaydVesting.Vesting).String(),
+		EndTime:     delaydVesting.EndTime,
+	}
+	return launch
+}

--- a/starport/services/network/queries.go
+++ b/starport/services/network/queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	campaigntypes "github.com/tendermint/spn/x/campaign/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/services/network/networktypes"
@@ -115,4 +116,38 @@ func (n Network) GenesisValidators(ctx context.Context, launchID uint64) (genVal
 	}
 
 	return genVals, nil
+}
+
+// MainnetAccounts returns the list of campaign mainnet accounts for a launch from SPN
+func (n Network) MainnetAccounts(ctx context.Context, campaignID uint64) (genAccs []networktypes.MainnetAccount, err error) {
+	n.ev.Send(events.New(events.StatusOngoing, "Fetching campaign mainnet accounts"))
+	res, err := campaigntypes.NewQueryClient(n.cosmos.Context).MainnetAccountAll(ctx, &campaigntypes.QueryAllMainnetAccountRequest{
+		CampaignID: campaignID,
+	})
+	if err != nil {
+		return genAccs, err
+	}
+
+	for _, acc := range res.MainnetAccount {
+		genAccs = append(genAccs, networktypes.ToMainnetAccount(acc))
+	}
+
+	return genAccs, nil
+}
+
+// MainnetVestingAccounts returns the list of campaign mainnet vesting accounts for a launch from SPN
+func (n Network) MainnetVestingAccounts(ctx context.Context, campaignID uint64) (genAccs []networktypes.MainnetVestingAccount, err error) {
+	n.ev.Send(events.New(events.StatusOngoing, "Fetching campaign mainnet vesting accounts"))
+	res, err := campaigntypes.NewQueryClient(n.cosmos.Context).MainnetVestingAccountAll(ctx, &campaigntypes.QueryAllMainnetVestingAccountRequest{
+		CampaignID: campaignID,
+	})
+	if err != nil {
+		return genAccs, err
+	}
+
+	for _, acc := range res.MainnetVestingAccount {
+		genAccs = append(genAccs, networktypes.ToMainnetVestingAccount(acc))
+	}
+
+	return genAccs, nil
 }


### PR DESCRIPTION
close #2069

## Description

Creates `starport network campaign account list [campaign-id]` command to list all accounts added to a campaign

### How to test

- Choose a campaign already launched and run
```shell
starport network --nightly campaign account list [champaign-id]
```