### PR TITLE
fix: installation of plugins for Go `v1.18` and above

### DIFF
--- a/starport/pkg/cosmosgen/install.go
+++ b/starport/pkg/cosmosgen/install.go
@@ -12,6 +12,20 @@ import (
 
 // InstallDependencies installs protoc dependencies needed by Cosmos ecosystem.
 func InstallDependencies(ctx context.Context, appPath string) error {
+
+	plugins := []string{
+		// installs the gocosmos plugin.
+		"github.com/regen-network/cosmos-proto/protoc-gen-gocosmos",
+
+		// install Go code generation plugin.
+		"github.com/golang/protobuf/protoc-gen-go",
+
+		// install grpc-gateway plugins.
+		"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
+		"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
+		"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2",
+	}
+
 	errb := &bytes.Buffer{}
 	err := cmdrunner.
 		New(
@@ -19,22 +33,8 @@ func InstallDependencies(ctx context.Context, appPath string) error {
 			cmdrunner.DefaultWorkdir(appPath),
 		).
 		Run(ctx,
-			step.New(
-				step.Exec(
-					"go",
-					"get",
-					// installs the gocosmos plugin.
-					"github.com/regen-network/cosmos-proto/protoc-gen-gocosmos",
-
-					// install Go code generation plugin.
-					"github.com/golang/protobuf/protoc-gen-go",
-
-					// install grpc-gateway plugins.
-					"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway",
-					"github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger",
-					"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2",
-				),
-			),
+			step.New(step.Exec("go", append([]string{"get"}, plugins...)...)),
+			step.New(step.Exec("go", append([]string{"install"}, plugins...)...)),
 		)
 	return errors.Wrap(err, errb.String())
 }

--- a/starport/pkg/cosmosgen/install.go
+++ b/starport/pkg/cosmosgen/install.go
@@ -12,7 +12,6 @@ import (
 
 // InstallDependencies installs protoc dependencies needed by Cosmos ecosystem.
 func InstallDependencies(ctx context.Context, appPath string) error {
-
 	plugins := []string{
 		// installs the gocosmos plugin.
 		"github.com/regen-network/cosmos-proto/protoc-gen-gocosmos",


### PR DESCRIPTION
This fixes https://github.com/tendermint/starport/issues/2171, but is not ideal... tooling binaries should be installed by running `go install [path]@[version]`, but protoc-gen-gocosmos uses a replace directive in the `go.mod` which is [incompatible with this method](https://github.com/golang/go/issues/44840#issuecomment-792789581). This fixes the problem for now, but adds plugin specific items to the go.mod of the scaffolded project, which shouldn't be there.