### PR TITLE
feat(cmd/network): the `chain prepare [id]` should fail if not-launched yet

### DIFF
--- a/starport/cmd/network_chain_prepare.go
+++ b/starport/cmd/network_chain_prepare.go
@@ -1,10 +1,16 @@
 package starportcmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/tendermint/starport/starport/services/network"
 	"github.com/tendermint/starport/starport/services/network/networkchain"
+)
+
+const (
+	flagForce = "force"
 )
 
 // NewNetworkChainPrepare returns a new command to prepare the chain for launch
@@ -16,6 +22,7 @@ func NewNetworkChainPrepare() *cobra.Command {
 		RunE:  networkChainPrepareHandler,
 	}
 
+	c.Flags().BoolP(flagForce, "f", false, "Force the prepare command to run even if the chain is not started")
 	c.Flags().AddFlagSet(flagNetworkFrom())
 	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	c.Flags().AddFlagSet(flagSetHome())
@@ -24,6 +31,8 @@ func NewNetworkChainPrepare() *cobra.Command {
 }
 
 func networkChainPrepareHandler(cmd *cobra.Command, args []string) error {
+	force, _ := cmd.Flags().GetBool(flagForce)
+
 	nb, err := newNetworkBuilder(cmd)
 	if err != nil {
 		return err
@@ -45,6 +54,10 @@ func networkChainPrepareHandler(cmd *cobra.Command, args []string) error {
 	chainLaunch, err := n.ChainLaunch(cmd.Context(), launchID)
 	if err != nil {
 		return err
+	}
+
+	if !force && !chainLaunch.LaunchTriggered {
+		return fmt.Errorf("chain %d is not launched yet", launchID)
 	}
 
 	c, err := nb.Chain(networkchain.SourceLaunch(chainLaunch))

--- a/starport/services/network/networktypes/chainlaunch.go
+++ b/starport/services/network/networktypes/chainlaunch.go
@@ -4,14 +4,15 @@ import launchtypes "github.com/tendermint/spn/x/launch/types"
 
 // ChainLaunch represents the launch of a chain on SPN
 type ChainLaunch struct {
-	ID          uint64 `json:"ID"`
-	ChainID     string `json:"ChainID"`
-	SourceURL   string `json:"SourceURL"`
-	SourceHash  string `json:"SourceHash"`
-	GenesisURL  string `json:"GenesisURL"`
-	GenesisHash string `json:"GenesisHash"`
-	LaunchTime  int64  `json:"LaunchTime"`
-	CampaignID  uint64 `json:"CampaignID"`
+	ID              uint64 `json:"ID"`
+	ChainID         string `json:"ChainID"`
+	SourceURL       string `json:"SourceURL"`
+	SourceHash      string `json:"SourceHash"`
+	GenesisURL      string `json:"GenesisURL"`
+	GenesisHash     string `json:"GenesisHash"`
+	LaunchTime      int64  `json:"LaunchTime"`
+	CampaignID      uint64 `json:"CampaignID"`
+	LaunchTriggered bool   `json:"LaunchTriggered"`
 }
 
 // ToChainLaunch converts a chain launch data from SPN and returns a ChainLaunch object
@@ -22,12 +23,13 @@ func ToChainLaunch(chain launchtypes.Chain) ChainLaunch {
 	}
 
 	launch := ChainLaunch{
-		ID:         chain.LaunchID,
-		ChainID:    chain.GenesisChainID,
-		SourceURL:  chain.SourceURL,
-		SourceHash: chain.SourceHash,
-		LaunchTime: launchTime,
-		CampaignID: chain.CampaignID,
+		ID:              chain.LaunchID,
+		ChainID:         chain.GenesisChainID,
+		SourceURL:       chain.SourceURL,
+		SourceHash:      chain.SourceHash,
+		LaunchTime:      launchTime,
+		CampaignID:      chain.CampaignID,
+		LaunchTriggered: chain.LaunchTriggered,
 	}
 
 	// check if custom genesis URL is provided.


### PR DESCRIPTION
close  #2064

## Description

Fail the prepare command if the chain hasn’t been launched, and add a force (`-f`) flag to force run the command

### How to test

- Run the prepare command with a chain ID not launched
```shell
starport network --nightly chain prepare 30 
```

- Run the prepare command with the force flag
```shell
starport network --nightly chain prepare 30 -f
```