### PR TITLE
fix(network): invalid query return parser for get coordinator

### DIFF
--- a/starport/pkg/cosmoserror/error.go
+++ b/starport/pkg/cosmoserror/error.go
@@ -10,12 +10,15 @@ import (
 var (
 	ErrInternal       = errors.New("internal error")
 	ErrInvalidRequest = errors.New("invalid request")
+	ErrNotFound       = errors.New("not found")
 )
 
 func Unwrap(err error) error {
 	s, ok := status.FromError(err)
 	if ok {
 		switch s.Code() {
+		case codes.NotFound:
+			return ErrNotFound
 		case codes.InvalidArgument:
 			return ErrInvalidRequest
 		case codes.Internal:

--- a/starport/pkg/goanalysis/goanalysis_test.go
+++ b/starport/pkg/goanalysis/goanalysis_test.go
@@ -2,11 +2,13 @@ package goanalysis_test
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
-	"github.com/tendermint/starport/starport/pkg/goanalysis"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tendermint/starport/starport/pkg/goanalysis"
 )
 
 var (

--- a/starport/services/network/publish.go
+++ b/starport/services/network/publish.go
@@ -7,6 +7,7 @@ import (
 	campaigntypes "github.com/tendermint/spn/x/campaign/types"
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 	profiletypes "github.com/tendermint/spn/x/profile/types"
+
 	"github.com/tendermint/starport/starport/pkg/cosmoserror"
 	"github.com/tendermint/starport/starport/pkg/cosmosutil"
 	"github.com/tendermint/starport/starport/pkg/events"
@@ -118,7 +119,7 @@ func (n Network) Publish(ctx context.Context, c Chain, options ...PublishOption)
 		CoordinatorByAddress(ctx, &profiletypes.QueryGetCoordinatorByAddressRequest{
 			Address: coordinatorAddress,
 		})
-	if cosmoserror.Unwrap(err) == cosmoserror.ErrInvalidRequest {
+	if cosmoserror.Unwrap(err) == cosmoserror.ErrNotFound {
 		msgCreateCoordinator := profiletypes.NewMsgCreateCoordinator(
 			coordinatorAddress,
 			"",

--- a/starport/services/network/queries.go
+++ b/starport/services/network/queries.go
@@ -9,9 +9,8 @@ import (
 	launchtypes "github.com/tendermint/spn/x/launch/types"
 	rewardtypes "github.com/tendermint/spn/x/reward/types"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
+	"github.com/tendermint/starport/starport/pkg/cosmoserror"
 	"github.com/tendermint/starport/starport/pkg/events"
 	"github.com/tendermint/starport/starport/services/network/networktypes"
 )
@@ -206,8 +205,7 @@ func (n Network) ChainReward(ctx context.Context, launchID uint64) (rewardtypes.
 			},
 		)
 
-	statusErr, ok := status.FromError(err)
-	if ok && statusErr.Code() == codes.NotFound {
+	if cosmoserror.Unwrap(err) == cosmoserror.ErrNotFound {
 		return rewardtypes.RewardPool{}, ErrObjectNotFound
 	} else if err != nil {
 		return rewardtypes.RewardPool{}, err


### PR DESCRIPTION
close #2176

## Description

Now the SPN returns the correct error code for not found queries. This PR fixes the error parse to check if the coordinator exists.