### PR TITLE
fix: Update command `submit-scavenge` arg

### DIFF
--- a/docs/guide/scavenge/08-cli.md
+++ b/docs/guide/scavenge/08-cli.md
@@ -97,7 +97,7 @@ import (
 
 func CmdSubmitScavenge() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "submit-scavenge [solutionHash] [description] [reward]",
+		Use:   "submit-scavenge [solution] [description] [reward]",
 		Short: "Broadcast message submit-scavenge",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Rename `solutionHash` to `solution` because the arg in command line is solution, not solution hash
https://github.com/tendermint/starport/blob/fd403a2c13678da2430ce62ee35315a0e5b7d498/docs/guide/scavenge/09-play.md?plain=1#L34
