### PR TITLE
feat(cmd/network): implement binary caching for network commands

### DIFF
--- a/starport/pkg/checksum/checksum.go
+++ b/starport/pkg/checksum/checksum.go
@@ -41,7 +41,8 @@ func Sum(dirPath, outPath string) error {
 	return os.WriteFile(outPath, b.Bytes(), 0666)
 }
 
-func BinaryChecksum(binaryName string) (string, error) {
+// Binary returns SHA256 hash of executable file, file is searched by name in PATH
+func Binary(binaryName string) (string, error) {
 	// get binary path
 	binaryPath, err := exec.LookPath(binaryName)
 	if err != nil {
@@ -61,10 +62,11 @@ func BinaryChecksum(binaryName string) (string, error) {
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
 }
 
-func SHA256Checksum(inputs ...[]byte) string {
+// Strings concatenates all inputs and returns SHA256 hash of them
+func Strings(inputs ...string) string {
 	h := sha256.New()
 	for _, input := range inputs {
-		h.Write(input)
+		h.Write([]byte(input))
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/starport/pkg/checksum/checksum.go
+++ b/starport/pkg/checksum/checksum.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -38,4 +39,32 @@ func Sum(dirPath, outPath string) error {
 	}
 
 	return os.WriteFile(outPath, b.Bytes(), 0666)
+}
+
+func BinaryChecksum(binaryName string) (string, error) {
+	// get binary path
+	binaryPath, err := exec.LookPath(binaryName)
+	if err != nil {
+		return "", err
+	}
+	f, err := os.Open(binaryPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func SHA256Checksum(inputs ...[]byte) string {
+	h := sha256.New()
+	for _, input := range inputs {
+		h.Write(input)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/starport/services/network/network.go
+++ b/starport/services/network/network.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
-
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosclient"
 	"github.com/tendermint/starport/starport/pkg/events"
@@ -29,6 +28,7 @@ type Chain interface {
 	AppTOMLPath() (string, error)
 	ConfigTOMLPath() (string, error)
 	NodeID(ctx context.Context) (string, error)
+	CacheBinary(launchID uint64) error
 }
 
 type Option func(*Network)

--- a/starport/services/network/networkchain/binarycache.go
+++ b/starport/services/network/networkchain/binarycache.go
@@ -1,0 +1,58 @@
+package networkchain
+
+import (
+	"strconv"
+
+	"github.com/tendermint/starport/starport/chainconfig"
+	"github.com/tendermint/starport/starport/pkg/checksum"
+	"github.com/tendermint/starport/starport/pkg/confile"
+	"github.com/tendermint/starport/starport/pkg/xfilepath"
+)
+
+const (
+	BinaryCacheDirectory = "binary-cache"
+	BinaryCacheFilename  = "list.yml"
+)
+
+type List struct {
+	CachedBinary map[string]string `json:"cached_binary" yaml:"cached_binary"`
+}
+
+// CacheBinaryForLaunchID caches hash sha256(sha256(binary) + sourcehash) for launch id
+func CacheBinaryForLaunchID(launchID uint64, binaryHash, sourceHash string) error {
+	cachePath, err := getBinaryCacheFilepath()
+	if err != nil {
+		return err
+	}
+	cacheList := List{CachedBinary: map[string]string{}}
+	err = confile.New(confile.DefaultYAMLEncodingCreator, cachePath).Load(&cacheList)
+	if err != nil {
+		return err
+	}
+	cacheList.CachedBinary[strconv.Itoa(int(launchID))] = checksum.SHA256Checksum([]byte(binaryHash), []byte(sourceHash))
+
+	return confile.New(confile.DefaultYAMLEncodingCreator, cachePath).Save(cacheList)
+}
+
+// CheckBinaryCacheForLaunchID checks if binary for the given launch was already built
+func CheckBinaryCacheForLaunchID(launchID uint64, binaryHash, sourceHash string) (bool, error) {
+	cachePath, err := getBinaryCacheFilepath()
+	if err != nil {
+		return false, err
+	}
+	cacheList := List{CachedBinary: map[string]string{}}
+	err = confile.New(confile.DefaultYAMLEncodingCreator, cachePath).Load(&cacheList)
+	if err != nil {
+		return false, err
+	}
+	return cacheList.CachedBinary[strconv.Itoa(int(launchID))] == checksum.SHA256Checksum([]byte(binaryHash), []byte(sourceHash)), nil
+}
+
+func getBinaryCacheFilepath() (string, error) {
+	return xfilepath.Join(
+		chainconfig.ConfigDirPath,
+		xfilepath.Path("spn"),
+		xfilepath.Path(BinaryCacheDirectory),
+		xfilepath.Path(BinaryCacheFilename),
+	)()
+}

--- a/starport/services/network/networkchain/init.go
+++ b/starport/services/network/networkchain/init.go
@@ -24,7 +24,7 @@ func (c *Chain) Init(ctx context.Context) error {
 
 	// build the chain and initialize it with a new validator key
 	c.ev.Send(events.New(events.StatusOngoing, "Building the blockchain"))
-	if _, err := c.chain.Build(ctx, ""); err != nil {
+	if _, err := c.Build(ctx); err != nil {
 		return err
 	}
 

--- a/starport/services/network/networkchain/networkchain.go
+++ b/starport/services/network/networkchain/networkchain.go
@@ -2,13 +2,15 @@ package networkchain
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-
 	sperrors "github.com/tendermint/starport/starport/errors"
 	"github.com/tendermint/starport/starport/pkg/chaincmd"
+	"github.com/tendermint/starport/starport/pkg/checksum"
 	"github.com/tendermint/starport/starport/pkg/cosmosaccount"
 	"github.com/tendermint/starport/starport/pkg/cosmosver"
 	"github.com/tendermint/starport/starport/pkg/events"
@@ -19,7 +21,8 @@ import (
 
 // Chain represents a network blockchain and lets you interact with its source code and binary.
 type Chain struct {
-	id string
+	id       string
+	launchID uint64
 
 	path string
 	home string
@@ -82,6 +85,7 @@ func SourceRemoteHash(url, hash string) SourceOption {
 func SourceLaunch(launch networktypes.ChainLaunch) SourceOption {
 	return func(c *Chain) {
 		c.id = launch.ChainID
+		c.launchID = launch.ID
 		c.url = launch.SourceURL
 		c.hash = launch.SourceHash
 		c.genesisURL = launch.GenesisURL
@@ -237,6 +241,45 @@ func (c Chain) NodeID(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return nodeID, nil
+}
+
+// Build builds chain sources, also checks if source was already built
+func (c *Chain) Build(ctx context.Context) (string, error) {
+	// if chain was already published and has launch id check binary cache
+	if c.launchID != 0 {
+		binaryName, err := c.chain.Binary()
+		if err != nil {
+			return "", err
+		}
+		binaryChecksum, err := checksum.BinaryChecksum(binaryName)
+		if err != nil && !errors.Is(err, exec.ErrNotFound) {
+			return "", err
+		}
+		binaryMatch, err := CheckBinaryCacheForLaunchID(c.launchID, binaryChecksum, c.hash)
+		if err != nil {
+			return "", err
+		}
+		if binaryMatch {
+			return binaryName, nil
+		}
+	}
+
+	// build binary
+	binaryName, err := c.chain.Build(ctx, "")
+	if err != nil {
+		return "", err
+	}
+
+	// cache built binary for launch id
+	binaryChecksum, err := checksum.BinaryChecksum(binaryName)
+	if err != nil {
+		return "", err
+	}
+	if err = CacheBinaryForLaunchID(c.launchID, binaryChecksum, c.hash); err != nil {
+		return "", err
+	}
+
+	return binaryName, nil
 }
 
 // fetchSource fetches the chain source from url and returns a temporary path where source is saved

--- a/starport/services/network/networkchain/networkchain.go
+++ b/starport/services/network/networkchain/networkchain.go
@@ -251,11 +251,11 @@ func (c *Chain) Build(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		binaryChecksum, err := checksum.BinaryChecksum(binaryName)
+		binaryChecksum, err := checksum.Binary(binaryName)
 		if err != nil && !errors.Is(err, exec.ErrNotFound) {
 			return "", err
 		}
-		binaryMatch, err := CheckBinaryCacheForLaunchID(c.launchID, binaryChecksum, c.hash)
+		binaryMatch, err := checkBinaryCacheForLaunchID(c.launchID, binaryChecksum, c.hash)
 		if err != nil {
 			return "", err
 		}
@@ -272,16 +272,27 @@ func (c *Chain) Build(ctx context.Context) (string, error) {
 
 	// cache built binary for launch id
 	if c.launchID != 0 {
-		binaryChecksum, err := checksum.BinaryChecksum(binaryName)
+		err := c.CacheBinary(c.launchID)
 		if err != nil {
-			return "", err
-		}
-		if err = CacheBinaryForLaunchID(c.launchID, binaryChecksum, c.hash); err != nil {
-			return "", err
+			return "", nil
 		}
 	}
 
 	return binaryName, nil
+}
+
+// CacheBinary caches last built chain binary associated with launch id
+func (c *Chain) CacheBinary(launchID uint64) error {
+	binaryName, err := c.chain.Binary()
+	if err != nil {
+		return err
+	}
+	binaryChecksum, err := checksum.Binary(binaryName)
+
+	if err != nil {
+		return err
+	}
+	return cacheBinaryForLaunchID(launchID, binaryChecksum, c.hash)
 }
 
 // fetchSource fetches the chain source from url and returns a temporary path where source is saved

--- a/starport/services/network/networkchain/networkchain.go
+++ b/starport/services/network/networkchain/networkchain.go
@@ -271,12 +271,14 @@ func (c *Chain) Build(ctx context.Context) (string, error) {
 	}
 
 	// cache built binary for launch id
-	binaryChecksum, err := checksum.BinaryChecksum(binaryName)
-	if err != nil {
-		return "", err
-	}
-	if err = CacheBinaryForLaunchID(c.launchID, binaryChecksum, c.hash); err != nil {
-		return "", err
+	if c.launchID != 0 {
+		binaryChecksum, err := checksum.BinaryChecksum(binaryName)
+		if err != nil {
+			return "", err
+		}
+		if err = CacheBinaryForLaunchID(c.launchID, binaryChecksum, c.hash); err != nil {
+			return "", err
+		}
 	}
 
 	return binaryName, nil

--- a/starport/services/network/networkchain/prepare.go
+++ b/starport/services/network/networkchain/prepare.go
@@ -39,7 +39,7 @@ func (c Chain) Prepare(ctx context.Context, gi networktypes.GenesisInformation) 
 	default:
 		// if config and validator key already exists, build the chain and initialize the genesis
 		c.ev.Send(events.New(events.StatusOngoing, "Building the blockchain"))
-		if _, err := c.chain.Build(ctx, ""); err != nil {
+		if _, err := c.Build(ctx); err != nil {
 			return err
 		}
 		c.ev.Send(events.New(events.StatusDone, "Blockchain build complete"))

--- a/starport/services/network/publish.go
+++ b/starport/services/network/publish.go
@@ -7,7 +7,6 @@ import (
 	campaigntypes "github.com/tendermint/spn/x/campaign/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 	profiletypes "github.com/tendermint/spn/x/profile/types"
-
 	"github.com/tendermint/starport/starport/pkg/cosmoserror"
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/events"
@@ -168,6 +167,11 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 	var createChainRes launchtypes.MsgCreateChainResponse
 	if err := res.Decode(&createChainRes); err != nil {
 		return 0, 0, 0, err
+	}
+
+	if err := c.CacheBinary(createChainRes.LaunchID); err != nil {
+		return 0, 0, 0, err
+
 	}
 
 	if !o.totalShares.Empty() {


### PR DESCRIPTION
This pull requests introduces caching for network commands. Few network commands have to build chain binary during their execution. It happens everytime but chain source can be the same between runs so chain binary can be reused.

Instead of calling c.chain.Build() new function c.Build() is introduced. It is checks if binary for a specific launch was built and reuse it.