### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/integration/app/cmd_serve_test.go
+++ b/integration/app/cmd_serve_test.go
@@ -88,9 +88,7 @@ func TestServeStargateWithConfigHome(t *testing.T) {
 }
 
 func TestServeStargateWithCustomConfigFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "starporttest")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	var (
 		env   = envtest.New(t)
@@ -99,7 +97,7 @@ func TestServeStargateWithCustomConfigFile(t *testing.T) {
 	// Move config
 	newConfig := "new_config.yml"
 	newConfigPath := filepath.Join(tmpDir, newConfig)
-	err = os.Rename(filepath.Join(apath, "config.yml"), newConfigPath)
+	err := os.Rename(filepath.Join(apath, "config.yml"), newConfigPath)
 	require.NoError(t, err)
 
 	servers := env.RandomizeServerPorts(tmpDir, newConfig)

--- a/starport/pkg/cosmosanalysis/app/app_test.go
+++ b/starport/pkg/cosmosanalysis/app/app_test.go
@@ -53,13 +53,11 @@ func (f Bar) RegisterTendermintService() {}
 )
 
 func TestCheckKeeper(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "app_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	// Test with a source file containing an app
 	tmpFile := filepath.Join(tmpDir, "app.go")
-	err = os.WriteFile(tmpFile, AppFile, 0644)
+	err := os.WriteFile(tmpFile, AppFile, 0644)
 	require.NoError(t, err)
 
 	err = app.CheckKeeper(tmpDir, "FooKeeper")
@@ -68,9 +66,7 @@ func TestCheckKeeper(t *testing.T) {
 	require.Error(t, err)
 
 	// No app in source must return an error
-	tmpDirNoApp, err := os.MkdirTemp("", "app_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDirNoApp := t.TempDir()
 	tmpFileNoApp := filepath.Join(tmpDirNoApp, "app.go")
 	err = os.WriteFile(tmpFileNoApp, NoAppFile, 0644)
 	require.NoError(t, err)
@@ -78,9 +74,7 @@ func TestCheckKeeper(t *testing.T) {
 	require.Error(t, err)
 
 	// More than one app must return an error
-	tmpDirTwoApp, err := os.MkdirTemp("", "app_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDirTwoApp := t.TempDir()
 	tmpFileTwoApp := filepath.Join(tmpDirTwoApp, "app.go")
 	err = os.WriteFile(tmpFileTwoApp, TwoAppFile, 0644)
 	require.NoError(t, err)

--- a/starport/pkg/cosmosanalysis/cosmosanalysis_test.go
+++ b/starport/pkg/cosmosanalysis/cosmosanalysis_test.go
@@ -39,12 +39,10 @@ func (f Foobar) barfoo() {}
 )
 
 func TestFindImplementation(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "cosmosanalysis_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	tmpDir := t.TempDir()
 
 	f1 := filepath.Join(tmpDir, "1.go")
-	err = os.WriteFile(f1, file1, 0644)
+	err := os.WriteFile(f1, file1, 0644)
 	require.NoError(t, err)
 	f2 := filepath.Join(tmpDir, "2.go")
 	err = os.WriteFile(f2, file2, 0644)
@@ -58,9 +56,7 @@ func TestFindImplementation(t *testing.T) {
 	require.Contains(t, found, "Foobar")
 
 	// empty directory
-	emptyDir, err := os.MkdirTemp("", "cosmosanalysis_test")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(emptyDir) })
+	emptyDir := t.TempDir()
 	found, err = cosmosanalysis.FindImplementation(emptyDir, expectedinterface)
 	require.NoError(t, err)
 	require.Empty(t, found)

--- a/starport/pkg/cosmosutil/genesis_test.go
+++ b/starport/pkg/cosmosutil/genesis_test.go
@@ -23,12 +23,10 @@ const (
 )
 
 func TestSetGenesisTime(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "")
-	t.Cleanup(func() { os.RemoveAll(tmp) })
+	tmp := t.TempDir()
 	tmpGenesis := filepath.Join(tmp, "genesis.json")
 
 	// fails with no file
-	require.NoError(t, err)
 	require.Error(t, cosmosutil.SetGenesisTime(tmpGenesis, 0))
 
 	require.NoError(t, os.WriteFile(tmpGenesis, []byte(genesisSample), 0644))

--- a/starport/pkg/localfs/search_test.go
+++ b/starport/pkg/localfs/search_test.go
@@ -10,16 +10,12 @@ import (
 
 func setupGlobTests(t *testing.T, files []string) string {
 	t.Helper()
-	tmpdir, err := os.MkdirTemp("", "glob-test")
-	require.NoError(t, err)
+	tmpdir := t.TempDir()
 
-	t.Cleanup(func() {
-		os.RemoveAll(tmpdir)
-	})
 	for _, file := range files {
 		fileDir := filepath.Dir(file)
 		fileDir = filepath.Join(tmpdir, fileDir)
-		err = os.MkdirAll(fileDir, 0755)
+		err := os.MkdirAll(fileDir, 0755)
 		require.NoError(t, err)
 		err = os.WriteFile(filepath.Join(tmpdir, file), []byte{}, 0644)
 		require.NoError(t, err)

--- a/starport/services/chain/chain_test.go
+++ b/starport/services/chain/chain_test.go
@@ -34,10 +34,7 @@ func tempSource(t *testing.T, tarPath string) (path string) {
 
 	defer f.Close()
 
-	dir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	require.NoError(t, archive.Untar(f, dir, &archive.TarOptions{NoLchown: true}))
 


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir