### PR TITLE
docs(blog): remove unused import

### DIFF
--- a/docs/guide/blog/index.md
+++ b/docs/guide/blog/index.md
@@ -269,7 +269,6 @@ import (
   "github.com/cosmonaut/blog/x/blog/types"
   "github.com/cosmos/cosmos-sdk/store/prefix"
   sdk "github.com/cosmos/cosmos-sdk/types"
-  "strconv"
 )
 
 func (k Keeper) AppendPost(ctx sdk.Context, post types.Post) uint64 {


### PR DESCRIPTION
**Problem**:
The `blog` doc  provides a snippet of code with an unnecessary import. This is during the implementation of `AppendPost` see:

`func (k Keeper) AppendPost(ctx sdk.Context, post types.Post) uint64`
(https://github.com/tendermint/starport/blob/30b3e5091c5cdbcf6447042b681b89108a324197/docs/guide/blog/index.md)

Non-experienced users will receive an error during the rebuilding of the chain that they may not know how to recover from.

```
cannot build app:

        error while running command go: 
../../x/mars/keeper/post.go:8:3: imported and not used: "strconv"
: exit status 2
```

**Solution**:
PR removes the unneeded `strconv` import.
