### PR TITLE
docs: fixing a typo under blog tutorial

### DIFF
--- a/docs/guide/blog/connect-blockchain.md
+++ b/docs/guide/blog/connect-blockchain.md
@@ -120,7 +120,7 @@ func main() {
 	// instantiate a query client for your `blog` blockchain
 	queryClient := types.NewQueryClient(cosmos.Context)
 
-	// query the blockchain using the client's `PostAll` method to get all posts
+	// query the blockchain using the client's `Posts` method to get all posts
 	// store all posts in queryResp
 	queryResp, err := queryClient.Posts(context.Background(), &types.QueryPostsRequest{})
 	if err != nil {


### PR DESCRIPTION
This PR is to fix a small typo under comment section of blog chain tutorial.