### PR TITLE
feat(network): remove unused flags from query commands

### DIFF
--- a/starport/cmd/network_campaign_account.go
+++ b/starport/cmd/network_campaign_account.go
@@ -40,8 +40,6 @@ func newNetworkCampaignAccountList() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  newNetworkCampaignAccountListHandler,
 	}
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_campaign_list.go
+++ b/starport/cmd/network_campaign_list.go
@@ -26,8 +26,6 @@ func NewNetworkCampaignList() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  networkCampaignListHandler,
 	}
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_campaign_show.go
+++ b/starport/cmd/network_campaign_show.go
@@ -17,8 +17,6 @@ func NewNetworkCampaignShow() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  networkCampaignShowHandler,
 	}
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_chain_list.go
+++ b/starport/cmd/network_chain_list.go
@@ -21,8 +21,6 @@ func NewNetworkChainList() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE:  networkChainListHandler,
 	}
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_chain_show.go
+++ b/starport/cmd/network_chain_show.go
@@ -40,8 +40,6 @@ func NewNetworkChainShow() *cobra.Command {
 		newNetworkChainShowValidators(),
 		newNetworkChainShowPeers(),
 	)
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_request_list.go
+++ b/starport/cmd/network_request_list.go
@@ -23,8 +23,6 @@ func NewNetworkRequestList() *cobra.Command {
 		RunE:  networkRequestListHandler,
 		Args:  cobra.ExactArgs(1),
 	}
-	c.Flags().AddFlagSet(flagNetworkFrom())
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 

--- a/starport/cmd/network_request_show.go
+++ b/starport/cmd/network_request_show.go
@@ -20,7 +20,6 @@ func NewNetworkRequestShow() *cobra.Command {
 		RunE:  networkRequestShowHandler,
 		Args:  cobra.ExactArgs(2),
 	}
-	c.Flags().AddFlagSet(flagSetKeyringBackend())
 	return c
 }
 


### PR DESCRIPTION
close #2137

## Description

remove unused `from` and `keyring` flags from network query commands

