### PR TITLE
chore: run `goimports`

### DIFF
--- a/integration/app/cmd_app_test.go
+++ b/integration/app/cmd_app_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/integration"
+
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 

--- a/integration/app/cmd_ibc_test.go
+++ b/integration/app/cmd_ibc_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/tendermint/starport/integration"
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 

--- a/integration/app/cmd_serve_test.go
+++ b/integration/app/cmd_serve_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/integration"
+
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 

--- a/integration/app/config_test.go
+++ b/integration/app/config_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/integration"
+
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/chainconfig"
 	"github.com/tendermint/starport/starport/pkg/confile"
 	"github.com/tendermint/starport/starport/pkg/randstr"

--- a/integration/app/tx_test.go
+++ b/integration/app/tx_test.go
@@ -8,12 +8,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/tendermint/starport/integration"
 	"net/http"
 	"testing"
 
+	envtest "github.com/tendermint/starport/integration"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/randstr"

--- a/integration/env.go
+++ b/integration/env.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/chainconfig"
 	"github.com/tendermint/starport/starport/pkg/availableport"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"

--- a/integration/faucet/faucet_test.go
+++ b/integration/faucet/faucet_test.go
@@ -12,11 +12,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
 	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
 	"github.com/tendermint/starport/starport/pkg/xurl"
-	"golang.org/x/sync/errgroup"
 )
 
 const (

--- a/integration/other_components/cmd_query_test.go
+++ b/integration/other_components/cmd_query_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/tendermint/starport/integration"
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 

--- a/integration/single/cmd_singleton_test.go
+++ b/integration/single/cmd_singleton_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/tendermint/starport/integration"
+	envtest "github.com/tendermint/starport/integration"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 

--- a/starport/chainconfig/config.go
+++ b/starport/chainconfig/config.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/imdario/mergo"
+
 	"github.com/tendermint/starport/starport/pkg/xfilepath"
 )
 

--- a/starport/cmd/account.go
+++ b/starport/cmd/account.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/entrywriter"

--- a/starport/cmd/account_create.go
+++ b/starport/cmd/account_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/account_delete.go
+++ b/starport/cmd/account_delete.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/account_export.go
+++ b/starport/cmd/account_export.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/account_import.go
+++ b/starport/cmd/account_import.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cosmos/go-bip39"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )

--- a/starport/cmd/account_list.go
+++ b/starport/cmd/account_list.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/account_show.go
+++ b/starport/cmd/account_show.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/chain_build.go
+++ b/starport/cmd/chain_build.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/chain_faucet.go
+++ b/starport/cmd/chain_faucet.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/chain_init.go
+++ b/starport/cmd/chain_init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/chain_serve.go
+++ b/starport/cmd/chain_serve.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/chain"
 )
 

--- a/starport/cmd/chain_simulate.go
+++ b/starport/cmd/chain_simulate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/chain"
 )
 

--- a/starport/cmd/cmd.go
+++ b/starport/cmd/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
 	"github.com/tendermint/starport/starport/internal/version"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"

--- a/starport/cmd/docs.go
+++ b/starport/cmd/docs.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/docs"
 	"github.com/tendermint/starport/starport/pkg/localfs"
 	"github.com/tendermint/starport/starport/pkg/markdownviewer"

--- a/starport/cmd/generate_dart.go
+++ b/starport/cmd/generate_dart.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/generate_go.go
+++ b/starport/cmd/generate_go.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/generate_openapi.go
+++ b/starport/cmd/generate_openapi.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/generate_vuex.go
+++ b/starport/cmd/generate_vuex.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/chain"
 )

--- a/starport/cmd/network.go
+++ b/starport/cmd/network.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"

--- a/starport/cmd/network_chain_init.go
+++ b/starport/cmd/network_chain_init.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"

--- a/starport/cmd/network_chain_join.go
+++ b/starport/cmd/network_chain_join.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rdegges/go-ipify"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/gitpod"

--- a/starport/cmd/network_chain_launch.go
+++ b/starport/cmd/network_chain_launch.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/network"
 )
 

--- a/starport/cmd/network_chain_list.go
+++ b/starport/cmd/network_chain_list.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/entrywriter"
 	"github.com/tendermint/starport/starport/services/network/networktypes"

--- a/starport/cmd/network_chain_prepare.go
+++ b/starport/cmd/network_chain_prepare.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/network"
 	"github.com/tendermint/starport/starport/services/network/networkchain"
 )

--- a/starport/cmd/network_chain_publish.go
+++ b/starport/cmd/network_chain_publish.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/network"
 	"github.com/tendermint/starport/starport/services/network/networkchain"

--- a/starport/cmd/network_chain_show.go
+++ b/starport/cmd/network_chain_show.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/entrywriter"
 	"github.com/tendermint/starport/starport/pkg/yaml"

--- a/starport/cmd/network_request_approve.go
+++ b/starport/cmd/network_request_approve.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/numbers"
 	"github.com/tendermint/starport/starport/services/network"

--- a/starport/cmd/network_request_list.go
+++ b/starport/cmd/network_request_list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/entrywriter"
 	"github.com/tendermint/starport/starport/services/network"
 )

--- a/starport/cmd/network_request_reject.go
+++ b/starport/cmd/network_request_reject.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/numbers"
 	"github.com/tendermint/starport/starport/services/network"

--- a/starport/cmd/network_request_show.go
+++ b/starport/cmd/network_request_show.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/yaml"
 	"github.com/tendermint/starport/starport/services/network"
 )

--- a/starport/cmd/network_request_verify.go
+++ b/starport/cmd/network_request_verify.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/numbers"

--- a/starport/cmd/relayer.go
+++ b/starport/cmd/relayer.go
@@ -3,6 +3,7 @@ package starportcmd
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 )
 

--- a/starport/cmd/relayer_configure.go
+++ b/starport/cmd/relayer_configure.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gookit/color"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cliquiz"
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"

--- a/starport/cmd/relayer_connect.go
+++ b/starport/cmd/relayer_connect.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/relayer"

--- a/starport/cmd/scaffold.go
+++ b/starport/cmd/scaffold.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/services/scaffolder"

--- a/starport/cmd/scaffold_band.go
+++ b/starport/cmd/scaffold_band.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/services/scaffolder"

--- a/starport/cmd/scaffold_chain.go
+++ b/starport/cmd/scaffold_chain.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/services/scaffolder"

--- a/starport/cmd/scaffold_flutter.go
+++ b/starport/cmd/scaffold_flutter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )

--- a/starport/cmd/scaffold_list.go
+++ b/starport/cmd/scaffold_list.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )
 

--- a/starport/cmd/scaffold_map.go
+++ b/starport/cmd/scaffold_map.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )
 

--- a/starport/cmd/scaffold_message.go
+++ b/starport/cmd/scaffold_message.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/services/scaffolder"

--- a/starport/cmd/scaffold_module.go
+++ b/starport/cmd/scaffold_module.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/validation"

--- a/starport/cmd/scaffold_mwasm.go
+++ b/starport/cmd/scaffold_mwasm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 )

--- a/starport/cmd/scaffold_package.go
+++ b/starport/cmd/scaffold_package.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/services/scaffolder"

--- a/starport/cmd/scaffold_query.go
+++ b/starport/cmd/scaffold_query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 )

--- a/starport/cmd/scaffold_single.go
+++ b/starport/cmd/scaffold_single.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )
 

--- a/starport/cmd/scaffold_type.go
+++ b/starport/cmd/scaffold_type.go
@@ -2,6 +2,7 @@ package starportcmd
 
 import (
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )
 

--- a/starport/cmd/scaffold_vue.go
+++ b/starport/cmd/scaffold_vue.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/clispinner"
 	"github.com/tendermint/starport/starport/services/scaffolder"
 )

--- a/starport/cmd/tools.go
+++ b/starport/cmd/tools.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/nodetime"

--- a/starport/cmd/version.go
+++ b/starport/cmd/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/internal/version"
 )
 

--- a/starport/internal/tools/gen-cli-docs/main.go
+++ b/starport/internal/tools/gen-cli-docs/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+
 	starportcmd "github.com/tendermint/starport/starport/cmd"
 )
 

--- a/starport/internal/version/version.go
+++ b/starport/internal/version/version.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/v37/github"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/exec"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/gitpod"

--- a/starport/pkg/chaincmd/runner/chain.go
+++ b/starport/pkg/chaincmd/runner/chain.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/cosmosver"

--- a/starport/pkg/chaincmd/runner/runner.go
+++ b/starport/pkg/chaincmd/runner/runner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"

--- a/starport/pkg/chaincmd/runner/simulate.go
+++ b/starport/pkg/chaincmd/runner/simulate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/cosmos/cosmos-sdk/types/simulation"
+
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 )
 

--- a/starport/pkg/cmdrunner/cmdrunner.go
+++ b/starport/pkg/cmdrunner/cmdrunner.go
@@ -7,9 +7,10 @@ import (
 	"os"
 	"os/exec"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/goenv"
-	"golang.org/x/sync/errgroup"
 )
 
 // Runner is an object to run commands

--- a/starport/pkg/cmdrunner/exec/exec.go
+++ b/starport/pkg/cmdrunner/exec/exec.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )

--- a/starport/pkg/cosmosanalysis/app/app_test.go
+++ b/starport/pkg/cosmosanalysis/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/app"
 )
 

--- a/starport/pkg/cosmosanalysis/cosmosanalysis_test.go
+++ b/starport/pkg/cosmosanalysis/cosmosanalysis_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosanalysis"
 )
 

--- a/starport/pkg/cosmosanalysis/module/module_test.go
+++ b/starport/pkg/cosmosanalysis/module/module_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/protoanalysis"
 )
 

--- a/starport/pkg/cosmosclient/cosmosclient.go
+++ b/starport/pkg/cosmosclient/cosmosclient.go
@@ -28,9 +28,10 @@ import (
 	proto "github.com/gogo/protobuf/proto"
 	prototypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
-	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )
 
 // FaucetTransferEnsureDuration is the duration that BroadcastTx will wait when a faucet transfer

--- a/starport/pkg/cosmoscmd/proxy.go
+++ b/starport/pkg/cosmoscmd/proxy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/ctxticker"
 	"github.com/tendermint/starport/starport/pkg/gitpod"

--- a/starport/pkg/cosmosfaucet/cosmosfaucet.go
+++ b/starport/pkg/cosmosfaucet/cosmosfaucet.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 )
 

--- a/starport/pkg/cosmosfaucet/http.go
+++ b/starport/pkg/cosmosfaucet/http.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
+
 	"github.com/tendermint/starport/starport/pkg/openapiconsole"
 )
 

--- a/starport/pkg/cosmosfaucet/http_faucet.go
+++ b/starport/pkg/cosmosfaucet/http_faucet.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/tendermint/starport/starport/pkg/xhttp"
 )
 

--- a/starport/pkg/cosmosfaucet/transfer.go
+++ b/starport/pkg/cosmosfaucet/transfer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 )
 

--- a/starport/pkg/cosmosgen/cosmosgen.go
+++ b/starport/pkg/cosmosgen/cosmosgen.go
@@ -3,8 +3,9 @@ package cosmosgen
 import (
 	"context"
 
-	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
 	gomodmodule "golang.org/x/mod/module"
+
+	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
 )
 
 // generateOptions used to configure code generation.

--- a/starport/pkg/cosmosgen/generate_dart.go
+++ b/starport/pkg/cosmosgen/generate_dart.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/mattn/go-zglob"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
 	"github.com/tendermint/starport/starport/pkg/protoc"
 	protocgendart "github.com/tendermint/starport/starport/pkg/protoc-gen-dart"
-	"golang.org/x/sync/errgroup"
 )
 
 var (

--- a/starport/pkg/cosmosgen/generate_go.go
+++ b/starport/pkg/cosmosgen/generate_go.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/protoanalysis"
 	"github.com/tendermint/starport/starport/pkg/protoc"
 )

--- a/starport/pkg/cosmosgen/generate_javascript.go
+++ b/starport/pkg/cosmosgen/generate_javascript.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/iancoleman/strcase"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
 	"github.com/tendermint/starport/starport/pkg/giturl"
 	"github.com/tendermint/starport/starport/pkg/gomodulepath"
@@ -16,7 +18,6 @@ import (
 	"github.com/tendermint/starport/starport/pkg/nodetime/programs/tsc"
 	"github.com/tendermint/starport/starport/pkg/protoc"
 	"github.com/tendermint/starport/starport/pkg/xstrings"
-	"golang.org/x/sync/errgroup"
 )
 
 var (

--- a/starport/pkg/cosmosgen/generate_openapi.go
+++ b/starport/pkg/cosmosgen/generate_openapi.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/iancoleman/strcase"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosanalysis/module"
 	swaggercombine "github.com/tendermint/starport/starport/pkg/nodetime/programs/swagger-combine"
 	"github.com/tendermint/starport/starport/pkg/protoc"

--- a/starport/pkg/cosmosgen/install.go
+++ b/starport/pkg/cosmosgen/install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )

--- a/starport/pkg/cosmosutil/address_test.go
+++ b/starport/pkg/cosmosutil/address_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 )
 

--- a/starport/pkg/cosmosutil/genesis_test.go
+++ b/starport/pkg/cosmosutil/genesis_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 )
 

--- a/starport/pkg/cosmosutil/gentx_test.go
+++ b/starport/pkg/cosmosutil/gentx_test.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 )
 

--- a/starport/pkg/cosmosutil/peer.go
+++ b/starport/pkg/cosmosutil/peer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/xurl"
 )
 

--- a/starport/pkg/entrywriter/entrywriter_test.go
+++ b/starport/pkg/entrywriter/entrywriter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/entrywriter"
 )
 

--- a/starport/pkg/gomodule/gomodule.go
+++ b/starport/pkg/gomodule/gomodule.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tendermint/starport/starport/pkg/cmdrunner"
-	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"github.com/tendermint/starport/starport/pkg/cmdrunner"
+	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 )
 
 // ErrGoModNotFound returned when go.mod file cannot be found for an app.

--- a/starport/pkg/gomodulepath/gomodulepath.go
+++ b/starport/pkg/gomodulepath/gomodulepath.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/tendermint/starport/starport/pkg/gomodule"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
+
+	"github.com/tendermint/starport/starport/pkg/gomodule"
 )
 
 // Path represents a Go module's path.

--- a/starport/pkg/multiformatname/multiformatname_test.go
+++ b/starport/pkg/multiformatname/multiformatname_test.go
@@ -3,9 +3,11 @@ package multiformatname_test
 import (
 	"errors"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/starport/starport/pkg/multiformatname"
 )
 
 func TestNewMultiFormatName(t *testing.T) {

--- a/starport/pkg/nodetime/programs/ts-relayer/tsrelayer.go
+++ b/starport/pkg/nodetime/programs/ts-relayer/tsrelayer.go
@@ -9,10 +9,11 @@ import (
 	"io"
 
 	"github.com/gorilla/rpc/v2/json2"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/nodetime"
-	"golang.org/x/sync/errgroup"
 )
 
 // Call calls a method in the ts relayer wrapper lib with args and fills reply from the returned value.

--- a/starport/pkg/nodetime/programs/tsc/tsc.go
+++ b/starport/pkg/nodetime/programs/tsc/tsc.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/imdario/mergo"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/exec"
 	"github.com/tendermint/starport/starport/pkg/confile"
 	"github.com/tendermint/starport/starport/pkg/nodetime"

--- a/starport/pkg/protoanalysis/parser.go
+++ b/starport/pkg/protoanalysis/parser.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/emicklei/proto"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/localfs"
 )
 

--- a/starport/pkg/protopath/protopath.go
+++ b/starport/pkg/protopath/protopath.go
@@ -5,9 +5,10 @@ import (
 	"errors"
 	"path/filepath"
 
+	"golang.org/x/mod/module"
+
 	"github.com/tendermint/starport/starport/pkg/gomodule"
 	"github.com/tendermint/starport/starport/pkg/xfilepath"
-	"golang.org/x/mod/module"
 )
 
 var (

--- a/starport/pkg/relayer/chain.go
+++ b/starport/pkg/relayer/chain.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/imdario/mergo"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"

--- a/starport/pkg/relayer/config/config.go
+++ b/starport/pkg/relayer/config/config.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/confile"
 )
 

--- a/starport/pkg/relayer/relayer.go
+++ b/starport/pkg/relayer/relayer.go
@@ -9,13 +9,14 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/ctxticker"
 	tsrelayer "github.com/tendermint/starport/starport/pkg/nodetime/programs/ts-relayer"
 	relayerconf "github.com/tendermint/starport/starport/pkg/relayer/config"
 	"github.com/tendermint/starport/starport/pkg/xurl"
-	"golang.org/x/sync/errgroup"
 )
 
 const (

--- a/starport/pkg/xfilepath/xfilepath_test.go
+++ b/starport/pkg/xfilepath/xfilepath_test.go
@@ -2,11 +2,13 @@ package xfilepath_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/starport/pkg/xfilepath"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/starport/starport/pkg/xfilepath"
 )
 
 func TestJoin(t *testing.T) {

--- a/starport/pkg/xgenny/run.go
+++ b/starport/pkg/xgenny/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/logger"
 	"github.com/gobuffalo/packd"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/validation"
 )

--- a/starport/pkg/xgenny/sourcemodification_test.go
+++ b/starport/pkg/xgenny/sourcemodification_test.go
@@ -1,9 +1,11 @@
 package xgenny_test
 
 import (
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/starport/starport/pkg/xgenny"
 )
 
 var (

--- a/starport/pkg/xstrings/xstrings_test.go
+++ b/starport/pkg/xstrings/xstrings_test.go
@@ -1,9 +1,11 @@
 package xstrings_test
 
 import (
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 )
 
 func TestNoDash(t *testing.T) {

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/checksum"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/exec"

--- a/starport/services/chain/chain.go
+++ b/starport/services/chain/chain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/gookit/color"
+
 	"github.com/tendermint/starport/starport/chainconfig"
 	sperrors "github.com/tendermint/starport/starport/errors"
 	"github.com/tendermint/starport/starport/pkg/chaincmd"

--- a/starport/services/chain/faucet.go
+++ b/starport/services/chain/faucet.go
@@ -8,6 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/pkg/errors"
+
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
 	"github.com/tendermint/starport/starport/pkg/xurl"

--- a/starport/services/chain/init.go
+++ b/starport/services/chain/init.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/imdario/mergo"
+
 	"github.com/tendermint/starport/starport/chainconfig"
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 	"github.com/tendermint/starport/starport/pkg/confile"

--- a/starport/services/chain/plugin-stargate.go
+++ b/starport/services/chain/plugin-stargate.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/pelletier/go-toml"
+
 	"github.com/tendermint/starport/starport/chainconfig"
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"

--- a/starport/services/chain/serve.go
+++ b/starport/services/chain/serve.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/otiai10/copy"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/tendermint/starport/starport/chainconfig"
 	chaincmdrunner "github.com/tendermint/starport/starport/pkg/chaincmd/runner"
 	"github.com/tendermint/starport/starport/pkg/cosmosfaucet"
@@ -21,7 +23,6 @@ import (
 	"github.com/tendermint/starport/starport/pkg/xfilepath"
 	"github.com/tendermint/starport/starport/pkg/xhttp"
 	"github.com/tendermint/starport/starport/pkg/xurl"
-	"golang.org/x/sync/errgroup"
 )
 
 const (

--- a/starport/services/network/join.go
+++ b/starport/services/network/join.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/cosmoserror"
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/events"

--- a/starport/services/network/launch.go
+++ b/starport/services/network/launch.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/pkg/xtime"
 	"github.com/tendermint/starport/starport/services/network/networktypes"

--- a/starport/services/network/network.go
+++ b/starport/services/network/network.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/events"

--- a/starport/services/network/networkchain/home_test.go
+++ b/starport/services/network/networkchain/home_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/services/network/networkchain"
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )

--- a/starport/services/network/networkchain/networkchain.go
+++ b/starport/services/network/networkchain/networkchain.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+
 	sperrors "github.com/tendermint/starport/starport/errors"
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"

--- a/starport/services/network/networkchain/prepare.go
+++ b/starport/services/network/networkchain/prepare.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/services/network/networktypes"

--- a/starport/services/network/networkchain/simulate.go
+++ b/starport/services/network/networkchain/simulate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/availableport"
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/pkg/httpstatuschecker"

--- a/starport/services/network/networktypes/chainlaunch_test.go
+++ b/starport/services/network/networktypes/chainlaunch_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )
 

--- a/starport/services/network/networktypes/genesisinformation_test.go
+++ b/starport/services/network/networktypes/genesisinformation_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )
 

--- a/starport/services/network/networktypes/request.go
+++ b/starport/services/network/networktypes/request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 )
 

--- a/starport/services/network/networktypes/request_test.go
+++ b/starport/services/network/networktypes/request_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )
 

--- a/starport/services/network/publish.go
+++ b/starport/services/network/publish.go
@@ -6,6 +6,7 @@ import (
 	campaigntypes "github.com/tendermint/spn/x/campaign/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 	profiletypes "github.com/tendermint/spn/x/profile/types"
+
 	"github.com/tendermint/starport/starport/pkg/cosmoserror"
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/events"

--- a/starport/services/network/queries.go
+++ b/starport/services/network/queries.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )

--- a/starport/services/network/request.go
+++ b/starport/services/network/request.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
+
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )

--- a/starport/services/scaffolder/init.go
+++ b/starport/services/scaffolder/init.go
@@ -9,13 +9,14 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/gobuffalo/genny"
 	"github.com/tendermint/flutter/v2"
+	"github.com/tendermint/vue"
+
 	"github.com/tendermint/starport/starport/pkg/giturl"
 	"github.com/tendermint/starport/starport/pkg/gomodulepath"
 	"github.com/tendermint/starport/starport/pkg/localfs"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/app"
 	modulecreate "github.com/tendermint/starport/starport/templates/module/create"
-	"github.com/tendermint/vue"
 )
 
 var (

--- a/starport/services/scaffolder/message.go
+++ b/starport/services/scaffolder/message.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/services/scaffolder/module.go
+++ b/starport/services/scaffolder/module.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	appanalysis "github.com/tendermint/starport/starport/pkg/cosmosanalysis/app"

--- a/starport/services/scaffolder/oracle.go
+++ b/starport/services/scaffolder/oracle.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/cmdrunner"
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/gocmd"

--- a/starport/services/scaffolder/packet.go
+++ b/starport/services/scaffolder/packet.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/services/scaffolder/patch.go
+++ b/starport/services/scaffolder/patch.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	modulecreate "github.com/tendermint/starport/starport/templates/module/create"
 )

--- a/starport/services/scaffolder/query.go
+++ b/starport/services/scaffolder/query.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/services/scaffolder/type.go
+++ b/starport/services/scaffolder/type.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/templates/app/app.go
+++ b/starport/templates/app/app.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"

--- a/starport/templates/field/parse_test.go
+++ b/starport/templates/field/parse_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/templates/field/datatype"
 )

--- a/starport/templates/field/plushhelpers/plushhelpers.go
+++ b/starport/templates/field/plushhelpers/plushhelpers.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/plush"
+
 	"github.com/tendermint/starport/starport/templates/field"
 	"github.com/tendermint/starport/starport/templates/field/datatype"
 )

--- a/starport/templates/ibc/oracle.go
+++ b/starport/templates/ibc/oracle.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/templates/ibc/packet.go
+++ b/starport/templates/ibc/packet.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"

--- a/starport/templates/message/message.go
+++ b/starport/templates/message/message.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/packd"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 	"github.com/tendermint/starport/starport/templates/testutil"
 )

--- a/starport/templates/message/stargate.go
+++ b/starport/templates/message/stargate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/typed"

--- a/starport/templates/module/create/genesistest.go
+++ b/starport/templates/module/create/genesistest.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 )

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/pkg/xstrings"

--- a/starport/templates/module/create/msgserver.go
+++ b/starport/templates/module/create/msgserver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/pkg/xstrings"

--- a/starport/templates/module/create/simulation.go
+++ b/starport/templates/module/create/simulation.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/field"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"

--- a/starport/templates/module/create/stargate.go
+++ b/starport/templates/module/create/stargate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/pkg/xstrings"

--- a/starport/templates/module/import/stargate.go
+++ b/starport/templates/module/import/stargate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 	"github.com/tendermint/starport/starport/templates/module"

--- a/starport/templates/query/query.go
+++ b/starport/templates/query/query.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/packd"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 )
 

--- a/starport/templates/query/stargate.go
+++ b/starport/templates/query/stargate.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 )

--- a/starport/templates/testutil/register.go
+++ b/starport/templates/testutil/register.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 )
 

--- a/starport/templates/typed/dry/stargate.go
+++ b/starport/templates/typed/dry/stargate.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/typed"
 )

--- a/starport/templates/typed/list/genesis.go
+++ b/starport/templates/typed/list/genesis.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/module"
 	"github.com/tendermint/starport/starport/templates/typed"

--- a/starport/templates/typed/list/simulation.go
+++ b/starport/templates/typed/list/simulation.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/typed"
 )

--- a/starport/templates/typed/list/stargate.go
+++ b/starport/templates/typed/list/stargate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/typed"

--- a/starport/templates/typed/map/simulation.go
+++ b/starport/templates/typed/map/simulation.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/typed"
 )

--- a/starport/templates/typed/map/stargate.go
+++ b/starport/templates/typed/map/stargate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/field/datatype"

--- a/starport/templates/typed/singleton/simulation.go
+++ b/starport/templates/typed/singleton/simulation.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/templates/typed"
 )

--- a/starport/templates/typed/singleton/stargate.go
+++ b/starport/templates/typed/singleton/stargate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gobuffalo/genny"
+
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
 	"github.com/tendermint/starport/starport/templates/module"

--- a/starport/templates/typed/typed.go
+++ b/starport/templates/typed/typed.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gobuffalo/packd"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
+
 	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 	"github.com/tendermint/starport/starport/templates/testutil"


### PR DESCRIPTION
## Description

Run the `make format` with the new `goimports` command to format all project.