### PR TITLE
refactor(templates): update the deprecated `string.Title` method to `cases.Title`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/grpc v1.44.0
 )
 

--- a/starport/pkg/entrywriter/entrywriter.go
+++ b/starport/pkg/entrywriter/entrywriter.go
@@ -3,10 +3,11 @@ package entrywriter
 import (
 	"fmt"
 	"io"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 )
 
 const (
@@ -32,7 +33,7 @@ func Write(out io.Writer, header []string, entries ...[]string) error {
 	formatLine := func(line []string, title bool) (formatted string) {
 		for _, cell := range line {
 			if title {
-				cell = strings.Title(cell)
+				cell = xstrings.Title(cell)
 			}
 			formatted += fmt.Sprintf("%s \t", cell)
 		}

--- a/starport/pkg/xstrings/xstrings.go
+++ b/starport/pkg/xstrings/xstrings.go
@@ -3,6 +3,9 @@ package xstrings
 import (
 	"strings"
 	"unicode"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // AllOrSomeFilter filters elems out from the list as they  present in filterList and
@@ -65,4 +68,10 @@ func NoNumberPrefix(s string) string {
 		return "_" + s
 	}
 	return s
+}
+
+// Title returns a copy of the string s with all Unicode letters that begin words
+// mapped to their Unicode title case.
+func Title(title string) string {
+	return cases.Title(language.English).String(title)
 }

--- a/starport/services/chain/build.go
+++ b/starport/services/chain/build.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/pkg/errors"
@@ -18,6 +17,7 @@ import (
 	"github.com/tendermint/starport/starport/pkg/cmdrunner/step"
 	"github.com/tendermint/starport/starport/pkg/goanalysis"
 	"github.com/tendermint/starport/starport/pkg/gocmd"
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 )
 
 const (
@@ -176,7 +176,7 @@ func (c *Chain) preBuild(ctx context.Context) (buildFlags []string, err error) {
 
 	ldFlags := config.Build.LDFlags
 	ldFlags = append(ldFlags,
-		fmt.Sprintf("-X github.com/cosmos/cosmos-sdk/version.Name=%s", strings.Title(c.app.Name)),
+		fmt.Sprintf("-X github.com/cosmos/cosmos-sdk/version.Name=%s", xstrings.Title(c.app.Name)),
 		fmt.Sprintf("-X github.com/cosmos/cosmos-sdk/version.AppName=%sd", c.app.Name),
 		fmt.Sprintf("-X github.com/cosmos/cosmos-sdk/version.Version=%s", c.sourceVersion.tag),
 		fmt.Sprintf("-X github.com/cosmos/cosmos-sdk/version.Commit=%s", c.sourceVersion.hash),

--- a/starport/templates/field/plushhelpers/plushhelpers.go
+++ b/starport/templates/field/plushhelpers/plushhelpers.go
@@ -1,10 +1,9 @@
 package plushhelpers
 
 import (
-	"strings"
-
 	"github.com/gobuffalo/plush"
 
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field"
 	"github.com/tendermint/starport/starport/templates/field/datatype"
 )
@@ -14,7 +13,7 @@ func ExtendPlushContext(ctx *plush.Context) {
 	ctx.Set("mergeGoImports", mergeGoImports)
 	ctx.Set("mergeProtoImports", mergeProtoImports)
 	ctx.Set("mergeCustomImports", mergeCustomImports)
-	ctx.Set("title", strings.Title)
+	ctx.Set("title", xstrings.Title)
 }
 
 func mergeCustomImports(fields ...field.Fields) []string {

--- a/starport/templates/ibc/packet.go
+++ b/starport/templates/ibc/packet.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tendermint/starport/starport/pkg/multiformatname"
 	"github.com/tendermint/starport/starport/pkg/placeholder"
 	"github.com/tendermint/starport/starport/pkg/xgenny"
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 	"github.com/tendermint/starport/starport/templates/module"
@@ -132,7 +133,7 @@ func moduleModify(replacer placeholder.Replacer, opts *PacketOptions) genny.RunF
 		replacementRecv := fmt.Sprintf(
 			templateRecv,
 			PlaceholderIBCPacketModuleRecv,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 			opts.PacketName.UpperCamel,
 		)
 		content := replacer.Replace(f.String(), PlaceholderIBCPacketModuleRecv, replacementRecv)
@@ -148,7 +149,7 @@ func moduleModify(replacer placeholder.Replacer, opts *PacketOptions) genny.RunF
 		replacementAck := fmt.Sprintf(
 			templateAck,
 			PlaceholderIBCPacketModuleAck,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 			opts.PacketName.UpperCamel,
 		)
 		content = replacer.Replace(content, PlaceholderIBCPacketModuleAck, replacementAck)
@@ -163,7 +164,7 @@ func moduleModify(replacer placeholder.Replacer, opts *PacketOptions) genny.RunF
 		replacementTimeout := fmt.Sprintf(
 			templateTimeout,
 			PlaceholderIBCPacketModuleTimeout,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 			opts.PacketName.UpperCamel,
 		)
 		content = replacer.Replace(content, PlaceholderIBCPacketModuleTimeout, replacementTimeout)

--- a/starport/templates/module/create/genesistest.go
+++ b/starport/templates/module/create/genesistest.go
@@ -1,13 +1,12 @@
 package modulecreate
 
 import (
-	"strings"
-
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
 	"github.com/gobuffalo/plushgen"
 
 	"github.com/tendermint/starport/starport/pkg/xgenny"
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field/plushhelpers"
 )
 
@@ -23,7 +22,7 @@ func AddGenesisTest(appPath, appName, modulePath, moduleName string, isIBC bool)
 	ctx.Set("modulePath", modulePath)
 	ctx.Set("appName", appName)
 	ctx.Set("isIBC", isIBC)
-	ctx.Set("title", strings.Title)
+	ctx.Set("title", xstrings.Title)
 
 	plushhelpers.ExtendPlushContext(ctx)
 	g.Transformer(plushgen.Transformer(ctx))

--- a/starport/templates/module/create/ibc.go
+++ b/starport/templates/module/create/ibc.go
@@ -3,7 +3,6 @@ package modulecreate
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
@@ -189,7 +188,7 @@ func appIBCModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunF
 
 		// Scoped keeper declaration for the module
 		templateScopedKeeperDeclaration := `Scoped%[1]vKeeper capabilitykeeper.ScopedKeeper`
-		replacementScopedKeeperDeclaration := fmt.Sprintf(templateScopedKeeperDeclaration, strings.Title(opts.ModuleName))
+		replacementScopedKeeperDeclaration := fmt.Sprintf(templateScopedKeeperDeclaration, xstrings.Title(opts.ModuleName))
 		content = replacer.Replace(content, module.PlaceholderIBCAppScopedKeeperDeclaration, replacementScopedKeeperDeclaration)
 
 		// Scoped keeper definition
@@ -197,7 +196,7 @@ func appIBCModify(replacer placeholder.Replacer, opts *CreateOptions) genny.RunF
 app.Scoped%[1]vKeeper = scoped%[1]vKeeper`
 		replacementScopedKeeperDefinition := fmt.Sprintf(
 			templateScopedKeeperDefinition,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 			opts.ModuleName,
 		)
 		content = replacer.Replace(content, module.PlaceholderIBCAppScopedKeeperDefinition, replacementScopedKeeperDefinition)
@@ -208,7 +207,7 @@ app.Scoped%[1]vKeeper = scoped%[1]vKeeper`
 scoped%[1]vKeeper,`
 		replacementKeeperArgument := fmt.Sprintf(
 			templateKeeperArgument,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 		)
 		content = replacer.Replace(content, module.PlaceholderIBCAppKeeperArgument, replacementKeeperArgument)
 

--- a/starport/templates/module/create/options.go
+++ b/starport/templates/module/create/options.go
@@ -2,8 +2,8 @@ package modulecreate
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/tendermint/starport/starport/pkg/xstrings"
 	"github.com/tendermint/starport/starport/templates/field"
 )
 
@@ -50,7 +50,7 @@ type Dependency struct {
 func NewDependency(name, keeperName string) Dependency {
 	// Default keeper name
 	if keeperName == "" {
-		keeperName = fmt.Sprintf("%sKeeper", strings.Title(name))
+		keeperName = fmt.Sprintf("%sKeeper", xstrings.Title(name))
 	}
 	return Dependency{
 		name,

--- a/starport/templates/module/create/stargate.go
+++ b/starport/templates/module/create/stargate.go
@@ -3,7 +3,6 @@ package modulecreate
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/gobuffalo/genny"
 	"github.com/gobuffalo/plush"
@@ -120,7 +119,7 @@ func appModifyStargate(replacer placeholder.Replacer, opts *CreateOptions) genny
 			module.PlaceholderSgAppKeeperDeclaration,
 			opts.ModuleName,
 			scopedKeeperDeclaration,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 		)
 		content = replacer.Replace(content, module.PlaceholderSgAppKeeperDeclaration, replacement)
 
@@ -175,7 +174,7 @@ func appModifyStargate(replacer placeholder.Replacer, opts *CreateOptions) genny
 			opts.ModuleName,
 			scopedKeeperDefinition,
 			ibcKeeperArgument,
-			strings.Title(opts.ModuleName),
+			xstrings.Title(opts.ModuleName),
 			depArgs,
 		)
 		content = replacer.Replace(content, module.PlaceholderSgAppKeeperDefinition, replacement)


### PR DESCRIPTION
## Description

The `strings.Title` method was deprecated. The rule Title uses for word boundaries does not handle Unicode punctuation properly. 

### Changes 

- Import `golang.org/x/text/cases` pkg;
- move from the `strings.Title` method to `cases.Title` instead;
- create a helper `Title` method into the `xstrings` pkg;