### PR TITLE
fix(templates): fix not found error codes for scaffolded queries

### DIFF
--- a/starport/templates/typed/list/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/list/stargate/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -60,7 +60,7 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 			desc: "not found",
 			id:   "not_found",
 			args: common,
-			err:  status.Error(codes.InvalidArgument, "not found"),
+			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
 		tc := tc

--- a/starport/templates/typed/map/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
+++ b/starport/templates/typed/map/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
@@ -50,7 +50,7 @@ func (k Keeper) <%= TypeName.UpperCamel %>(c context.Context, req *types.QueryGe
 	    <%= for (i, index) in Indexes { %>req.<%= index.Name.UpperCamel %>,
         <% } %>)
 	if !found {
-	    return nil, status.Error(codes.InvalidArgument, "not found")
+	    return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	return &types.QueryGet<%= TypeName.UpperCamel %>Response{<%= TypeName.UpperCamel %>: val}, nil

--- a/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/client/cli/query_{{typeName}}_test.go.plush
@@ -68,7 +68,7 @@ func TestShow<%= TypeName.UpperCamel %>(t *testing.T) {
 			<%= for (i, index) in Indexes { %>id<%= index.Name.UpperCamel %>: <%= index.ValueInvalidIndex() %>,
             <% } %>
 			args: common,
-			err:  status.Error(codes.InvalidArgument, "not found"),
+			err:  status.Error(codes.NotFound, "not found"),
 		},
 	} {
 		tc := tc

--- a/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
+++ b/starport/templates/typed/map/stargate/tests/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}_test.go.plush
@@ -50,7 +50,7 @@ func Test<%= TypeName.UpperCamel %>QuerySingle(t *testing.T) {
 			    <%= for (i, index) in Indexes { %><%= index.Name.UpperCamel %>:<%= index.ValueInvalidIndex() %>,
                 <% } %>
 			},
-			err:     status.Error(codes.InvalidArgument, "not found"),
+			err:     status.Error(codes.NotFound, "not found"),
 		},
 		{
 			desc: "InvalidRequest",

--- a/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
+++ b/starport/templates/typed/singleton/stargate/component/x/{{moduleName}}/keeper/grpc_query_{{typeName}}.go.plush
@@ -17,7 +17,7 @@ func (k Keeper) <%= TypeName.UpperCamel %>(c context.Context, req *types.QueryGe
 
 	val, found := k.Get<%= TypeName.UpperCamel %>(ctx)
 	if !found {
-	    return nil, status.Error(codes.InvalidArgument, "not found")
+	    return nil, status.Error(codes.NotFound, "not found")
 	}
 
 	return &types.QueryGet<%= TypeName.UpperCamel %>Response{<%= TypeName.UpperCamel %>: val}, nil


### PR DESCRIPTION
## Description

Now not found queries are returning invalid argument errors. This PR fixes the code for the scaffolded queries, returning not found code.